### PR TITLE
Rename use case subsections

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -18,7 +18,7 @@ Introduction here.
 Use cases {#usecases}
 =====================
 
-## High-Level Use Cases ## {#usecases-highlevel}
+## Application Use Cases ## {#usecases-application}
 
 This section illustrates application-level use cases for neural network
 inference hardware acceleration. All applications in those use cases can be
@@ -116,10 +116,10 @@ it needs to reduce recorded video data to be stored. The application generates
 the short version of the recorded video by using a machine learning model for
 video summarization such as [[Video-Summarization-with-LSTM]].
 
-## Low-Level Use Cases ## {#usecases-lowlevel}
+## Framework Use Cases ## {#usecases-framework}
 
-This section collects API-level use cases for a dedicated low-level API for
-neural network inference hardware acceleration. It is expected that Machine
+This section collects framework-level use cases for a dedicated low-level API
+for neural network inference hardware acceleration. It is expected that Machine
 Learning frameworks will be key consumers of the Web Neural Network API (WebNN
 API) and the low-level details exposed through the WebNN API are abstracted out
 from typical web developers. However, it is also expected that web developers

--- a/index.html
+++ b/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 0da7328bb90ef81993146377e4e0fed236969c4c" name="generator">
   <link href="https://webmachinelearning.github.io/webnn/" rel="canonical">
-  <meta content="1fdaa40ef1f3aa409021ee5b4d83456853561c04" name="document-revision">
+  <meta content="22aa13753df61f5fa6bc91a42bc27aa40d4d0150" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1366,7 +1366,7 @@ pre .property::before, pre .property::after {
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Web Neural Network API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-01-17">17 January 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-02-14">14 February 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1406,7 +1406,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <a href="#usecases"><span class="secno">2</span> <span class="content">Use cases</span></a>
      <ol class="toc">
       <li>
-       <a href="#usecases-highlevel"><span class="secno">2.1</span> <span class="content">High-Level Use Cases</span></a>
+       <a href="#usecases-application"><span class="secno">2.1</span> <span class="content">Application Use Cases</span></a>
        <ol class="toc">
         <li><a href="#usecase-person-detection"><span class="secno">2.1.1</span> <span class="content">Person Detection</span></a>
         <li><a href="#usecase-segmentation"><span class="secno">2.1.2</span> <span class="content">Semantic Segmentation</span></a>
@@ -1421,7 +1421,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li><a href="#usecase-video-summalization"><span class="secno">2.1.11</span> <span class="content">Video Summarization</span></a>
        </ol>
       <li>
-       <a href="#usecases-lowlevel"><span class="secno">2.2</span> <span class="content">Low-Level Use Cases</span></a>
+       <a href="#usecases-framework"><span class="secno">2.2</span> <span class="content">Framework Use Cases</span></a>
        <ol class="toc">
         <li><a href="#usecase-custom-layer"><span class="secno">2.2.1</span> <span class="content">Custom Layer</span></a>
         <li><a href="#usecase-network-concat"><span class="secno">2.2.2</span> <span class="content">Network Concatenation</span></a>
@@ -1442,7 +1442,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
    <p>Introduction here.</p>
    <h2 class="heading settled" data-level="2" id="usecases"><span class="secno">2. </span><span class="content">Use cases</span><a class="self-link" href="#usecases"></a></h2>
-   <h3 class="heading settled" data-level="2.1" id="usecases-highlevel"><span class="secno">2.1. </span><span class="content">High-Level Use Cases</span><a class="self-link" href="#usecases-highlevel"></a></h3>
+   <h3 class="heading settled" data-level="2.1" id="usecases-application"><span class="secno">2.1. </span><span class="content">Application Use Cases</span><a class="self-link" href="#usecases-application"></a></h3>
    <p>This section illustrates application-level use cases for neural network
 inference hardware acceleration. All applications in those use cases can be
 built on top of pre-trained deep neural network (DNN) models.</p>
@@ -1512,9 +1512,9 @@ an emoji that represents the estimated emotion.</p>
 it needs to reduce recorded video data to be stored. The application generates
 the short version of the recorded video by using a machine learning model for
 video summarization such as <a data-link-type="biblio" href="#biblio-video-summarization-with-lstm">[Video-Summarization-with-LSTM]</a>.</p>
-   <h3 class="heading settled" data-level="2.2" id="usecases-lowlevel"><span class="secno">2.2. </span><span class="content">Low-Level Use Cases</span><a class="self-link" href="#usecases-lowlevel"></a></h3>
-   <p>This section collects API-level use cases for a dedicated low-level API for
-neural network inference hardware acceleration. It is expected that Machine
+   <h3 class="heading settled" data-level="2.2" id="usecases-framework"><span class="secno">2.2. </span><span class="content">Framework Use Cases</span><a class="self-link" href="#usecases-framework"></a></h3>
+   <p>This section collects framework-level use cases for a dedicated low-level API
+for neural network inference hardware acceleration. It is expected that Machine
 Learning frameworks will be key consumers of the Web Neural Network API (WebNN
 API) and the low-level details exposed through the WebNN API are abstracted out
 from typical web developers. However, it is also expected that web developers


### PR DESCRIPTION
'Low-level' and 'high-level' are ambiguous in this context.

Partial fix to #8.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/pull/10.html" title="Last updated on Feb 18, 2019, 10:42 AM UTC (e48c3ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/10/94c6171...e48c3ce.html" title="Last updated on Feb 18, 2019, 10:42 AM UTC (e48c3ce)">Diff</a>