### PR TITLE
Add target hardware section to explainer

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -14,6 +14,21 @@ How will the web be better when this feature launches? And who will it help?
 
 You’re not going to solve every problem so enumerate the attractive, nearby problems that are out of scope for this effort. This may include details on the tradeoffs made due to architectural limitations made due to implementation details, and features left out either due to interoperability concerns or other hurdles, and how you plan to improve on this. This can often be the single most important part of your document, so give it careful thought.
 
+### Target hardware
+
+With this API web developers are able to target typical computing devices people use in their daily lives that run major operating systems. Initial prototypes have demonstrated reasonable performance on:
+
+* smartphones e.g. Google Pixel 3 or equivalent
+* laptops e.g. 13" MacBook Pro 2015 or equivalent
+
+The APIs in scope of this group will not be tied to any particular platform and will be implementable on top of existing major platform APIs, such as:
+
+* Android Neural Networks API
+* Windows DirectML
+* macOS/iOS Metal Performance Shaders and Basic Neural Network Subroutines
+
+Depending on the underlying hardware capabilities, these platform APIs may make use of CPU parallelism, general-purpose GPU, or dedicated ML hardware accelerators. The API will provide high-level hints to web developers to enable [performance adaptation](https://webmachinelearning.github.io/webnn/#usecase-perf-adapt), but will remain hardware agnostic otherwise.
+
 ## Getting started / example code
 
 Provide a terse example for the most common use case of the feature.  If you need to show how to get the feature set up (initialized, or using permissions, etc.), include that too


### PR DESCRIPTION
At [F2F](https://www.w3.org/2019/09/20-webmachinelearning-minutes.html#x02) we agreed it'd be good to start evolve the [explainer](https://github.com/webmachinelearning/webnn/blob/master/explainer.md) document in parallel with the [formal spec](https://webmachinelearning.github.io/webnn/).

Here's my first stab at the hardware support section of that document, PTAL @huningxin @nsthorat and others.

We should consider the explainer document a place where we write down our collective thoughts without needing to worry too much if those will change. By this definition, the explainer is expected evolve and change significantly and everyone is encouraged to contribute. It is a markdown file, so low barrier to entry :-)

To contract with the spec, I'd propose we put things in the formal spec that we think have reached adequate stability, since changing the formal spec is more costly (in terms of editors' time, also in terms of implementations that implement the spec in the future, let alone web developers that write to the API direct).