### PR TITLE
Add element-wise binary op

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -236,12 +236,19 @@ interface NeuralNetworkContext {
 };
 </script>
 
-### add ### {#api-neuralnetworkcontext-add}
+### binary ### {#api-neuralnetworkcontext-binary}
 <script type=idl>
+enum BinaryOperation {
+  "add",
+  "sub",
+  "mul",
+  "div",
+  "max",
+  "min"
+};
+
 partial interface NeuralNetworkContext {
-  // Create an Operand object that represents the result of an element-wise
-  // binary addition operation with input operands a and b.
-  Operand add(Operand a, Operand b);
+  Operand binary(BinaryOperation op, Operand lhs, Operand rhs);
 };
 </script>
 
@@ -324,15 +331,6 @@ partial interface NeuralNetworkContext {
         - If both *a* and *b* are 1-D, the operation is a vector dot-product,
             which produces a scalar output.
 </div>
-
-### mul ### {#api-neuralnetworkcontext-mul}
-<script type=idl>
-partial interface NeuralNetworkContext {
-  // Create an Operand object that represents the result of an element-wise
-  // binary multiplication operation with input operands a and b.
-  Operand mul(Operand a, Operand b);
-};
-</script>
 
 ## Model ## {#api-model}
 <script type=idl>
@@ -420,13 +418,13 @@ const tensor2 = nn.constant(float32TensorType,
 const tensor3 = nn.input(float32TensorType);
 
 // intermediateOutput0 is the output of the first Add operation.
-const intermediateOutput0 = nn.add(tensor0, tensor1);
+const intermediateOutput0 = nn.binary('add', tensor0, tensor1);
 
 // intermediateOutput1 is the output of the second Add operation.
-const intermediateOutput1 = nn.add(tensor2, tensor3);
+const intermediateOutput1 = nn.binary('add', tensor2, tensor3);
 
 // output is the output tensor of the Mul operation.
-const output = nn.mul(intermediateOutput0, intermediateOutput1);
+const output = nn.binary('mul', intermediateOutput0, intermediateOutput1);
 
 // Create the model by identifying the outputs.
 const model = await nn.createModel([output]);

--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-
 <!doctype html><html lang="en">
  <head>
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
@@ -1222,7 +1221,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version c1dbacab, updated Mon Mar 30 18:56:12 2020 -0700" name="generator">
+  <meta content="Bikeshed version e3f9ab1a, updated Fri Apr 24 17:43:54 2020 -0700" name="generator">
   <link href="https://webmachinelearning.github.io/webnn/" rel="canonical">
 <style>/* style-autolinks */
 
@@ -1470,7 +1469,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Web Neural Network API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-04-04">4 April 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-05-03">3 May 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1545,10 +1544,9 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
       <li>
        <a href="#api-neuralnetworkcontext"><span class="secno">3.5</span> <span class="content">NeuralNetworkContext</span></a>
        <ol class="toc">
-        <li><a href="#api-neuralnetworkcontext-add"><span class="secno">3.5.1</span> <span class="content">add</span></a>
+        <li><a href="#api-neuralnetworkcontext-binary"><span class="secno">3.5.1</span> <span class="content">binary</span></a>
         <li><a href="#api-neuralnetworkcontext-conv2d"><span class="secno">3.5.2</span> <span class="content">conv2d</span></a>
         <li><a href="#api-neuralnetworkcontext-matmul"><span class="secno">3.5.3</span> <span class="content">matmul</span></a>
-        <li><a href="#api-neuralnetworkcontext-mul"><span class="secno">3.5.4</span> <span class="content">mul</span></a>
        </ol>
       <li><a href="#api-model"><span class="secno">3.6</span> <span class="content">Model</span></a>
       <li><a href="#api-compilation"><span class="secno">3.7</span> <span class="content">Compilation</span></a>
@@ -1738,11 +1736,18 @@ so that the application loads the tiny model in the case of CPU-only devices.</p
   <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#model" id="ref-for-model"><c- n>Model</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="createModel(outputs)" id="dom-neuralnetworkcontext-createmodel"><code><c- g>createModel</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-createmodel"></a></dfn>(<c- b>sequence</c->&lt;<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand②"><c- n>Operand</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/createModel(outputs)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-createmodel-outputs-outputs"><code><c- g>outputs</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-createmodel-outputs-outputs"></a></dfn>);
 };
 </pre>
-   <h4 class="heading settled" data-level="3.5.1" id="api-neuralnetworkcontext-add"><span class="secno">3.5.1. </span><span class="content">add</span><a class="self-link" href="#api-neuralnetworkcontext-add"></a></h4>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext①"><c- g>NeuralNetworkContext</c-></a> {
-  // Create an Operand object that represents the result of an element-wise
-  // binary addition operation with input operands a and b.
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="add(a, b)" id="dom-neuralnetworkcontext-add"><code><c- g>add</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-add"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/add(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-add-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-add-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑤"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/add(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-add-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-add-a-b-b"></a></dfn>);
+   <h4 class="heading settled" data-level="3.5.1" id="api-neuralnetworkcontext-binary"><span class="secno">3.5.1. </span><span class="content">binary</span><a class="self-link" href="#api-neuralnetworkcontext-binary"></a></h4>
+<pre class="idl highlight def"><c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-binaryoperation"><code><c- g>BinaryOperation</c-></code></dfn> {
+  <dfn class="idl-code" data-dfn-for="BinaryOperation" data-dfn-type="enum-value" data-export id="dom-binaryoperation-add"><code><c- s>"add"</c-></code><a class="self-link" href="#dom-binaryoperation-add"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="BinaryOperation" data-dfn-type="enum-value" data-export id="dom-binaryoperation-sub"><code><c- s>"sub"</c-></code><a class="self-link" href="#dom-binaryoperation-sub"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="BinaryOperation" data-dfn-type="enum-value" data-export id="dom-binaryoperation-mul"><code><c- s>"mul"</c-></code><a class="self-link" href="#dom-binaryoperation-mul"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="BinaryOperation" data-dfn-type="enum-value" data-export id="dom-binaryoperation-div"><code><c- s>"div"</c-></code><a class="self-link" href="#dom-binaryoperation-div"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="BinaryOperation" data-dfn-type="enum-value" data-export id="dom-binaryoperation-max"><code><c- s>"max"</c-></code><a class="self-link" href="#dom-binaryoperation-max"></a></dfn>,
+  <dfn class="idl-code" data-dfn-for="BinaryOperation" data-dfn-type="enum-value" data-export id="dom-binaryoperation-min"><code><c- s>"min"</c-></code><a class="self-link" href="#dom-binaryoperation-min"></a></dfn>
+};
+
+<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext①"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="binary(op, lhs, rhs)" id="dom-neuralnetworkcontext-binary"><code><c- g>binary</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-binary"></a></dfn>(<a class="n" data-link-type="idl-name" href="#enumdef-binaryoperation" id="ref-for-enumdef-binaryoperation"><c- n>BinaryOperation</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/binary(op, lhs, rhs)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-binary-op-lhs-rhs-op"><code><c- g>op</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-binary-op-lhs-rhs-op"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/binary(op, lhs, rhs)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-binary-op-lhs-rhs-lhs"><code><c- g>lhs</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-binary-op-lhs-rhs-lhs"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑤"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/binary(op, lhs, rhs)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-binary-op-lhs-rhs-rhs"><code><c- g>rhs</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-binary-op-lhs-rhs-rhs"></a></dfn>);
 };
 </pre>
    <h4 class="heading settled" data-level="3.5.2" id="api-neuralnetworkcontext-conv2d"><span class="secno">3.5.2. </span><span class="content">conv2d</span><a class="self-link" href="#api-neuralnetworkcontext-conv2d"></a></h4>
@@ -1842,13 +1847,6 @@ its dimensions.</p>
 which produces a scalar output.</p>
     </ul>
    </div>
-   <h4 class="heading settled" data-level="3.5.4" id="api-neuralnetworkcontext-mul"><span class="secno">3.5.4. </span><span class="content">mul</span><a class="self-link" href="#api-neuralnetworkcontext-mul"></a></h4>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext④"><c- g>NeuralNetworkContext</c-></a> {
-  // Create an Operand object that represents the result of an element-wise
-  // binary multiplication operation with input operands a and b.
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①⑧"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="mul(a, b)" id="dom-neuralnetworkcontext-mul"><code><c- g>mul</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①⑨"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand②⓪"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-b"></a></dfn>);
-};
-</pre>
    <h3 class="heading settled" data-level="3.6" id="api-model"><span class="secno">3.6. </span><span class="content">Model</span><a class="self-link" href="#api-model"></a></h3>
 <pre class="idl highlight def"><c- b>enum</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="enum" data-export id="enumdef-powerpreference"><code><c- g>PowerPreference</c-></code></dfn> {
   // Let the user agent decide the most suitable behavior. This is the default value.
@@ -1886,8 +1884,8 @@ which produces a scalar output.</p>
 <pre class="highlight"><c- kr>const</c-> nn <c- o>=</c-> navigator<c- p>.</c->ml<c- p>.</c->getNeuralNetworkContext<c- p>();</c->
 </pre>
    </div>
-   <div class="example" id="example-b88ca87a">
-    <a class="self-link" href="#example-b88ca87a"></a> The following code builds a graph as: 
+   <div class="example" id="example-c1400b76">
+    <a class="self-link" href="#example-c1400b76"></a> The following code builds a graph as: 
 <pre>tensor0 ---+
            +--- Add ---> intermediateOutput0 ---+
 tensor1 ---+                                    |
@@ -1923,13 +1921,13 @@ tensor3 ---+
 <c- kr>const</c-> tensor3 <c- o>=</c-> nn<c- p>.</c->input<c- p>(</c->float32TensorType<c- p>);</c->
 
 <c- c1>// intermediateOutput0 is the output of the first Add operation.</c->
-<c- kr>const</c-> intermediateOutput0 <c- o>=</c-> nn<c- p>.</c->add<c- p>(</c->tensor0<c- p>,</c-> tensor1<c- p>);</c->
+<c- kr>const</c-> intermediateOutput0 <c- o>=</c-> nn<c- p>.</c->binary<c- p>(</c-><c- t>'add'</c-><c- p>,</c-> tensor0<c- p>,</c-> tensor1<c- p>);</c->
 
 <c- c1>// intermediateOutput1 is the output of the second Add operation.</c->
-<c- kr>const</c-> intermediateOutput1 <c- o>=</c-> nn<c- p>.</c->add<c- p>(</c->tensor2<c- p>,</c-> tensor3<c- p>);</c->
+<c- kr>const</c-> intermediateOutput1 <c- o>=</c-> nn<c- p>.</c->binary<c- p>(</c-><c- t>'add'</c-><c- p>,</c-> tensor2<c- p>,</c-> tensor3<c- p>);</c->
 
 <c- c1>// output is the output tensor of the Mul operation.</c->
-<c- kr>const</c-> output <c- o>=</c-> nn<c- p>.</c->mul<c- p>(</c->intermediateOutput0<c- p>,</c-> intermediateOutput1<c- p>);</c->
+<c- kr>const</c-> output <c- o>=</c-> nn<c- p>.</c->binary<c- p>(</c-><c- t>'mul'</c-><c- p>,</c-> intermediateOutput0<c- p>,</c-> intermediateOutput1<c- p>);</c->
 
 <c- c1>// Create the model by identifying the outputs.</c->
 <c- kr>const</c-> model <c- o>=</c-> await nn<c- p>.</c->createModel<c- p>([</c->output<c- p>]);</c->
@@ -2121,7 +2119,9 @@ API.</p>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#dom-neuralnetworkcontext-add">add(a, b)</a><span>, in §3.5.1</span>
+   <li><a href="#dom-binaryoperation-add">"add"</a><span>, in §3.5.1</span>
+   <li><a href="#enumdef-binaryoperation">BinaryOperation</a><span>, in §3.5.1</span>
+   <li><a href="#dom-neuralnetworkcontext-binary">binary(op, lhs, rhs)</a><span>, in §3.5.1</span>
    <li><a href="#compilation">Compilation</a><span>, in §3.7</span>
    <li><a href="#dictdef-compilationoptions">CompilationOptions</a><span>, in §3.6</span>
    <li><a href="#dom-neuralnetworkcontext-constant">constant(desc, value)</a><span>, in §3.5</span>
@@ -2133,6 +2133,7 @@ API.</p>
    <li><a href="#dom-neuralnetworkcontext-createmodel">createModel(outputs)</a><span>, in §3.5</span>
    <li><a href="#dom-powerpreference-default">"default"</a><span>, in §3.6</span>
    <li><a href="#dom-operanddescriptor-dimensions">dimensions</a><span>, in §3.3</span>
+   <li><a href="#dom-binaryoperation-div">"div"</a><span>, in §3.5.1</span>
    <li><a href="#execution">Execution</a><span>, in §3.8</span>
    <li><a href="#dom-operandtype-float16">"float16"</a><span>, in §3.3</span>
    <li><a href="#dom-operandtype-float32">"float32"</a><span>, in §3.3</span>
@@ -2142,10 +2143,12 @@ API.</p>
    <li><a href="#dom-operandtype-int32">"int32"</a><span>, in §3.3</span>
    <li><a href="#dom-powerpreference-low-power">"low-power"</a><span>, in §3.6</span>
    <li><a href="#dom-neuralnetworkcontext-matmul">matmul(a, b)</a><span>, in §3.5.3</span>
+   <li><a href="#dom-binaryoperation-max">"max"</a><span>, in §3.5.1</span>
+   <li><a href="#dom-binaryoperation-min">"min"</a><span>, in §3.5.1</span>
    <li><a href="#ml">ML</a><span>, in §3.2</span>
    <li><a href="#dom-navigator-ml">ml</a><span>, in §3.1</span>
    <li><a href="#model">Model</a><span>, in §3.6</span>
-   <li><a href="#dom-neuralnetworkcontext-mul">mul(a, b)</a><span>, in §3.5.4</span>
+   <li><a href="#dom-binaryoperation-mul">"mul"</a><span>, in §3.5.1</span>
    <li><a href="#dom-operandlayout-nchw">"nchw"</a><span>, in §3.3</span>
    <li><a href="#neuralnetworkcontext">NeuralNetworkContext</a><span>, in §3.5</span>
    <li><a href="#dom-operandlayout-nhwc">"nhwc"</a><span>, in §3.3</span>
@@ -2159,6 +2162,7 @@ API.</p>
    <li><a href="#dom-execution-setinput">setInput(index, data)</a><span>, in §3.8</span>
    <li><a href="#dom-execution-setoutput">setOutput(index, data)</a><span>, in §3.8</span>
    <li><a href="#dom-execution-startcompute">startCompute()</a><span>, in §3.8</span>
+   <li><a href="#dom-binaryoperation-sub">"sub"</a><span>, in §3.5.1</span>
    <li><a href="#dom-operandtype-tensor-float16">"tensor-float16"</a><span>, in §3.3</span>
    <li><a href="#dom-operandtype-tensor-float32">"tensor-float32"</a><span>, in §3.3</span>
    <li><a href="#dom-operandtype-tensor-int32">"tensor-int32"</a><span>, in §3.3</span>
@@ -2318,10 +2322,17 @@ API.</p>
   <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#model"><c- n>Model</c-></a>> <a href="#dom-neuralnetworkcontext-createmodel"><code><c- g>createModel</c-></code></a>(<c- b>sequence</c->&lt;<a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a>> <a href="#dom-neuralnetworkcontext-createmodel-outputs-outputs"><code><c- g>outputs</c-></code></a>);
 };
 
+<c- b>enum</c-> <a href="#enumdef-binaryoperation"><code><c- g>BinaryOperation</c-></code></a> {
+  <a href="#dom-binaryoperation-add"><code><c- s>"add"</c-></code></a>,
+  <a href="#dom-binaryoperation-sub"><code><c- s>"sub"</c-></code></a>,
+  <a href="#dom-binaryoperation-mul"><code><c- s>"mul"</c-></code></a>,
+  <a href="#dom-binaryoperation-div"><code><c- s>"div"</c-></code></a>,
+  <a href="#dom-binaryoperation-max"><code><c- s>"max"</c-></code></a>,
+  <a href="#dom-binaryoperation-min"><code><c- s>"min"</c-></code></a>
+};
+
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext"><c- g>NeuralNetworkContext</c-></a> {
-  // Create an Operand object that represents the result of an element-wise
-  // binary addition operation with input operands a and b.
-  <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-add"><code><c- g>add</c-></code></a>(<a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-add-a-b-a"><code><c- g>a</c-></code></a>, <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-add-a-b-b"><code><c- g>b</c-></code></a>);
+  <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-binary"><code><c- g>binary</c-></code></a>(<a class="n" data-link-type="idl-name" href="#enumdef-binaryoperation"><c- n>BinaryOperation</c-></a> <a href="#dom-neuralnetworkcontext-binary-op-lhs-rhs-op"><code><c- g>op</c-></code></a>, <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-binary-op-lhs-rhs-lhs"><code><c- g>lhs</c-></code></a>, <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-binary-op-lhs-rhs-rhs"><code><c- g>rhs</c-></code></a>);
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext"><c- g>NeuralNetworkContext</c-></a> {
@@ -2332,12 +2343,6 @@ API.</p>
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext"><c- g>NeuralNetworkContext</c-></a> {
   <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-matmul"><code><c- g>matmul</c-></code></a>(<a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-matmul-a-b-a"><code><c- g>a</c-></code></a>, <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-matmul-a-b-b"><code><c- g>b</c-></code></a>);
-};
-
-<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext"><c- g>NeuralNetworkContext</c-></a> {
-  // Create an Operand object that represents the result of an element-wise
-  // binary multiplication operation with input operands a and b.
-  <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-mul"><code><c- g>mul</c-></code></a>(<a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-mul-a-b-a"><code><c- g>a</c-></code></a>, <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-mul-a-b-b"><code><c- g>b</c-></code></a>);
 };
 
 <c- b>enum</c-> <a href="#enumdef-powerpreference"><code><c- g>PowerPreference</c-></code></a> {
@@ -2397,20 +2402,24 @@ API.</p>
    <b><a href="#operand">#operand</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-operand">3.5. NeuralNetworkContext</a> <a href="#ref-for-operand①">(2)</a> <a href="#ref-for-operand②">(3)</a>
-    <li><a href="#ref-for-operand③">3.5.1. add</a> <a href="#ref-for-operand④">(2)</a> <a href="#ref-for-operand⑤">(3)</a>
+    <li><a href="#ref-for-operand③">3.5.1. binary</a> <a href="#ref-for-operand④">(2)</a> <a href="#ref-for-operand⑤">(3)</a>
     <li><a href="#ref-for-operand⑥">3.5.2. conv2d</a> <a href="#ref-for-operand⑦">(2)</a> <a href="#ref-for-operand⑧">(3)</a> <a href="#ref-for-operand⑨">(4)</a> <a href="#ref-for-operand①⓪">(5)</a> <a href="#ref-for-operand①①">(6)</a>
     <li><a href="#ref-for-operand①②">3.5.3. matmul</a> <a href="#ref-for-operand①③">(2)</a> <a href="#ref-for-operand①④">(3)</a> <a href="#ref-for-operand①⑤">(4)</a> <a href="#ref-for-operand①⑥">(5)</a> <a href="#ref-for-operand①⑦">(6)</a>
-    <li><a href="#ref-for-operand①⑧">3.5.4. mul</a> <a href="#ref-for-operand①⑨">(2)</a> <a href="#ref-for-operand②⓪">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="neuralnetworkcontext">
    <b><a href="#neuralnetworkcontext">#neuralnetworkcontext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-neuralnetworkcontext">3.2. ML</a>
-    <li><a href="#ref-for-neuralnetworkcontext①">3.5.1. add</a>
+    <li><a href="#ref-for-neuralnetworkcontext①">3.5.1. binary</a>
     <li><a href="#ref-for-neuralnetworkcontext②">3.5.2. conv2d</a>
     <li><a href="#ref-for-neuralnetworkcontext③">3.5.3. matmul</a>
-    <li><a href="#ref-for-neuralnetworkcontext④">3.5.4. mul</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="enumdef-binaryoperation">
+   <b><a href="#enumdef-binaryoperation">#enumdef-binaryoperation</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-enumdef-binaryoperation">3.5.1. binary</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-powerpreference">


### PR DESCRIPTION
The first PR is to add element-wise add and multiply according to [r01](https://www.w3.org/2020/04/30-webmachinelearning-minutes.html#r01) of WebML CG Teleconference – 30 April 2020.

> RESOLUTION: Add elementwise add, elementwise multiply, concatenation, and reshape ops to the WebNN API


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/53.html" title="Last updated on May 4, 2020, 3:39 AM UTC (d926781)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/53/3e09f7b...huningxin:d926781.html" title="Last updated on May 4, 2020, 3:39 AM UTC (d926781)">Diff</a>