### PR TITLE
Add conv2d

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10,6 +10,10 @@ Editor: Chai Chaoweeraprasit 120203, Microsoft Corporation https://microsoft.com
 Abstract: This document describes a dedicated low-level API for neural network inference hardware acceleration.
 Repository: https://github.com/webmachinelearning/webnn
 !Explainer: <a href="https://github.com/webmachinelearning/webnn/blob/master/explainer.md">explainer.md</a>
+Markup Shorthands: markdown yes
+Markup Shorthands: dfn yes
+Markup Shorthands: idl yes
+Markup Shorthands: css no
 </pre>
 
 Introduction {#intro}
@@ -180,6 +184,11 @@ interface ML {
 
 ## OperandDescriptor ## {#api-operanddescriptor}
 <script type=idl>
+enum OperandLayout {
+  "nchw",
+  "nhwc"
+};
+
 enum OperandType {
   "float32",
   "float16",
@@ -235,6 +244,53 @@ partial interface NeuralNetworkContext {
   Operand add(Operand a, Operand b);
 };
 </script>
+
+### conv2d ### {#api-neuralnetworkcontext-conv2d}
+<script type=idl>
+partial interface NeuralNetworkContext {
+  Operand conv2d(Operand input, Operand filter,
+                 sequence<long> padding, sequence<long> strides, sequence<long> dilations,
+                 optional OperandLayout layout = "nchw");
+};
+</script>
+
+<div algorithm=conv2d>
+    **Arguments:**
+        - *input*: an {{Operand}}. The input 4-D tensor. The logical shape
+            is interpreted according to the value of *layout*.
+        - *filter*: an {{Operand}}. The filter 4-D tensor. The logical shape
+            is interpreted according to the value of *layout*.
+        - *padding*: a sequence of {{long}} of length 4. The padding for the
+            beginning and ending along each spatial dimension of *input*,
+            [beginning_height, ending_height, beginning_width, ending_width].
+        - *strides*: a sequence of {{long}} of length 2. The stride of the
+            sliding window for each spatial dimension of *input*,
+            [stride_height, stirde_width].
+        - *dilations*: a sequence of {{long}} of length 2. The dilation factor
+            for each spatial dimension of *input*, [dilation_height,
+            dilation_width].
+        - *layout*: an optional {{OperandLayout}} with value as "nchw" or
+            "nhwc". The default value is "nchw". This argument specifies the
+            layout format of the input, output and filter tensor.
+            Specifically,
+
+            "nchw":
+                - input tensor: [batches, input_channels, height, width]
+                - filter tensor: [output_channels, input_channels, height,
+                    width]
+                - output tensor: [batches, output_channels, height, width]
+            "nhwc":
+                - input tensor: [batches, height, width, input_channels]
+                - filter tensor: [height, width, input_channels,
+                    output_channels]
+                - output tensor: [batches, height, width, output_channels]
+
+    **Returns:** an {{Operand}}. The output 4-D tensor that contains the
+    result of the convolution. The logical shape is interpreted according to the
+    value of *layout*.
+
+    Computes a 2-D convolution given input and filter 4-D tensors.
+</div>
 
 ### mul ### {#api-neuralnetworkcontext-mul}
 <script type=idl>

--- a/index.html
+++ b/index.html
@@ -1469,7 +1469,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Web Neural Network API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-02-25">25 February 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-02-26">26 February 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1545,7 +1545,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
        <a href="#api-neuralnetworkcontext"><span class="secno">3.5</span> <span class="content">NeuralNetworkContext</span></a>
        <ol class="toc">
         <li><a href="#api-neuralnetworkcontext-add"><span class="secno">3.5.1</span> <span class="content">add</span></a>
-        <li><a href="#api-neuralnetworkcontext-mul"><span class="secno">3.5.2</span> <span class="content">mul</span></a>
+        <li><a href="#api-neuralnetworkcontext-conv2d"><span class="secno">3.5.2</span> <span class="content">conv2d</span></a>
+        <li><a href="#api-neuralnetworkcontext-mul"><span class="secno">3.5.3</span> <span class="content">mul</span></a>
        </ol>
       <li><a href="#api-model"><span class="secno">3.6</span> <span class="content">Model</span></a>
       <li><a href="#api-compilation"><span class="secno">3.7</span> <span class="content">Compilation</span></a>
@@ -1688,7 +1689,12 @@ so that the application loads the tiny model in the case of CPU-only devices.</p
 };
 </pre>
    <h3 class="heading settled" data-level="3.3" id="api-operanddescriptor"><span class="secno">3.3. </span><span class="content">OperandDescriptor</span><a class="self-link" href="#api-operanddescriptor"></a></h3>
-<pre class="idl highlight def"><c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-operandtype"><code><c- g>OperandType</c-></code></dfn> {
+<pre class="idl highlight def"><c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-operandlayout"><code><c- g>OperandLayout</c-></code></dfn> {
+  <dfn class="idl-code" data-dfn-for="OperandLayout" data-dfn-type="enum-value" data-export id="dom-operandlayout-nchw"><code><c- s>"nchw"</c-></code><a class="self-link" href="#dom-operandlayout-nchw"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="OperandLayout" data-dfn-type="enum-value" data-export id="dom-operandlayout-nhwc"><code><c- s>"nhwc"</c-></code><a class="self-link" href="#dom-operandlayout-nhwc"></a></dfn>
+};
+
+<c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-operandtype"><code><c- g>OperandType</c-></code></dfn> {
   <dfn class="idl-code" data-dfn-for="OperandType" data-dfn-type="enum-value" data-export id="dom-operandtype-float32"><code><c- s>"float32"</c-></code><a class="self-link" href="#dom-operandtype-float32"></a></dfn>,
   <dfn class="idl-code" data-dfn-for="OperandType" data-dfn-type="enum-value" data-export id="dom-operandtype-float16"><code><c- s>"float16"</c-></code><a class="self-link" href="#dom-operandtype-float16"></a></dfn>,
   <dfn class="idl-code" data-dfn-for="OperandType" data-dfn-type="enum-value" data-export id="dom-operandtype-int32"><code><c- s>"int32"</c-></code><a class="self-link" href="#dom-operandtype-int32"></a></dfn>,
@@ -1737,11 +1743,70 @@ so that the application loads the tiny model in the case of CPU-only devices.</p
   <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="add(a, b)" id="dom-neuralnetworkcontext-add"><code><c- g>add</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-add"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/add(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-add-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-add-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑤"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/add(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-add-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-add-a-b-b"></a></dfn>);
 };
 </pre>
-   <h4 class="heading settled" data-level="3.5.2" id="api-neuralnetworkcontext-mul"><span class="secno">3.5.2. </span><span class="content">mul</span><a class="self-link" href="#api-neuralnetworkcontext-mul"></a></h4>
+   <h4 class="heading settled" data-level="3.5.2" id="api-neuralnetworkcontext-conv2d"><span class="secno">3.5.2. </span><span class="content">conv2d</span><a class="self-link" href="#api-neuralnetworkcontext-conv2d"></a></h4>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext②"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑥"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="conv2d(input, filter, padding, strides, dilations, layout)|conv2d(input, filter, padding, strides, dilations)" id="dom-neuralnetworkcontext-conv2d"><code><c- g>conv2d</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-conv2d"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑦"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations, layout), NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-input"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑧"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations, layout), NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-filter"><code><c- g>filter</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-filter"></a></dfn>,
+                 <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long②"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations, layout), NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-padding"><code><c- g>padding</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-padding"></a></dfn>, <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long③"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations, layout), NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-strides"><code><c- g>strides</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-strides"></a></dfn>, <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long④"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations, layout), NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-dilations"><code><c- g>dilations</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-dilations"></a></dfn>,
+                 <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#enumdef-operandlayout" id="ref-for-enumdef-operandlayout"><c- n>OperandLayout</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations, layout), NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-layout"><code><c- g>layout</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-layout"></a></dfn> = "nchw");
+};
+</pre>
+   <div class="algorithm" data-algorithm="conv2d">
+     <strong>Arguments:</strong> 
+    <ul>
+     <li data-md>
+      <p><em>input</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑨">Operand</a></code>. The input 4-D tensor. The logical shape
+is interpreted according to the value of <em>layout</em>.</p>
+     <li data-md>
+      <p><em>filter</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand①⓪">Operand</a></code>. The filter 4-D tensor. The logical shape
+is interpreted according to the value of <em>layout</em>.</p>
+     <li data-md>
+      <p><em>padding</em>: a sequence of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑤">long</a></code> of length 4. The padding for the
+beginning and ending along each spatial dimension of <em>input</em>,
+[beginning_height, ending_height, beginning_width, ending_width].</p>
+     <li data-md>
+      <p><em>strides</em>: a sequence of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑥">long</a></code> of length 2. The stride of the
+sliding window for each spatial dimension of <em>input</em>,
+[stride_height, stirde_width].</p>
+     <li data-md>
+      <p><em>dilations</em>: a sequence of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑦">long</a></code> of length 2. The dilation factor
+for each spatial dimension of <em>input</em>, [dilation_height,
+dilation_width].</p>
+     <li data-md>
+      <p><em>layout</em>: an optional <code class="idl"><a data-link-type="idl" href="#enumdef-operandlayout" id="ref-for-enumdef-operandlayout①">OperandLayout</a></code> with value as "nchw" or
+"nhwc". The default value is "nchw". This argument specifies the
+layout format of the input, output and filter tensor.
+Specifically,</p>
+      <p>"nchw":</p>
+      <ul>
+       <li data-md>
+        <p>input tensor: [batches, input_channels, height, width]</p>
+       <li data-md>
+        <p>filter tensor: [output_channels, input_channels, height,
+width]</p>
+       <li data-md>
+        <p>output tensor: [batches, output_channels, height, width]</p>
+      </ul>
+      "nhwc": 
+      <ul>
+       <li data-md>
+        <p>input tensor: [batches, height, width, input_channels]</p>
+       <li data-md>
+        <p>filter tensor: [height, width, input_channels,
+output_channels]</p>
+       <li data-md>
+        <p>output tensor: [batches, height, width, output_channels]</p>
+      </ul>
+    </ul>
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand①①">Operand</a></code>. The output 4-D tensor that contains the
+    result of the convolution. The logical shape is interpreted according to the
+    value of <em>layout</em>.</p>
+    <p>Computes a 2-D convolution given input and filter 4-D tensors.</p>
+   </div>
+   <h4 class="heading settled" data-level="3.5.3" id="api-neuralnetworkcontext-mul"><span class="secno">3.5.3. </span><span class="content">mul</span><a class="self-link" href="#api-neuralnetworkcontext-mul"></a></h4>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext③"><c- g>NeuralNetworkContext</c-></a> {
   // Create an Operand object that represents the result of an element-wise
   // binary multiplication operation with input operands a and b.
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑥"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="mul(a, b)" id="dom-neuralnetworkcontext-mul"><code><c- g>mul</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑦"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑧"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-b"></a></dfn>);
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①②"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="mul(a, b)" id="dom-neuralnetworkcontext-mul"><code><c- g>mul</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①③"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①④"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-b"></a></dfn>);
 };
 </pre>
    <h3 class="heading settled" data-level="3.6" id="api-model"><span class="secno">3.6. </span><span class="content">Model</span><a class="self-link" href="#api-model"></a></h3>
@@ -2011,6 +2076,8 @@ API.</p>
    <li><a href="#compilation">Compilation</a><span>, in §3.7</span>
    <li><a href="#enumdef-compilationpreference">CompilationPreference</a><span>, in §3.6</span>
    <li><a href="#dom-neuralnetworkcontext-constant">constant(desc, value)</a><span>, in §3.5</span>
+   <li><a href="#dom-neuralnetworkcontext-conv2d">conv2d(input, filter, padding, strides, dilations)</a><span>, in §3.5.2</span>
+   <li><a href="#dom-neuralnetworkcontext-conv2d">conv2d(input, filter, padding, strides, dilations, layout)</a><span>, in §3.5.2</span>
    <li><a href="#dom-model-createcompilation">createCompilation(preference)</a><span>, in §3.6</span>
    <li><a href="#dom-compilation-createexecution">createExecution()</a><span>, in §3.7</span>
    <li><a href="#dom-neuralnetworkcontext-createmodel">createModel(outputs)</a><span>, in §3.5</span>
@@ -2026,10 +2093,13 @@ API.</p>
    <li><a href="#dom-navigator-ml">ml</a><span>, in §3.1</span>
    <li><a href="#ml">ML</a><span>, in §3.2</span>
    <li><a href="#model">Model</a><span>, in §3.6</span>
-   <li><a href="#dom-neuralnetworkcontext-mul">mul(a, b)</a><span>, in §3.5.2</span>
+   <li><a href="#dom-neuralnetworkcontext-mul">mul(a, b)</a><span>, in §3.5.3</span>
+   <li><a href="#dom-operandlayout-nchw">"nchw"</a><span>, in §3.3</span>
    <li><a href="#neuralnetworkcontext">NeuralNetworkContext</a><span>, in §3.5</span>
+   <li><a href="#dom-operandlayout-nhwc">"nhwc"</a><span>, in §3.3</span>
    <li><a href="#operand">Operand</a><span>, in §3.4</span>
    <li><a href="#dictdef-operanddescriptor">OperandDescriptor</a><span>, in §3.3</span>
+   <li><a href="#enumdef-operandlayout">OperandLayout</a><span>, in §3.3</span>
    <li><a href="#enumdef-operandtype">OperandType</a><span>, in §3.3</span>
    <li><a href="#dom-operanddescriptor-scale">scale</a><span>, in §3.3</span>
    <li><a href="#dom-execution-setinput">setInput(index, data)</a><span>, in §3.8</span>
@@ -2067,6 +2137,7 @@ API.</p>
    <a href="https://heycam.github.io/webidl/#idl-long">https://heycam.github.io/webidl/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">3.3. OperandDescriptor</a> <a href="#ref-for-idl-long①">(2)</a>
+    <li><a href="#ref-for-idl-long②">3.5.2. conv2d</a> <a href="#ref-for-idl-long③">(2)</a> <a href="#ref-for-idl-long④">(3)</a> <a href="#ref-for-idl-long⑤">(4)</a> <a href="#ref-for-idl-long⑥">(5)</a> <a href="#ref-for-idl-long⑦">(6)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
@@ -2144,7 +2215,12 @@ API.</p>
 };
 
 <c- b>interface</c-> <a href="#ml"><code><c- g>ML</c-></code></a> {
-  <a class="n" data-link-type="idl-name" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext③"><c- n>NeuralNetworkContext</c-></a> <a href="#dom-ml-getneuralnetworkcontext"><code><c- g>getNeuralNetworkContext</c-></code></a>();
+  <a class="n" data-link-type="idl-name" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext④"><c- n>NeuralNetworkContext</c-></a> <a href="#dom-ml-getneuralnetworkcontext"><code><c- g>getNeuralNetworkContext</c-></code></a>();
+};
+
+<c- b>enum</c-> <a href="#enumdef-operandlayout"><code><c- g>OperandLayout</c-></code></a> {
+  <a href="#dom-operandlayout-nchw"><code><c- s>"nchw"</c-></code></a>,
+  <a href="#dom-operandlayout-nhwc"><code><c- s>"nhwc"</c-></code></a>
 };
 
 <c- b>enum</c-> <a href="#enumdef-operandtype"><code><c- g>OperandType</c-></code></a> {
@@ -2164,7 +2240,7 @@ API.</p>
 
   // The dimensions field is only required for tensor operands.
   // The negative value means an unknown dimension.
-  <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long②"><c- b>long</c-></a>> <a data-type="sequence<long> " href="#dom-operanddescriptor-dimensions"><code><c- g>dimensions</c-></code></a>;
+  <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑧"><c- b>long</c-></a>> <a data-type="sequence<long> " href="#dom-operanddescriptor-dimensions"><code><c- g>dimensions</c-></code></a>;
 
   // The following two fields are only required for quantized operand.
   // scale: an non-negative floating point value
@@ -2178,10 +2254,10 @@ API.</p>
 
 <c- b>interface</c-> <a href="#neuralnetworkcontext"><code><c- g>NeuralNetworkContext</c-></code></a> {
   // Create an Operand object that represents a model input.
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑨"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-input"><code><c- g>input</c-></code></a>(<a class="n" data-link-type="idl-name" href="#dictdef-operanddescriptor" id="ref-for-dictdef-operanddescriptor②"><c- n>OperandDescriptor</c-></a> <a href="#dom-neuralnetworkcontext-input-desc-desc"><code><c- g>desc</c-></code></a>);
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①⑥"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-input"><code><c- g>input</c-></code></a>(<a class="n" data-link-type="idl-name" href="#dictdef-operanddescriptor" id="ref-for-dictdef-operanddescriptor②"><c- n>OperandDescriptor</c-></a> <a href="#dom-neuralnetworkcontext-input-desc-desc"><code><c- g>desc</c-></code></a>);
 
   // Create an Operand object that represents a model constant.
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①①"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-constant"><code><c- g>constant</c-></code></a>(<a class="n" data-link-type="idl-name" href="#dictdef-operanddescriptor" id="ref-for-dictdef-operanddescriptor①①"><c- n>OperandDescriptor</c-></a> <a href="#dom-neuralnetworkcontext-constant-desc-value-desc"><code><c- g>desc</c-></code></a>, <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#ArrayBufferView" id="ref-for-ArrayBufferView③"><c- n>ArrayBufferView</c-></a> <a href="#dom-neuralnetworkcontext-constant-desc-value-value"><code><c- g>value</c-></code></a>);
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①⑤"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-constant"><code><c- g>constant</c-></code></a>(<a class="n" data-link-type="idl-name" href="#dictdef-operanddescriptor" id="ref-for-dictdef-operanddescriptor①①"><c- n>OperandDescriptor</c-></a> <a href="#dom-neuralnetworkcontext-constant-desc-value-desc"><code><c- g>desc</c-></code></a>, <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#ArrayBufferView" id="ref-for-ArrayBufferView③"><c- n>ArrayBufferView</c-></a> <a href="#dom-neuralnetworkcontext-constant-desc-value-value"><code><c- g>value</c-></code></a>);
 
   // Create a Model object by identifying output operands.
   <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#model" id="ref-for-model①"><c- n>Model</c-></a>> <a href="#dom-neuralnetworkcontext-createmodel"><code><c- g>createModel</c-></code></a>(<c- b>sequence</c->&lt;<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand②①"><c- n>Operand</c-></a>> <a href="#dom-neuralnetworkcontext-createmodel-outputs-outputs"><code><c- g>outputs</c-></code></a>);
@@ -2194,9 +2270,15 @@ API.</p>
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext②①"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑥①"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-conv2d"><code><c- g>conv2d</c-></code></a>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑦①"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-input"><code><c- g>input</c-></code></a>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑧①"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-filter"><code><c- g>filter</c-></code></a>,
+                 <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long②①"><c- b>long</c-></a>> <a href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-padding"><code><c- g>padding</c-></code></a>, <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long③①"><c- b>long</c-></a>> <a href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-strides"><code><c- g>strides</c-></code></a>, <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long④①"><c- b>long</c-></a>> <a href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-dilations"><code><c- g>dilations</c-></code></a>,
+                 <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#enumdef-operandlayout" id="ref-for-enumdef-operandlayout②"><c- n>OperandLayout</c-></a> <a href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-layout"><code><c- g>layout</c-></code></a> = "nchw");
+};
+
+<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext③①"><c- g>NeuralNetworkContext</c-></a> {
   // Create an Operand object that represents the result of an element-wise
   // binary multiplication operation with input operands a and b.
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑥①"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-mul"><code><c- g>mul</c-></code></a>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑦①"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-mul-a-b-a"><code><c- g>a</c-></code></a>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑧①"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-mul-a-b-b"><code><c- g>b</c-></code></a>);
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①②①"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-mul"><code><c- g>mul</c-></code></a>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①③①"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-mul-a-b-a"><code><c- g>a</c-></code></a>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①④①"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-mul-a-b-b"><code><c- g>b</c-></code></a>);
 };
 
 <c- b>enum</c-> <a href="#enumdef-compilationpreference"><code><c- g>CompilationPreference</c-></code></a> {
@@ -2226,6 +2308,12 @@ API.</p>
     <li><a href="#ref-for-ml">3.1. Navigator</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="enumdef-operandlayout">
+   <b><a href="#enumdef-operandlayout">#enumdef-operandlayout</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-enumdef-operandlayout">3.5.2. conv2d</a> <a href="#ref-for-enumdef-operandlayout①">(2)</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="enumdef-operandtype">
    <b><a href="#enumdef-operandtype">#enumdef-operandtype</a></b><b>Referenced in:</b>
    <ul>
@@ -2243,7 +2331,8 @@ API.</p>
    <ul>
     <li><a href="#ref-for-operand">3.5. NeuralNetworkContext</a> <a href="#ref-for-operand①">(2)</a> <a href="#ref-for-operand②">(3)</a>
     <li><a href="#ref-for-operand③">3.5.1. add</a> <a href="#ref-for-operand④">(2)</a> <a href="#ref-for-operand⑤">(3)</a>
-    <li><a href="#ref-for-operand⑥">3.5.2. mul</a> <a href="#ref-for-operand⑦">(2)</a> <a href="#ref-for-operand⑧">(3)</a>
+    <li><a href="#ref-for-operand⑥">3.5.2. conv2d</a> <a href="#ref-for-operand⑦">(2)</a> <a href="#ref-for-operand⑧">(3)</a> <a href="#ref-for-operand⑨">(4)</a> <a href="#ref-for-operand①⓪">(5)</a> <a href="#ref-for-operand①①">(6)</a>
+    <li><a href="#ref-for-operand①②">3.5.3. mul</a> <a href="#ref-for-operand①③">(2)</a> <a href="#ref-for-operand①④">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="neuralnetworkcontext">
@@ -2251,7 +2340,8 @@ API.</p>
    <ul>
     <li><a href="#ref-for-neuralnetworkcontext">3.2. ML</a>
     <li><a href="#ref-for-neuralnetworkcontext①">3.5.1. add</a>
-    <li><a href="#ref-for-neuralnetworkcontext②">3.5.2. mul</a>
+    <li><a href="#ref-for-neuralnetworkcontext②">3.5.2. conv2d</a>
+    <li><a href="#ref-for-neuralnetworkcontext③">3.5.3. mul</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-compilationpreference">


### PR DESCRIPTION
According to [the resolution of 6 Feb CG meeting](https://www.w3.org/2020/02/06-webmachinelearning-minutes.html#x02), 

> RESOLUTION: Add conv2d and matMul op definitions to WebNN API

creating this PR.

This PR is based on conv2d signature proposed by @nsthorat in #28. Regarding to the [conv2d compatibility table](https://github.com/webmachinelearning/webnn/blob/master/op_compatibility/conv2d.md), *strides* for N and C dimension are not supported by all investigated APIs, so keep *strides* just for spatial dimensions.

@nsthorat @wchao1115 @anssiko , please take a look. Thanks!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/43.html" title="Last updated on Feb 27, 2020, 1:50 AM UTC (7cf9f18)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/43/d11c07f...huningxin:7cf9f18.html" title="Last updated on Feb 27, 2020, 1:50 AM UTC (7cf9f18)">Diff</a>