### PR TITLE
Add reshape

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -424,6 +424,30 @@ partial interface NeuralNetworkContext {
     is the maximum size along that dimension of the input tensors.
 </div>
 
+### reshape ### {#api-neuralnetworkcontext-reshape}
+<script type=idl>
+partial interface NeuralNetworkContext {
+  Operand reshape(Operand input, sequence<long> newShape);
+};
+</script>
+
+<div algorithm=reshape>
+    **Arguments:**
+        - *input*: an {{Operand}}. The input tensor.
+        - *newShape*: a sequence of {{long}}. The shape of the output tensor.
+            The number of elements implied by *newShape* must be the same as the
+            number of elements in the input tensor. Only one component of
+            *newShape* can be the special value of -1. The size of the dimension
+            with the value -1 is computed so that the total size remains
+            constant.
+
+    **Returns:**: an {{Operand}}. The output tensor. The values of the output
+    tensor are the same as values of the input tensor. The shape of the output
+    tensor is specified by the *newShape* argument.
+
+    Reshapes a tensor to a given new shape.
+</div>
+
 ### transpose ### {#api-neuralnetworkcontext-transpose}
 <script type=idl>
 partial interface NeuralNetworkContext {

--- a/index.html
+++ b/index.html
@@ -1223,7 +1223,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 70ffa934, updated Fri May 1 10:12:04 2020 -0700" name="generator">
   <link href="https://webmachinelearning.github.io/webnn/" rel="canonical">
-  <meta content="27241e9161b8dfb1da14bcf97d496e73d6b7d1de" name="document-revision">
+  <meta content="b0e4ad8305e533e14b0eb4428bc5c50a0099c33a" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1551,7 +1551,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li><a href="#api-neuralnetworkcontext-gemm"><span class="secno">3.5.4</span> <span class="content">gemm</span></a>
         <li><a href="#api-neuralnetworkcontext-matmul"><span class="secno">3.5.5</span> <span class="content">matmul</span></a>
         <li><a href="#api-neuralnetworkcontext-mul"><span class="secno">3.5.6</span> <span class="content">mul</span></a>
-        <li><a href="#api-neuralnetworkcontext-transpose"><span class="secno">3.5.7</span> <span class="content">transpose</span></a>
+        <li><a href="#api-neuralnetworkcontext-reshape"><span class="secno">3.5.7</span> <span class="content">reshape</span></a>
+        <li><a href="#api-neuralnetworkcontext-transpose"><span class="secno">3.5.8</span> <span class="content">transpose</span></a>
        </ol>
       <li><a href="#api-model"><span class="secno">3.6</span> <span class="content">Model</span></a>
       <li><a href="#api-compilation"><span class="secno">3.7</span> <span class="content">Compilation</span></a>
@@ -1945,20 +1946,42 @@ which produces a scalar output.</p>
     rank of the input tensors. For each dimension of the output tensor, its size
     is the maximum size along that dimension of the input tensors.</p>
    </div>
-   <h4 class="heading settled" data-level="3.5.7" id="api-neuralnetworkcontext-transpose"><span class="secno">3.5.7. </span><span class="content">transpose</span><a class="self-link" href="#api-neuralnetworkcontext-transpose"></a></h4>
+   <h4 class="heading settled" data-level="3.5.7" id="api-neuralnetworkcontext-reshape"><span class="secno">3.5.7. </span><span class="content">reshape</span><a class="self-link" href="#api-neuralnetworkcontext-reshape"></a></h4>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑦"><c- g>NeuralNetworkContext</c-></a> {
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④⓪"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="transpose(input, permutation)|transpose(input)" id="dom-neuralnetworkcontext-transpose"><code><c- g>transpose</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④①"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/transpose(input, permutation), NeuralNetworkContext/transpose(input)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-transpose-input-permutation-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose-input-permutation-input"></a></dfn>, <c- b>optional</c-> <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⓪"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/transpose(input, permutation), NeuralNetworkContext/transpose(input)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-transpose-input-permutation-permutation"><code><c- g>permutation</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose-input-permutation-permutation"></a></dfn>);
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④⓪"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="reshape(input, newShape)" id="dom-neuralnetworkcontext-reshape"><code><c- g>reshape</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-reshape"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④①"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/reshape(input, newShape)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-reshape-input-newshape-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-reshape-input-newshape-input"></a></dfn>, <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⓪"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/reshape(input, newShape)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-reshape-input-newshape-newshape"><code><c- g>newShape</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-reshape-input-newshape-newshape"></a></dfn>);
+};
+</pre>
+   <div class="algorithm" data-algorithm="reshape">
+     <strong>Arguments:</strong> 
+    <ul>
+     <li data-md>
+      <p><em>input</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④②">Operand</a></code>. The input tensor.</p>
+     <li data-md>
+      <p><em>newShape</em>: a sequence of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①①">long</a></code>. The shape of the output tensor.
+The number of elements implied by <em>newShape</em> must be the same as the
+number of elements in the input tensor. Only one component of <em>newShape</em> can be the special value of -1. The size of the dimension
+with the value -1 is computed so that the total size remains
+constant.</p>
+    </ul>
+    <p><strong>Returns:</strong>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④③">Operand</a></code>. The output tensor. The values of the output
+    tensor are the same as values of the input tensor. The shape of the output
+    tensor is specified by the <em>newShape</em> argument.</p>
+    <p>Reshapes a tensor to a given new shape.</p>
+   </div>
+   <h4 class="heading settled" data-level="3.5.8" id="api-neuralnetworkcontext-transpose"><span class="secno">3.5.8. </span><span class="content">transpose</span><a class="self-link" href="#api-neuralnetworkcontext-transpose"></a></h4>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑧"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④④"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="transpose(input, permutation)|transpose(input)" id="dom-neuralnetworkcontext-transpose"><code><c- g>transpose</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④⑤"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/transpose(input, permutation), NeuralNetworkContext/transpose(input)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-transpose-input-permutation-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose-input-permutation-input"></a></dfn>, <c- b>optional</c-> <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①②"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/transpose(input, permutation), NeuralNetworkContext/transpose(input)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-transpose-input-permutation-permutation"><code><c- g>permutation</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose-input-permutation-permutation"></a></dfn>);
 };
 </pre>
    <div class="algorithm" data-algorithm="transpose">
      <strong>Arguments:</strong> 
     <ul>
      <li data-md>
-      <p><em>input</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④②">Operand</a></code>. The input N-D tensor.</p>
+      <p><em>input</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④⑥">Operand</a></code>. The input N-D tensor.</p>
      <li data-md>
-      <p><em>permutation</em>: an optional sequence of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①①">long</a></code> values. The values used to permute the output shape. When it’s not specified, it’s set to <code>[N-1...0]</code>, where <code>N</code> is the rank of the input tensor. These default values cause the output to become a transposed tensor of the input. When specified, the number of values in the sequence must be the same as the rank of the input tensor, and the values in the sequence must be within the range from 0 to N-1 with no two or more same values found in the sequence.</p>
+      <p><em>permutation</em>: an optional sequence of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①③">long</a></code> values. The values used to permute the output shape. When it’s not specified, it’s set to <code>[N-1...0]</code>, where <code>N</code> is the rank of the input tensor. These default values cause the output to become a transposed tensor of the input. When specified, the number of values in the sequence must be the same as the rank of the input tensor, and the values in the sequence must be within the range from 0 to N-1 with no two or more same values found in the sequence.</p>
     </ul>
-    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④③">Operand</a></code>. The permuted or transposed N-D tensor.</p>
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④⑦">Operand</a></code>. The permuted or transposed N-D tensor.</p>
     <p>Permute the dimensions of the input tensor according to the <em>permutation</em> argument.</p>
    </div>
    <h3 class="heading settled" data-level="3.6" id="api-model"><span class="secno">3.6. </span><span class="content">Model</span><a class="self-link" href="#api-model"></a></h3>
@@ -2277,6 +2300,7 @@ API.</p>
    <li><a href="#enumdef-operandtype">OperandType</a><span>, in §3.3</span>
    <li><a href="#enumdef-powerpreference">PowerPreference</a><span>, in §3.6</span>
    <li><a href="#dom-compilationoptions-powerpreference">powerPreference</a><span>, in §3.6</span>
+   <li><a href="#dom-neuralnetworkcontext-reshape">reshape(input, newShape)</a><span>, in §3.5.7</span>
    <li><a href="#dom-operanddescriptor-scale">scale</a><span>, in §3.3</span>
    <li><a href="#dom-execution-setinput">setInput(index, data)</a><span>, in §3.8</span>
    <li><a href="#dom-execution-setoutput">setOutput(index, data)</a><span>, in §3.8</span>
@@ -2285,8 +2309,8 @@ API.</p>
    <li><a href="#dom-operandtype-tensor-float32">"tensor-float32"</a><span>, in §3.3</span>
    <li><a href="#dom-operandtype-tensor-int32">"tensor-int32"</a><span>, in §3.3</span>
    <li><a href="#dom-operandtype-tensor-quant8-asymm">"tensor-quant8-asymm"</a><span>, in §3.3</span>
-   <li><a href="#dom-neuralnetworkcontext-transpose">transpose(input)</a><span>, in §3.5.7</span>
-   <li><a href="#dom-neuralnetworkcontext-transpose">transpose(input, permutation)</a><span>, in §3.5.7</span>
+   <li><a href="#dom-neuralnetworkcontext-transpose">transpose(input)</a><span>, in §3.5.8</span>
+   <li><a href="#dom-neuralnetworkcontext-transpose">transpose(input, permutation)</a><span>, in §3.5.8</span>
    <li><a href="#dom-operanddescriptor-type">type</a><span>, in §3.3</span>
    <li><a href="#dom-operandtype-uint32">"uint32"</a><span>, in §3.3</span>
    <li><a href="#dom-operanddescriptor-zeropoint">zeroPoint</a><span>, in §3.3</span>
@@ -2329,7 +2353,8 @@ API.</p>
     <li><a href="#ref-for-idl-long">3.3. OperandDescriptor</a> <a href="#ref-for-idl-long①">(2)</a>
     <li><a href="#ref-for-idl-long②">3.5.2. concat</a> <a href="#ref-for-idl-long③">(2)</a>
     <li><a href="#ref-for-idl-long④">3.5.3. conv2d</a> <a href="#ref-for-idl-long⑤">(2)</a> <a href="#ref-for-idl-long⑥">(3)</a> <a href="#ref-for-idl-long⑦">(4)</a> <a href="#ref-for-idl-long⑧">(5)</a> <a href="#ref-for-idl-long⑨">(6)</a>
-    <li><a href="#ref-for-idl-long①⓪">3.5.7. transpose</a> <a href="#ref-for-idl-long①①">(2)</a>
+    <li><a href="#ref-for-idl-long①⓪">3.5.7. reshape</a> <a href="#ref-for-idl-long①①">(2)</a>
+    <li><a href="#ref-for-idl-long①②">3.5.8. transpose</a> <a href="#ref-for-idl-long①③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
@@ -2493,6 +2518,10 @@ API.</p>
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-reshape"><code><c- g>reshape</c-></code></a>(<a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-reshape-input-newshape-input"><code><c- g>input</c-></code></a>, <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><c- b>long</c-></a>> <a href="#dom-neuralnetworkcontext-reshape-input-newshape-newshape"><code><c- g>newShape</c-></code></a>);
+};
+
+<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext"><c- g>NeuralNetworkContext</c-></a> {
   <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-transpose"><code><c- g>transpose</c-></code></a>(<a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-transpose-input-permutation-input"><code><c- g>input</c-></code></a>, <c- b>optional</c-> <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><c- b>long</c-></a>> <a href="#dom-neuralnetworkcontext-transpose-input-permutation-permutation"><code><c- g>permutation</c-></code></a>);
 };
 
@@ -2560,7 +2589,8 @@ API.</p>
     <li><a href="#ref-for-operand②⓪">3.5.4. gemm</a> <a href="#ref-for-operand②①">(2)</a> <a href="#ref-for-operand②②">(3)</a> <a href="#ref-for-operand②③">(4)</a> <a href="#ref-for-operand②④">(5)</a> <a href="#ref-for-operand②⑤">(6)</a> <a href="#ref-for-operand②⑥">(7)</a> <a href="#ref-for-operand②⑦">(8)</a>
     <li><a href="#ref-for-operand②⑧">3.5.5. matmul</a> <a href="#ref-for-operand②⑨">(2)</a> <a href="#ref-for-operand③⓪">(3)</a> <a href="#ref-for-operand③①">(4)</a> <a href="#ref-for-operand③②">(5)</a> <a href="#ref-for-operand③③">(6)</a>
     <li><a href="#ref-for-operand③④">3.5.6. mul</a> <a href="#ref-for-operand③⑤">(2)</a> <a href="#ref-for-operand③⑥">(3)</a> <a href="#ref-for-operand③⑦">(4)</a> <a href="#ref-for-operand③⑧">(5)</a> <a href="#ref-for-operand③⑨">(6)</a>
-    <li><a href="#ref-for-operand④⓪">3.5.7. transpose</a> <a href="#ref-for-operand④①">(2)</a> <a href="#ref-for-operand④②">(3)</a> <a href="#ref-for-operand④③">(4)</a>
+    <li><a href="#ref-for-operand④⓪">3.5.7. reshape</a> <a href="#ref-for-operand④①">(2)</a> <a href="#ref-for-operand④②">(3)</a> <a href="#ref-for-operand④③">(4)</a>
+    <li><a href="#ref-for-operand④④">3.5.8. transpose</a> <a href="#ref-for-operand④⑤">(2)</a> <a href="#ref-for-operand④⑥">(3)</a> <a href="#ref-for-operand④⑦">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="typedefdef-number">
@@ -2579,7 +2609,8 @@ API.</p>
     <li><a href="#ref-for-neuralnetworkcontext④">3.5.4. gemm</a>
     <li><a href="#ref-for-neuralnetworkcontext⑤">3.5.5. matmul</a>
     <li><a href="#ref-for-neuralnetworkcontext⑥">3.5.6. mul</a>
-    <li><a href="#ref-for-neuralnetworkcontext⑦">3.5.7. transpose</a>
+    <li><a href="#ref-for-neuralnetworkcontext⑦">3.5.7. reshape</a>
+    <li><a href="#ref-for-neuralnetworkcontext⑧">3.5.8. transpose</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-powerpreference">


### PR DESCRIPTION
This PR is to add reshape according to [r01](https://www.w3.org/2020/04/30-webmachinelearning-minutes.html#r01) of WebML CG Teleconference – 30 April 2020.

> RESOLUTION: Add elementwise add, elementwise multiply, concatenation, and reshape ops to the WebNN API


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/57.html" title="Last updated on May 14, 2020, 3:24 PM UTC (f73fd68)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/57/ad86cb4...huningxin:f73fd68.html" title="Last updated on May 14, 2020, 3:24 PM UTC (f73fd68)">Diff</a>