### PR TITLE
Add relu and max

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -403,6 +403,28 @@ partial interface NeuralNetworkContext {
             which produces a scalar output.
 </div>
 
+### max ### {#api-neuralnetworkcontext-max}
+<script type=idl>
+partial interface NeuralNetworkContext {
+  Operand max(Operand a, Operand b);
+};
+</script>
+
+<div algorithm=max>
+    **Arguments:**
+        - *a*: an {{Operand}}. The first input tensor.
+        - *b*: an {{Operand}}. The second input tensor.
+
+    **Returns:** an {{Operand}}. The output tensor that contains the result of
+    element-wise maximum of the two input tensors.
+
+    Computes the element-wise maximum of the two input tensors. The element-wise
+    maximum will be broadcasted according to [[!numpy-broadcasting-rule]]. The
+    rank of the output tensor is the maximum rank of the input tensors. For each
+    dimension of the output tensor, its size is the maximum size along that
+    dimension of the input tensors.
+</div>
+
 ### mul ### {#api-neuralnetworkcontext-mul}
 <script type=idl>
 partial interface NeuralNetworkContext {
@@ -422,6 +444,35 @@ partial interface NeuralNetworkContext {
     [[!numpy-broadcasting-rule]]. The rank of the output tensor is the maximum
     rank of the input tensors. For each dimension of the output tensor, its size
     is the maximum size along that dimension of the input tensors.
+</div>
+
+### relu ### {#api-neuralnetworkcontext-relu}
+<script type=idl>
+partial interface NeuralNetworkContext {
+  Operand relu(Operand x);
+};
+</script>
+
+<div algorithm=relu>
+    **Arguments:**
+        - *x*: an {{Operand}}. The input tensor.
+
+    **Returns:** an {{Operand}}. The output tensor of the same shape as *x*.
+
+    Calculate the <a
+    href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)">rectified
+    linear</a> function on the input tensor element-wise. The calculation
+    follows the expression `max(0, x)`.
+
+    <div class="note">
+    The behavior of this operation can be generically emulated from the usage of
+    other operations as follow. However, user agents typically have a more
+    efficient implementation for it, therefore its usage is encouraged from the
+    performance standpoint.
+    <pre highlight="js">
+    return nn.max(nn.constant(0), x);
+    </pre>
+    </div>
 </div>
 
 ### reshape ### {#api-neuralnetworkcontext-reshape}

--- a/index.html
+++ b/index.html
@@ -1223,7 +1223,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 70ffa934, updated Fri May 1 10:12:04 2020 -0700" name="generator">
   <link href="https://webmachinelearning.github.io/webnn/" rel="canonical">
-  <meta content="b0e4ad8305e533e14b0eb4428bc5c50a0099c33a" name="document-revision">
+  <meta content="c14010b8fa65f7d1e200a095234fd2ea431c9468" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1470,7 +1470,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Web Neural Network API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-05-14">14 May 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-05-20">20 May 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1550,9 +1550,11 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li><a href="#api-neuralnetworkcontext-conv2d"><span class="secno">3.5.3</span> <span class="content">conv2d</span></a>
         <li><a href="#api-neuralnetworkcontext-gemm"><span class="secno">3.5.4</span> <span class="content">gemm</span></a>
         <li><a href="#api-neuralnetworkcontext-matmul"><span class="secno">3.5.5</span> <span class="content">matmul</span></a>
-        <li><a href="#api-neuralnetworkcontext-mul"><span class="secno">3.5.6</span> <span class="content">mul</span></a>
-        <li><a href="#api-neuralnetworkcontext-reshape"><span class="secno">3.5.7</span> <span class="content">reshape</span></a>
-        <li><a href="#api-neuralnetworkcontext-transpose"><span class="secno">3.5.8</span> <span class="content">transpose</span></a>
+        <li><a href="#api-neuralnetworkcontext-max"><span class="secno">3.5.6</span> <span class="content">max</span></a>
+        <li><a href="#api-neuralnetworkcontext-mul"><span class="secno">3.5.7</span> <span class="content">mul</span></a>
+        <li><a href="#api-neuralnetworkcontext-relu"><span class="secno">3.5.8</span> <span class="content">relu</span></a>
+        <li><a href="#api-neuralnetworkcontext-reshape"><span class="secno">3.5.9</span> <span class="content">reshape</span></a>
+        <li><a href="#api-neuralnetworkcontext-transpose"><span class="secno">3.5.10</span> <span class="content">transpose</span></a>
        </ol>
       <li><a href="#api-model"><span class="secno">3.6</span> <span class="content">Model</span></a>
       <li><a href="#api-compilation"><span class="secno">3.7</span> <span class="content">Compilation</span></a>
@@ -1926,12 +1928,12 @@ its dimensions.</p>
 which produces a scalar output.</p>
     </ul>
    </div>
-   <h4 class="heading settled" data-level="3.5.6" id="api-neuralnetworkcontext-mul"><span class="secno">3.5.6. </span><span class="content">mul</span><a class="self-link" href="#api-neuralnetworkcontext-mul"></a></h4>
+   <h4 class="heading settled" data-level="3.5.6" id="api-neuralnetworkcontext-max"><span class="secno">3.5.6. </span><span class="content">max</span><a class="self-link" href="#api-neuralnetworkcontext-max"></a></h4>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑥"><c- g>NeuralNetworkContext</c-></a> {
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③④"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="mul(a, b)" id="dom-neuralnetworkcontext-mul"><code><c- g>mul</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③⑤"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③⑥"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-b"></a></dfn>);
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③④"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="max(a, b)" id="dom-neuralnetworkcontext-max"><code><c- g>max</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-max"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③⑤"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/max(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-max-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-max-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③⑥"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/max(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-max-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-max-a-b-b"></a></dfn>);
 };
 </pre>
-   <div class="algorithm" data-algorithm="mul">
+   <div class="algorithm" data-algorithm="max">
      <strong>Arguments:</strong> 
     <ul>
      <li data-md>
@@ -1940,22 +1942,67 @@ which produces a scalar output.</p>
       <p><em>b</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③⑧">Operand</a></code>. The second input tensor.</p>
     </ul>
     <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③⑨">Operand</a></code>. The output tensor that contains the result of
+    element-wise maximum of the two input tensors.</p>
+    <p>Computes the element-wise maximum of the two input tensors. The element-wise
+    maximum will be broadcasted according to <a data-link-type="biblio" href="#biblio-numpy-broadcasting-rule">[numpy-broadcasting-rule]</a>. The
+    rank of the output tensor is the maximum rank of the input tensors. For each
+    dimension of the output tensor, its size is the maximum size along that
+    dimension of the input tensors.</p>
+   </div>
+   <h4 class="heading settled" data-level="3.5.7" id="api-neuralnetworkcontext-mul"><span class="secno">3.5.7. </span><span class="content">mul</span><a class="self-link" href="#api-neuralnetworkcontext-mul"></a></h4>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑦"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④⓪"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="mul(a, b)" id="dom-neuralnetworkcontext-mul"><code><c- g>mul</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④①"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④②"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-b"></a></dfn>);
+};
+</pre>
+   <div class="algorithm" data-algorithm="mul">
+     <strong>Arguments:</strong> 
+    <ul>
+     <li data-md>
+      <p><em>a</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④③">Operand</a></code>. The first input tensor.</p>
+     <li data-md>
+      <p><em>b</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④④">Operand</a></code>. The second input tensor.</p>
+    </ul>
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④⑤">Operand</a></code>. The output tensor that contains the result of
     element-wise binary multiplication of the two input tensors.</p>
     <p>Computes the element-wise binary multiplication of the two input tensors.
     The element-wise binary multiplication will be broadcasted according to <a data-link-type="biblio" href="#biblio-numpy-broadcasting-rule">[numpy-broadcasting-rule]</a>. The rank of the output tensor is the maximum
     rank of the input tensors. For each dimension of the output tensor, its size
     is the maximum size along that dimension of the input tensors.</p>
    </div>
-   <h4 class="heading settled" data-level="3.5.7" id="api-neuralnetworkcontext-reshape"><span class="secno">3.5.7. </span><span class="content">reshape</span><a class="self-link" href="#api-neuralnetworkcontext-reshape"></a></h4>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑦"><c- g>NeuralNetworkContext</c-></a> {
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④⓪"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="reshape(input, newShape)" id="dom-neuralnetworkcontext-reshape"><code><c- g>reshape</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-reshape"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④①"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/reshape(input, newShape)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-reshape-input-newshape-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-reshape-input-newshape-input"></a></dfn>, <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⓪"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/reshape(input, newShape)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-reshape-input-newshape-newshape"><code><c- g>newShape</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-reshape-input-newshape-newshape"></a></dfn>);
+   <h4 class="heading settled" data-level="3.5.8" id="api-neuralnetworkcontext-relu"><span class="secno">3.5.8. </span><span class="content">relu</span><a class="self-link" href="#api-neuralnetworkcontext-relu"></a></h4>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑧"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④⑥"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="relu(x)" id="dom-neuralnetworkcontext-relu"><code><c- g>relu</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-relu"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④⑦"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/relu(x)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-relu-x-x"><code><c- g>x</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-relu-x-x"></a></dfn>);
+};
+</pre>
+   <div class="algorithm" data-algorithm="relu">
+     <strong>Arguments:</strong> 
+    <ul>
+     <li data-md>
+      <p><em>x</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④⑧">Operand</a></code>. The input tensor.</p>
+    </ul>
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④⑨">Operand</a></code>. The output tensor of the same shape as <em>x</em>.</p>
+    <p>Calculate the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)">rectified
+    linear</a> function on the input tensor element-wise. The calculation
+    follows the expression <code>max(0, x)</code>.</p>
+    <div class="note" role="note">
+      The behavior of this operation can be generically emulated from the usage of
+    other operations as follow. However, user agents typically have a more
+    efficient implementation for it, therefore its usage is encouraged from the
+    performance standpoint. 
+<pre class="highlight"><c- k>return</c-> nn<c- p>.</c->max<c- p>(</c->nn<c- p>.</c->constant<c- p>(</c-><c- mi>0</c-><c- p>),</c-> x<c- p>);</c->
+</pre>
+    </div>
+   </div>
+   <h4 class="heading settled" data-level="3.5.9" id="api-neuralnetworkcontext-reshape"><span class="secno">3.5.9. </span><span class="content">reshape</span><a class="self-link" href="#api-neuralnetworkcontext-reshape"></a></h4>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑨"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑤⓪"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="reshape(input, newShape)" id="dom-neuralnetworkcontext-reshape"><code><c- g>reshape</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-reshape"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑤①"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/reshape(input, newShape)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-reshape-input-newshape-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-reshape-input-newshape-input"></a></dfn>, <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⓪"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/reshape(input, newShape)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-reshape-input-newshape-newshape"><code><c- g>newShape</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-reshape-input-newshape-newshape"></a></dfn>);
 };
 </pre>
    <div class="algorithm" data-algorithm="reshape">
      <strong>Arguments:</strong> 
     <ul>
      <li data-md>
-      <p><em>input</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④②">Operand</a></code>. The input tensor.</p>
+      <p><em>input</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑤②">Operand</a></code>. The input tensor.</p>
      <li data-md>
       <p><em>newShape</em>: a sequence of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①①">long</a></code>. The shape of the output tensor.
 The number of elements implied by <em>newShape</em> must be the same as the
@@ -1963,25 +2010,25 @@ number of elements in the input tensor. Only one component of <em>newShape</em> 
 with the value -1 is computed so that the total size remains
 constant.</p>
     </ul>
-    <p><strong>Returns:</strong>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④③">Operand</a></code>. The output tensor. The values of the output
+    <p><strong>Returns:</strong>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑤③">Operand</a></code>. The output tensor. The values of the output
     tensor are the same as values of the input tensor. The shape of the output
     tensor is specified by the <em>newShape</em> argument.</p>
     <p>Reshapes a tensor to a given new shape.</p>
    </div>
-   <h4 class="heading settled" data-level="3.5.8" id="api-neuralnetworkcontext-transpose"><span class="secno">3.5.8. </span><span class="content">transpose</span><a class="self-link" href="#api-neuralnetworkcontext-transpose"></a></h4>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑧"><c- g>NeuralNetworkContext</c-></a> {
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④④"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="transpose(input, permutation)|transpose(input)" id="dom-neuralnetworkcontext-transpose"><code><c- g>transpose</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④⑤"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/transpose(input, permutation), NeuralNetworkContext/transpose(input)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-transpose-input-permutation-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose-input-permutation-input"></a></dfn>, <c- b>optional</c-> <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①②"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/transpose(input, permutation), NeuralNetworkContext/transpose(input)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-transpose-input-permutation-permutation"><code><c- g>permutation</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose-input-permutation-permutation"></a></dfn>);
+   <h4 class="heading settled" data-level="3.5.10" id="api-neuralnetworkcontext-transpose"><span class="secno">3.5.10. </span><span class="content">transpose</span><a class="self-link" href="#api-neuralnetworkcontext-transpose"></a></h4>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext①⓪"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑤④"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="transpose(input, permutation)|transpose(input)" id="dom-neuralnetworkcontext-transpose"><code><c- g>transpose</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑤⑤"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/transpose(input, permutation), NeuralNetworkContext/transpose(input)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-transpose-input-permutation-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose-input-permutation-input"></a></dfn>, <c- b>optional</c-> <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①②"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/transpose(input, permutation), NeuralNetworkContext/transpose(input)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-transpose-input-permutation-permutation"><code><c- g>permutation</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose-input-permutation-permutation"></a></dfn>);
 };
 </pre>
    <div class="algorithm" data-algorithm="transpose">
      <strong>Arguments:</strong> 
     <ul>
      <li data-md>
-      <p><em>input</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④⑥">Operand</a></code>. The input N-D tensor.</p>
+      <p><em>input</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑤⑥">Operand</a></code>. The input N-D tensor.</p>
      <li data-md>
       <p><em>permutation</em>: an optional sequence of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①③">long</a></code> values. The values used to permute the output shape. When it’s not specified, it’s set to <code>[N-1...0]</code>, where <code>N</code> is the rank of the input tensor. These default values cause the output to become a transposed tensor of the input. When specified, the number of values in the sequence must be the same as the rank of the input tensor, and the values in the sequence must be within the range from 0 to N-1 with no two or more same values found in the sequence.</p>
     </ul>
-    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④⑦">Operand</a></code>. The permuted or transposed N-D tensor.</p>
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑤⑦">Operand</a></code>. The permuted or transposed N-D tensor.</p>
     <p>Permute the dimensions of the input tensor according to the <em>permutation</em> argument.</p>
    </div>
    <h3 class="heading settled" data-level="3.6" id="api-model"><span class="secno">3.6. </span><span class="content">Model</span><a class="self-link" href="#api-model"></a></h3>
@@ -2286,10 +2333,11 @@ API.</p>
    <li><a href="#dom-operandtype-int32">"int32"</a><span>, in §3.3</span>
    <li><a href="#dom-powerpreference-low-power">"low-power"</a><span>, in §3.6</span>
    <li><a href="#dom-neuralnetworkcontext-matmul">matmul(a, b)</a><span>, in §3.5.5</span>
+   <li><a href="#dom-neuralnetworkcontext-max">max(a, b)</a><span>, in §3.5.6</span>
    <li><a href="#ml">ML</a><span>, in §3.2</span>
    <li><a href="#dom-navigator-ml">ml</a><span>, in §3.1</span>
    <li><a href="#model">Model</a><span>, in §3.6</span>
-   <li><a href="#dom-neuralnetworkcontext-mul">mul(a, b)</a><span>, in §3.5.6</span>
+   <li><a href="#dom-neuralnetworkcontext-mul">mul(a, b)</a><span>, in §3.5.7</span>
    <li><a href="#dom-operandlayout-nchw">"nchw"</a><span>, in §3.3</span>
    <li><a href="#neuralnetworkcontext">NeuralNetworkContext</a><span>, in §3.5</span>
    <li><a href="#dom-operandlayout-nhwc">"nhwc"</a><span>, in §3.3</span>
@@ -2300,7 +2348,8 @@ API.</p>
    <li><a href="#enumdef-operandtype">OperandType</a><span>, in §3.3</span>
    <li><a href="#enumdef-powerpreference">PowerPreference</a><span>, in §3.6</span>
    <li><a href="#dom-compilationoptions-powerpreference">powerPreference</a><span>, in §3.6</span>
-   <li><a href="#dom-neuralnetworkcontext-reshape">reshape(input, newShape)</a><span>, in §3.5.7</span>
+   <li><a href="#dom-neuralnetworkcontext-relu">relu(x)</a><span>, in §3.5.8</span>
+   <li><a href="#dom-neuralnetworkcontext-reshape">reshape(input, newShape)</a><span>, in §3.5.9</span>
    <li><a href="#dom-operanddescriptor-scale">scale</a><span>, in §3.3</span>
    <li><a href="#dom-execution-setinput">setInput(index, data)</a><span>, in §3.8</span>
    <li><a href="#dom-execution-setoutput">setOutput(index, data)</a><span>, in §3.8</span>
@@ -2309,8 +2358,8 @@ API.</p>
    <li><a href="#dom-operandtype-tensor-float32">"tensor-float32"</a><span>, in §3.3</span>
    <li><a href="#dom-operandtype-tensor-int32">"tensor-int32"</a><span>, in §3.3</span>
    <li><a href="#dom-operandtype-tensor-quant8-asymm">"tensor-quant8-asymm"</a><span>, in §3.3</span>
-   <li><a href="#dom-neuralnetworkcontext-transpose">transpose(input)</a><span>, in §3.5.8</span>
-   <li><a href="#dom-neuralnetworkcontext-transpose">transpose(input, permutation)</a><span>, in §3.5.8</span>
+   <li><a href="#dom-neuralnetworkcontext-transpose">transpose(input)</a><span>, in §3.5.10</span>
+   <li><a href="#dom-neuralnetworkcontext-transpose">transpose(input, permutation)</a><span>, in §3.5.10</span>
    <li><a href="#dom-operanddescriptor-type">type</a><span>, in §3.3</span>
    <li><a href="#dom-operandtype-uint32">"uint32"</a><span>, in §3.3</span>
    <li><a href="#dom-operanddescriptor-zeropoint">zeroPoint</a><span>, in §3.3</span>
@@ -2353,8 +2402,8 @@ API.</p>
     <li><a href="#ref-for-idl-long">3.3. OperandDescriptor</a> <a href="#ref-for-idl-long①">(2)</a>
     <li><a href="#ref-for-idl-long②">3.5.2. concat</a> <a href="#ref-for-idl-long③">(2)</a>
     <li><a href="#ref-for-idl-long④">3.5.3. conv2d</a> <a href="#ref-for-idl-long⑤">(2)</a> <a href="#ref-for-idl-long⑥">(3)</a> <a href="#ref-for-idl-long⑦">(4)</a> <a href="#ref-for-idl-long⑧">(5)</a> <a href="#ref-for-idl-long⑨">(6)</a>
-    <li><a href="#ref-for-idl-long①⓪">3.5.7. reshape</a> <a href="#ref-for-idl-long①①">(2)</a>
-    <li><a href="#ref-for-idl-long①②">3.5.8. transpose</a> <a href="#ref-for-idl-long①③">(2)</a>
+    <li><a href="#ref-for-idl-long①⓪">3.5.9. reshape</a> <a href="#ref-for-idl-long①①">(2)</a>
+    <li><a href="#ref-for-idl-long①②">3.5.10. transpose</a> <a href="#ref-for-idl-long①③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
@@ -2514,7 +2563,15 @@ API.</p>
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-max"><code><c- g>max</c-></code></a>(<a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-max-a-b-a"><code><c- g>a</c-></code></a>, <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-max-a-b-b"><code><c- g>b</c-></code></a>);
+};
+
+<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext"><c- g>NeuralNetworkContext</c-></a> {
   <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-mul"><code><c- g>mul</c-></code></a>(<a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-mul-a-b-a"><code><c- g>a</c-></code></a>, <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-mul-a-b-b"><code><c- g>b</c-></code></a>);
+};
+
+<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-relu"><code><c- g>relu</c-></code></a>(<a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-relu-x-x"><code><c- g>x</c-></code></a>);
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext"><c- g>NeuralNetworkContext</c-></a> {
@@ -2588,9 +2645,11 @@ API.</p>
     <li><a href="#ref-for-operand①④">3.5.3. conv2d</a> <a href="#ref-for-operand①⑤">(2)</a> <a href="#ref-for-operand①⑥">(3)</a> <a href="#ref-for-operand①⑦">(4)</a> <a href="#ref-for-operand①⑧">(5)</a> <a href="#ref-for-operand①⑨">(6)</a>
     <li><a href="#ref-for-operand②⓪">3.5.4. gemm</a> <a href="#ref-for-operand②①">(2)</a> <a href="#ref-for-operand②②">(3)</a> <a href="#ref-for-operand②③">(4)</a> <a href="#ref-for-operand②④">(5)</a> <a href="#ref-for-operand②⑤">(6)</a> <a href="#ref-for-operand②⑥">(7)</a> <a href="#ref-for-operand②⑦">(8)</a>
     <li><a href="#ref-for-operand②⑧">3.5.5. matmul</a> <a href="#ref-for-operand②⑨">(2)</a> <a href="#ref-for-operand③⓪">(3)</a> <a href="#ref-for-operand③①">(4)</a> <a href="#ref-for-operand③②">(5)</a> <a href="#ref-for-operand③③">(6)</a>
-    <li><a href="#ref-for-operand③④">3.5.6. mul</a> <a href="#ref-for-operand③⑤">(2)</a> <a href="#ref-for-operand③⑥">(3)</a> <a href="#ref-for-operand③⑦">(4)</a> <a href="#ref-for-operand③⑧">(5)</a> <a href="#ref-for-operand③⑨">(6)</a>
-    <li><a href="#ref-for-operand④⓪">3.5.7. reshape</a> <a href="#ref-for-operand④①">(2)</a> <a href="#ref-for-operand④②">(3)</a> <a href="#ref-for-operand④③">(4)</a>
-    <li><a href="#ref-for-operand④④">3.5.8. transpose</a> <a href="#ref-for-operand④⑤">(2)</a> <a href="#ref-for-operand④⑥">(3)</a> <a href="#ref-for-operand④⑦">(4)</a>
+    <li><a href="#ref-for-operand③④">3.5.6. max</a> <a href="#ref-for-operand③⑤">(2)</a> <a href="#ref-for-operand③⑥">(3)</a> <a href="#ref-for-operand③⑦">(4)</a> <a href="#ref-for-operand③⑧">(5)</a> <a href="#ref-for-operand③⑨">(6)</a>
+    <li><a href="#ref-for-operand④⓪">3.5.7. mul</a> <a href="#ref-for-operand④①">(2)</a> <a href="#ref-for-operand④②">(3)</a> <a href="#ref-for-operand④③">(4)</a> <a href="#ref-for-operand④④">(5)</a> <a href="#ref-for-operand④⑤">(6)</a>
+    <li><a href="#ref-for-operand④⑥">3.5.8. relu</a> <a href="#ref-for-operand④⑦">(2)</a> <a href="#ref-for-operand④⑧">(3)</a> <a href="#ref-for-operand④⑨">(4)</a>
+    <li><a href="#ref-for-operand⑤⓪">3.5.9. reshape</a> <a href="#ref-for-operand⑤①">(2)</a> <a href="#ref-for-operand⑤②">(3)</a> <a href="#ref-for-operand⑤③">(4)</a>
+    <li><a href="#ref-for-operand⑤④">3.5.10. transpose</a> <a href="#ref-for-operand⑤⑤">(2)</a> <a href="#ref-for-operand⑤⑥">(3)</a> <a href="#ref-for-operand⑤⑦">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="typedefdef-number">
@@ -2608,9 +2667,11 @@ API.</p>
     <li><a href="#ref-for-neuralnetworkcontext③">3.5.3. conv2d</a>
     <li><a href="#ref-for-neuralnetworkcontext④">3.5.4. gemm</a>
     <li><a href="#ref-for-neuralnetworkcontext⑤">3.5.5. matmul</a>
-    <li><a href="#ref-for-neuralnetworkcontext⑥">3.5.6. mul</a>
-    <li><a href="#ref-for-neuralnetworkcontext⑦">3.5.7. reshape</a>
-    <li><a href="#ref-for-neuralnetworkcontext⑧">3.5.8. transpose</a>
+    <li><a href="#ref-for-neuralnetworkcontext⑥">3.5.6. max</a>
+    <li><a href="#ref-for-neuralnetworkcontext⑦">3.5.7. mul</a>
+    <li><a href="#ref-for-neuralnetworkcontext⑧">3.5.8. relu</a>
+    <li><a href="#ref-for-neuralnetworkcontext⑨">3.5.9. reshape</a>
+    <li><a href="#ref-for-neuralnetworkcontext①⓪">3.5.10. transpose</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-powerpreference">


### PR DESCRIPTION
Per the [first wave models](https://github.com/webmachinelearning/webnn/blob/master/op_compatibility/first_wave_models.md), `relu` is required by SqueezeNet, MobileNet and ResNet. `relu` can be implemented by element-wise `max`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/62.html" title="Last updated on May 25, 2020, 3:09 AM UTC (f75101e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/62/c14010b...huningxin:f75101e.html" title="Last updated on May 25, 2020, 3:09 AM UTC (f75101e)">Diff</a>