### PR TITLE
Add spec text of add and mul

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -244,11 +244,24 @@ interface NeuralNetworkContext {
 ### add ### {#api-neuralnetworkcontext-add}
 <script type=idl>
 partial interface NeuralNetworkContext {
-  // Create an Operand object that represents the result of an element-wise
-  // binary addition operation with input operands a and b.
   Operand add(Operand a, Operand b);
 };
 </script>
+
+<div algorithm=add>
+    **Arguments:**
+        - *a*: an {{Operand}}. The first input tensor.
+        - *b*: an {{Operand}}. The second input tensor.
+
+    **Returns:** an {{Operand}}. The output tensor that contains the result of
+    element-wise binary addition of the two input tensors.
+
+    Computes the element-wise binary addition of the two input tensors. The
+    element-wise binary addition will be broadcasted according to
+    [[!numpy-broadcasting-rule]]. The rank of the output tensor is the maximum
+    rank of the input tensors. For each dimension of the output tensor, its size
+    is the maximum size along that dimension of the input tensors.
+</div>
 
 ### conv2d ### {#api-neuralnetworkcontext-conv2d}
 <script type=idl>
@@ -370,11 +383,23 @@ partial interface NeuralNetworkContext {
 ### mul ### {#api-neuralnetworkcontext-mul}
 <script type=idl>
 partial interface NeuralNetworkContext {
-  // Create an Operand object that represents the result of an element-wise
-  // binary multiplication operation with input operands a and b.
   Operand mul(Operand a, Operand b);
 };
 </script>
+<div algorithm=mul>
+    **Arguments:**
+        - *a*: an {{Operand}}. The first input tensor.
+        - *b*: an {{Operand}}. The second input tensor.
+
+    **Returns:** an {{Operand}}. The output tensor that contains the result of
+    element-wise binary multiplication of the two input tensors.
+
+    Computes the element-wise binary multiplication of the two input tensors.
+    The element-wise binary multiplication will be broadcasted according to
+    [[!numpy-broadcasting-rule]]. The rank of the output tensor is the maximum
+    rank of the input tensors. For each dimension of the output tensor, its size
+    is the maximum size along that dimension of the input tensors.
+</div>
 
 ### transpose ### {#api-neuralnetworkcontext-transpose}
 <script type=idl>

--- a/index.html
+++ b/index.html
@@ -1223,7 +1223,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 70ffa934, updated Fri May 1 10:12:04 2020 -0700" name="generator">
   <link href="https://webmachinelearning.github.io/webnn/" rel="canonical">
-  <meta content="6d0b502aa0f504aa33e165c8a5c82bcd213a22d0" name="document-revision">
+  <meta content="6c740a807b2d1702c0a97a21bbdc3e5cae863738" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1470,7 +1470,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Web Neural Network API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-05-13">13 May 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-05-14">14 May 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1747,14 +1747,27 @@ so that the application loads the tiny model in the case of CPU-only devices.</p
 </pre>
    <h4 class="heading settled" data-level="3.5.1" id="api-neuralnetworkcontext-add"><span class="secno">3.5.1. </span><span class="content">add</span><a class="self-link" href="#api-neuralnetworkcontext-add"></a></h4>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext①"><c- g>NeuralNetworkContext</c-></a> {
-  // Create an Operand object that represents the result of an element-wise
-  // binary addition operation with input operands a and b.
   <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="add(a, b)" id="dom-neuralnetworkcontext-add"><code><c- g>add</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-add"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑤"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/add(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-add-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-add-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑥"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/add(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-add-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-add-a-b-b"></a></dfn>);
 };
 </pre>
+   <div class="algorithm" data-algorithm="add">
+     <strong>Arguments:</strong> 
+    <ul>
+     <li data-md>
+      <p><em>a</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑦">Operand</a></code>. The first input tensor.</p>
+     <li data-md>
+      <p><em>b</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑧">Operand</a></code>. The second input tensor.</p>
+    </ul>
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑨">Operand</a></code>. The output tensor that contains the result of
+    element-wise binary addition of the two input tensors.</p>
+    <p>Computes the element-wise binary addition of the two input tensors. The
+    element-wise binary addition will be broadcasted according to <a data-link-type="biblio" href="#biblio-numpy-broadcasting-rule">[numpy-broadcasting-rule]</a>. The rank of the output tensor is the maximum
+    rank of the input tensors. For each dimension of the output tensor, its size
+    is the maximum size along that dimension of the input tensors.</p>
+   </div>
    <h4 class="heading settled" data-level="3.5.2" id="api-neuralnetworkcontext-conv2d"><span class="secno">3.5.2. </span><span class="content">conv2d</span><a class="self-link" href="#api-neuralnetworkcontext-conv2d"></a></h4>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext②"><c- g>NeuralNetworkContext</c-></a> {
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑦"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="conv2d(input, filter, padding, strides, dilations, layout)|conv2d(input, filter, padding, strides, dilations)" id="dom-neuralnetworkcontext-conv2d"><code><c- g>conv2d</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-conv2d"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑧"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations, layout), NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-input"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑨"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations, layout), NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-filter"><code><c- g>filter</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-filter"></a></dfn>,
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①⓪"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="conv2d(input, filter, padding, strides, dilations, layout)|conv2d(input, filter, padding, strides, dilations)" id="dom-neuralnetworkcontext-conv2d"><code><c- g>conv2d</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-conv2d"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①①"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations, layout), NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-input"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①②"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations, layout), NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-filter"><code><c- g>filter</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-filter"></a></dfn>,
                  <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long②"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations, layout), NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-padding"><code><c- g>padding</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-padding"></a></dfn>, <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long③"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations, layout), NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-strides"><code><c- g>strides</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-strides"></a></dfn>, <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long④"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations, layout), NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-dilations"><code><c- g>dilations</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-dilations"></a></dfn>,
                  <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#enumdef-operandlayout" id="ref-for-enumdef-operandlayout"><c- n>OperandLayout</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations, layout), NeuralNetworkContext/conv2d(input, filter, padding, strides, dilations)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-layout"><code><c- g>layout</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-conv2d-input-filter-padding-strides-dilations-layout-layout"></a></dfn> = "nchw");
 };
@@ -1763,10 +1776,10 @@ so that the application loads the tiny model in the case of CPU-only devices.</p
      <strong>Arguments:</strong> 
     <ul>
      <li data-md>
-      <p><em>input</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand①⓪">Operand</a></code>. The input 4-D tensor. The logical shape
+      <p><em>input</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand①③">Operand</a></code>. The input 4-D tensor. The logical shape
 is interpreted according to the value of <em>layout</em>.</p>
      <li data-md>
-      <p><em>filter</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand①①">Operand</a></code>. The filter 4-D tensor. The logical shape
+      <p><em>filter</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand①④">Operand</a></code>. The filter 4-D tensor. The logical shape
 is interpreted according to the value of <em>layout</em>.</p>
      <li data-md>
       <p><em>padding</em>: a sequence of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑤">long</a></code> of length 4. The padding for the
@@ -1806,14 +1819,14 @@ output_channels]</p>
         <p>output tensor: [batches, height, width, output_channels]</p>
       </ul>
     </ul>
-    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand①②">Operand</a></code>. The output 4-D tensor that contains the
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand①⑤">Operand</a></code>. The output 4-D tensor that contains the
     result of the convolution. The logical shape is interpreted according to the
     value of <em>layout</em>.</p>
     <p>Computes a 2-D convolution given input and filter 4-D tensors.</p>
    </div>
    <h4 class="heading settled" data-level="3.5.3" id="api-neuralnetworkcontext-gemm"><span class="secno">3.5.3. </span><span class="content">gemm</span><a class="self-link" href="#api-neuralnetworkcontext-gemm"></a></h4>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext③"><c- g>NeuralNetworkContext</c-></a> {
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①③"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="gemm(a, b, c, alpha, beta, aTranspose, bTranspose)|gemm(a, b, c, alpha, beta, aTranspose)|gemm(a, b, c, alpha, beta)|gemm(a, b, c, alpha)|gemm(a, b, c)|gemm(a, b)" id="dom-neuralnetworkcontext-gemm"><code><c- g>gemm</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-gemm"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①④"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose, bTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta), NeuralNetworkContext/gemm(a, b, c, alpha), NeuralNetworkContext/gemm(a, b, c), NeuralNetworkContext/gemm(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①⑤"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose, bTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta), NeuralNetworkContext/gemm(a, b, c, alpha), NeuralNetworkContext/gemm(a, b, c), NeuralNetworkContext/gemm(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-b"></a></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①⑥"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose, bTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta), NeuralNetworkContext/gemm(a, b, c, alpha), NeuralNetworkContext/gemm(a, b, c), NeuralNetworkContext/gemm(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-c"><code><c- g>c</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-c"></a></dfn> = <c- b>null</c->, 
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①⑥"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="gemm(a, b, c, alpha, beta, aTranspose, bTranspose)|gemm(a, b, c, alpha, beta, aTranspose)|gemm(a, b, c, alpha, beta)|gemm(a, b, c, alpha)|gemm(a, b, c)|gemm(a, b)" id="dom-neuralnetworkcontext-gemm"><code><c- g>gemm</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-gemm"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①⑦"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose, bTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta), NeuralNetworkContext/gemm(a, b, c, alpha), NeuralNetworkContext/gemm(a, b, c), NeuralNetworkContext/gemm(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①⑧"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose, bTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta), NeuralNetworkContext/gemm(a, b, c, alpha), NeuralNetworkContext/gemm(a, b, c), NeuralNetworkContext/gemm(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-b"></a></dfn>, <c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①⑨"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose, bTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta), NeuralNetworkContext/gemm(a, b, c, alpha), NeuralNetworkContext/gemm(a, b, c), NeuralNetworkContext/gemm(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-c"><code><c- g>c</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-c"></a></dfn> = <c- b>null</c->, 
                <c- b>optional</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-float" id="ref-for-idl-float①"><c- b>float</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose, bTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta), NeuralNetworkContext/gemm(a, b, c, alpha), NeuralNetworkContext/gemm(a, b, c), NeuralNetworkContext/gemm(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-alpha"><code><c- g>alpha</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-alpha"></a></dfn> = 1.0, <c- b>optional</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-float" id="ref-for-idl-float②"><c- b>float</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose, bTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta), NeuralNetworkContext/gemm(a, b, c, alpha), NeuralNetworkContext/gemm(a, b, c), NeuralNetworkContext/gemm(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-beta"><code><c- g>beta</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-beta"></a></dfn> = 1.0, 
                <c- b>optional</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean"><c- b>boolean</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose, bTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta), NeuralNetworkContext/gemm(a, b, c, alpha), NeuralNetworkContext/gemm(a, b, c), NeuralNetworkContext/gemm(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-atranspose"><code><c- g>aTranspose</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-atranspose"></a></dfn> = <c- b>false</c->, <c- b>optional</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean①"><c- b>boolean</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose, bTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta, aTranspose), NeuralNetworkContext/gemm(a, b, c, alpha, beta), NeuralNetworkContext/gemm(a, b, c, alpha), NeuralNetworkContext/gemm(a, b, c), NeuralNetworkContext/gemm(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-btranspose"><code><c- g>bTranspose</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-gemm-a-b-c-alpha-beta-atranspose-btranspose-btranspose"></a></dfn> = <c- b>false</c->);
 };
@@ -1822,11 +1835,11 @@ output_channels]</p>
      <strong>Arguments:</strong> 
     <ul>
      <li data-md>
-      <p><em>a</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand①⑦">Operand</a></code>. The first input 2-D tensor.</p>
+      <p><em>a</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand②⓪">Operand</a></code>. The first input 2-D tensor.</p>
      <li data-md>
-      <p><em>b</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand①⑧">Operand</a></code>. The second input 2-D tensor.</p>
+      <p><em>b</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand②①">Operand</a></code>. The second input 2-D tensor.</p>
      <li data-md>
-      <p><em>c</em>: an optional <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand①⑨">Operand</a></code>. The third input 2-D tensor.</p>
+      <p><em>c</em>: an optional <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand②②">Operand</a></code>. The third input 2-D tensor.</p>
      <li data-md>
       <p><em>alpha</em>: an optional <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-float" id="ref-for-idl-float③">float</a></code> scalar multiplier for the first input, default to 1.0.</p>
      <li data-md>
@@ -1836,7 +1849,7 @@ output_channels]</p>
      <li data-md>
       <p><em>bTranspose</em>: an optional <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-boolean" id="ref-for-idl-boolean③">boolean</a></code> indicating if the second input should be transposed prior to calculating the output, default to false.</p>
     </ul>
-    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand②⓪">Operand</a></code>. The output 2-D tensor that contains the calculated product of all the inputs.</p>
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand②③">Operand</a></code>. The output 2-D tensor that contains the calculated product of all the inputs.</p>
     <p>Calculate the <a href="https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3">general matrix multiplication of the Basic Liner Algebra Subprograms</a>. The calculation follows the expression <code>alpha * A * B + beta * C</code>, where <code>A</code>, <code>B</code>, and <code>C</code> are matrices, and <code>A</code> and <code>B</code> may optionally be transposed prior to the calculation.</p>
     <div class="note" role="note">
       The behavior of this operation can be generically emulated from the usage of other operations as follow. However, user agents typically have a more efficient implementation for it, therefore its usage is encouraged from the performance standpoint. 
@@ -1853,18 +1866,18 @@ output_channels]</p>
    </div>
    <h4 class="heading settled" data-level="3.5.4" id="api-neuralnetworkcontext-matmul"><span class="secno">3.5.4. </span><span class="content">matmul</span><a class="self-link" href="#api-neuralnetworkcontext-matmul"></a></h4>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext④"><c- g>NeuralNetworkContext</c-></a> {
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand②①"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="matmul(a, b)" id="dom-neuralnetworkcontext-matmul"><code><c- g>matmul</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-matmul"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand②②"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/matmul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-matmul-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-matmul-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand②③"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/matmul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-matmul-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-matmul-a-b-b"></a></dfn>);
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand②④"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="matmul(a, b)" id="dom-neuralnetworkcontext-matmul"><code><c- g>matmul</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-matmul"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand②⑤"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/matmul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-matmul-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-matmul-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand②⑥"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/matmul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-matmul-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-matmul-a-b-b"></a></dfn>);
 };
 </pre>
    <div class="algorithm" data-algorithm="matmul">
      <strong>Arguments:</strong> 
     <ul>
      <li data-md>
-      <p><em>a</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand②④">Operand</a></code>. The first input N-D tensor.</p>
+      <p><em>a</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand②⑦">Operand</a></code>. The first input N-D tensor.</p>
      <li data-md>
-      <p><em>b</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand②⑤">Operand</a></code>. The second input N-D tensor.</p>
+      <p><em>b</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand②⑧">Operand</a></code>. The second input N-D tensor.</p>
     </ul>
-    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand②⑥">Operand</a></code>. The output N-D tensor that contains the matrix
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand②⑨">Operand</a></code>. The output N-D tensor that contains the matrix
     product of two input tensors.</p>
     <p>Computes the matrix product of two input tensors. It behaves as following:</p>
     <ul>
@@ -1891,25 +1904,38 @@ which produces a scalar output.</p>
    </div>
    <h4 class="heading settled" data-level="3.5.5" id="api-neuralnetworkcontext-mul"><span class="secno">3.5.5. </span><span class="content">mul</span><a class="self-link" href="#api-neuralnetworkcontext-mul"></a></h4>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑤"><c- g>NeuralNetworkContext</c-></a> {
-  // Create an Operand object that represents the result of an element-wise
-  // binary multiplication operation with input operands a and b.
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand②⑦"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="mul(a, b)" id="dom-neuralnetworkcontext-mul"><code><c- g>mul</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand②⑧"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand②⑨"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-b"></a></dfn>);
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③⓪"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="mul(a, b)" id="dom-neuralnetworkcontext-mul"><code><c- g>mul</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③①"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③②"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-b"></a></dfn>);
 };
 </pre>
+   <div class="algorithm" data-algorithm="mul">
+     <strong>Arguments:</strong> 
+    <ul>
+     <li data-md>
+      <p><em>a</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③③">Operand</a></code>. The first input tensor.</p>
+     <li data-md>
+      <p><em>b</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③④">Operand</a></code>. The second input tensor.</p>
+    </ul>
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③⑤">Operand</a></code>. The output tensor that contains the result of
+    element-wise binary multiplication of the two input tensors.</p>
+    <p>Computes the element-wise binary multiplication of the two input tensors.
+    The element-wise binary multiplication will be broadcasted according to <a data-link-type="biblio" href="#biblio-numpy-broadcasting-rule">[numpy-broadcasting-rule]</a>. The rank of the output tensor is the maximum
+    rank of the input tensors. For each dimension of the output tensor, its size
+    is the maximum size along that dimension of the input tensors.</p>
+   </div>
    <h4 class="heading settled" data-level="3.5.6" id="api-neuralnetworkcontext-transpose"><span class="secno">3.5.6. </span><span class="content">transpose</span><a class="self-link" href="#api-neuralnetworkcontext-transpose"></a></h4>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑥"><c- g>NeuralNetworkContext</c-></a> {
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③⓪"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="transpose(input, permutation)|transpose(input)" id="dom-neuralnetworkcontext-transpose"><code><c- g>transpose</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③①"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/transpose(input, permutation), NeuralNetworkContext/transpose(input)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-transpose-input-permutation-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose-input-permutation-input"></a></dfn>, <c- b>optional</c-> <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑧"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/transpose(input, permutation), NeuralNetworkContext/transpose(input)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-transpose-input-permutation-permutation"><code><c- g>permutation</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose-input-permutation-permutation"></a></dfn>);
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③⑥"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="transpose(input, permutation)|transpose(input)" id="dom-neuralnetworkcontext-transpose"><code><c- g>transpose</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③⑦"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/transpose(input, permutation), NeuralNetworkContext/transpose(input)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-transpose-input-permutation-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose-input-permutation-input"></a></dfn>, <c- b>optional</c-> <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑧"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/transpose(input, permutation), NeuralNetworkContext/transpose(input)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-transpose-input-permutation-permutation"><code><c- g>permutation</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose-input-permutation-permutation"></a></dfn>);
 };
 </pre>
    <div class="algorithm" data-algorithm="transpose">
      <strong>Arguments:</strong> 
     <ul>
      <li data-md>
-      <p><em>input</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③②">Operand</a></code>. The input N-D tensor.</p>
+      <p><em>input</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③⑧">Operand</a></code>. The input N-D tensor.</p>
      <li data-md>
       <p><em>permutation</em>: an optional sequence of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long⑨">long</a></code> values. The values used to permute the output shape. When it’s not specified, it’s set to <code>[N-1...0]</code>, where <code>N</code> is the rank of the input tensor. These default values cause the output to become a transposed tensor of the input. When specified, the number of values in the sequence must be the same as the rank of the input tensor, and the values in the sequence must be within the range from 0 to N-1 with no two or more same values found in the sequence.</p>
     </ul>
-    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③③">Operand</a></code>. The permuted or transposed N-D tensor.</p>
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③⑨">Operand</a></code>. The permuted or transposed N-D tensor.</p>
     <p>Permute the dimensions of the input tensor according to the <em>permutation</em> argument.</p>
    </div>
    <h3 class="heading settled" data-level="3.6" id="api-model"><span class="secno">3.6. </span><span class="content">Model</span><a class="self-link" href="#api-model"></a></h3>
@@ -2414,8 +2440,6 @@ API.</p>
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext"><c- g>NeuralNetworkContext</c-></a> {
-  // Create an Operand object that represents the result of an element-wise
-  // binary addition operation with input operands a and b.
   <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-add"><code><c- g>add</c-></code></a>(<a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-add-a-b-a"><code><c- g>a</c-></code></a>, <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-add-a-b-b"><code><c- g>b</c-></code></a>);
 };
 
@@ -2436,8 +2460,6 @@ API.</p>
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext"><c- g>NeuralNetworkContext</c-></a> {
-  // Create an Operand object that represents the result of an element-wise
-  // binary multiplication operation with input operands a and b.
   <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-mul"><code><c- g>mul</c-></code></a>(<a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-mul-a-b-a"><code><c- g>a</c-></code></a>, <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-mul-a-b-b"><code><c- g>b</c-></code></a>);
 };
 
@@ -2503,12 +2525,12 @@ API.</p>
    <b><a href="#operand">#operand</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-operand">3.5. NeuralNetworkContext</a> <a href="#ref-for-operand①">(2)</a> <a href="#ref-for-operand②">(3)</a> <a href="#ref-for-operand③">(4)</a>
-    <li><a href="#ref-for-operand④">3.5.1. add</a> <a href="#ref-for-operand⑤">(2)</a> <a href="#ref-for-operand⑥">(3)</a>
-    <li><a href="#ref-for-operand⑦">3.5.2. conv2d</a> <a href="#ref-for-operand⑧">(2)</a> <a href="#ref-for-operand⑨">(3)</a> <a href="#ref-for-operand①⓪">(4)</a> <a href="#ref-for-operand①①">(5)</a> <a href="#ref-for-operand①②">(6)</a>
-    <li><a href="#ref-for-operand①③">3.5.3. gemm</a> <a href="#ref-for-operand①④">(2)</a> <a href="#ref-for-operand①⑤">(3)</a> <a href="#ref-for-operand①⑥">(4)</a> <a href="#ref-for-operand①⑦">(5)</a> <a href="#ref-for-operand①⑧">(6)</a> <a href="#ref-for-operand①⑨">(7)</a> <a href="#ref-for-operand②⓪">(8)</a>
-    <li><a href="#ref-for-operand②①">3.5.4. matmul</a> <a href="#ref-for-operand②②">(2)</a> <a href="#ref-for-operand②③">(3)</a> <a href="#ref-for-operand②④">(4)</a> <a href="#ref-for-operand②⑤">(5)</a> <a href="#ref-for-operand②⑥">(6)</a>
-    <li><a href="#ref-for-operand②⑦">3.5.5. mul</a> <a href="#ref-for-operand②⑧">(2)</a> <a href="#ref-for-operand②⑨">(3)</a>
-    <li><a href="#ref-for-operand③⓪">3.5.6. transpose</a> <a href="#ref-for-operand③①">(2)</a> <a href="#ref-for-operand③②">(3)</a> <a href="#ref-for-operand③③">(4)</a>
+    <li><a href="#ref-for-operand④">3.5.1. add</a> <a href="#ref-for-operand⑤">(2)</a> <a href="#ref-for-operand⑥">(3)</a> <a href="#ref-for-operand⑦">(4)</a> <a href="#ref-for-operand⑧">(5)</a> <a href="#ref-for-operand⑨">(6)</a>
+    <li><a href="#ref-for-operand①⓪">3.5.2. conv2d</a> <a href="#ref-for-operand①①">(2)</a> <a href="#ref-for-operand①②">(3)</a> <a href="#ref-for-operand①③">(4)</a> <a href="#ref-for-operand①④">(5)</a> <a href="#ref-for-operand①⑤">(6)</a>
+    <li><a href="#ref-for-operand①⑥">3.5.3. gemm</a> <a href="#ref-for-operand①⑦">(2)</a> <a href="#ref-for-operand①⑧">(3)</a> <a href="#ref-for-operand①⑨">(4)</a> <a href="#ref-for-operand②⓪">(5)</a> <a href="#ref-for-operand②①">(6)</a> <a href="#ref-for-operand②②">(7)</a> <a href="#ref-for-operand②③">(8)</a>
+    <li><a href="#ref-for-operand②④">3.5.4. matmul</a> <a href="#ref-for-operand②⑤">(2)</a> <a href="#ref-for-operand②⑥">(3)</a> <a href="#ref-for-operand②⑦">(4)</a> <a href="#ref-for-operand②⑧">(5)</a> <a href="#ref-for-operand②⑨">(6)</a>
+    <li><a href="#ref-for-operand③⓪">3.5.5. mul</a> <a href="#ref-for-operand③①">(2)</a> <a href="#ref-for-operand③②">(3)</a> <a href="#ref-for-operand③③">(4)</a> <a href="#ref-for-operand③④">(5)</a> <a href="#ref-for-operand③⑤">(6)</a>
+    <li><a href="#ref-for-operand③⑥">3.5.6. transpose</a> <a href="#ref-for-operand③⑦">(2)</a> <a href="#ref-for-operand③⑧">(3)</a> <a href="#ref-for-operand③⑨">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="typedefdef-number">


### PR DESCRIPTION
This PR is to add spec texts of element-wise add and multiply according to [r01](https://www.w3.org/2020/04/30-webmachinelearning-minutes.html#r01) of WebML CG Teleconference – 30 April 2020.

> RESOLUTION: Add elementwise add, elementwise multiply, concatenation, and reshape ops to the WebNN API


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/54.html" title="Last updated on May 14, 2020, 2:03 AM UTC (7f8b1b5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/54/928572e...huningxin:7f8b1b5.html" title="Last updated on May 14, 2020, 2:03 AM UTC (7f8b1b5)">Diff</a>