### PR TITLE
Add leakyRelu and min

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -378,6 +378,39 @@ partial interface NeuralNetworkContext {
     </div>
 </div>
 
+### leakyRelu ### {#api-neuralnetworkcontext-leakyrelu}
+<script type=idl>
+partial interface NeuralNetworkContext {
+  Operand leakyRelu(Operand x, optional float alpha = 0.01);
+};
+</script>
+
+<div algorithm=leakyrelu>
+    **Arguments:**
+        - *x*: an {{Operand}}. The input tensor.
+        - *alpha*: an optional {{float}} scalar multiplier, default to 0.01.
+
+    **Returns:** an {{Operand}}. The output tensor of the same shape as *x*.
+
+    Calculate the <a
+    href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)#Leaky_ReLU">
+    leaky version of rectified linear function</a> on the input tensor
+    element-wise. The calculation follows the expression `max(0, x) + alpha ∗
+    min(0, x)`.
+
+    <div class="note">
+    The behavior of this operation can be generically emulated from the usage of
+    other operations as follow. However, user agents typically have a more
+    efficient implementation for it, therefore its usage is encouraged from the
+    performance standpoint.
+    <pre highlight="js">
+    return nn.add(nn.max(nn.constant(0), x),
+                  nn.mul(nn.constant(alpha), nn.min(nn.constant(0), x)));
+    </pre>
+    </div>
+</div>
+
+
 ### matmul ### {#api-neuralnetworkcontext-matmul}
 <script type=idl>
 partial interface NeuralNetworkContext {
@@ -433,6 +466,29 @@ partial interface NeuralNetworkContext {
     dimension of the input tensors.
 </div>
 
+### min ### {#api-neuralnetworkcontext-min}
+<script type=idl>
+partial interface NeuralNetworkContext {
+  Operand min(Operand a, Operand b);
+};
+</script>
+
+<div algorithm=min>
+    **Arguments:**
+        - *a*: an {{Operand}}. The first input tensor.
+        - *b*: an {{Operand}}. The second input tensor.
+
+    **Returns:** an {{Operand}}. The output tensor that contains the result of
+    element-wise minimum of the two input tensors.
+
+    Computes the element-wise minimum of the two input tensors. The element-wise
+    minimum will be broadcasted according to [[!numpy-broadcasting-rule]]. The
+    rank of the output tensor is the maximum rank of the input tensors. For each
+    dimension of the output tensor, its size is the maximum size along that
+    dimension of the input tensors.
+</div>
+
+
 ### mul ### {#api-neuralnetworkcontext-mul}
 <script type=idl>
 partial interface NeuralNetworkContext {
@@ -469,7 +525,7 @@ partial interface NeuralNetworkContext {
 
     Calculate the <a
     href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)">rectified
-    linear</a> function on the input tensor element-wise. The calculation
+    linear function</a> on the input tensor element-wise. The calculation
     follows the expression `max(0, x)`.
 
     <div class="note">

--- a/index.html
+++ b/index.html
@@ -1221,8 +1221,9 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 78f8c09c, updated Tue May 19 10:51:23 2020 -0700" name="generator">
+  <meta content="Bikeshed version 70ffa934, updated Fri May 1 10:12:04 2020 -0700" name="generator">
   <link href="https://webmachinelearning.github.io/webnn/" rel="canonical">
+  <meta content="d0bc1f69e6ddca6c1f6b80cafc443d10294c8b17" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1469,7 +1470,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Web Neural Network API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-05-29">29 May 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-06-05">5 June 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1549,12 +1550,14 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
         <li><a href="#api-neuralnetworkcontext-concat"><span class="secno">3.5.2</span> <span class="content">concat</span></a>
         <li><a href="#api-neuralnetworkcontext-conv2d"><span class="secno">3.5.3</span> <span class="content">conv2d</span></a>
         <li><a href="#api-neuralnetworkcontext-gemm"><span class="secno">3.5.4</span> <span class="content">gemm</span></a>
-        <li><a href="#api-neuralnetworkcontext-matmul"><span class="secno">3.5.5</span> <span class="content">matmul</span></a>
-        <li><a href="#api-neuralnetworkcontext-max"><span class="secno">3.5.6</span> <span class="content">max</span></a>
-        <li><a href="#api-neuralnetworkcontext-mul"><span class="secno">3.5.7</span> <span class="content">mul</span></a>
-        <li><a href="#api-neuralnetworkcontext-relu"><span class="secno">3.5.8</span> <span class="content">relu</span></a>
-        <li><a href="#api-neuralnetworkcontext-reshape"><span class="secno">3.5.9</span> <span class="content">reshape</span></a>
-        <li><a href="#api-neuralnetworkcontext-transpose"><span class="secno">3.5.10</span> <span class="content">transpose</span></a>
+        <li><a href="#api-neuralnetworkcontext-leakyrelu"><span class="secno">3.5.5</span> <span class="content">leakyRelu</span></a>
+        <li><a href="#api-neuralnetworkcontext-matmul"><span class="secno">3.5.6</span> <span class="content">matmul</span></a>
+        <li><a href="#api-neuralnetworkcontext-max"><span class="secno">3.5.7</span> <span class="content">max</span></a>
+        <li><a href="#api-neuralnetworkcontext-min"><span class="secno">3.5.8</span> <span class="content">min</span></a>
+        <li><a href="#api-neuralnetworkcontext-mul"><span class="secno">3.5.9</span> <span class="content">mul</span></a>
+        <li><a href="#api-neuralnetworkcontext-relu"><span class="secno">3.5.10</span> <span class="content">relu</span></a>
+        <li><a href="#api-neuralnetworkcontext-reshape"><span class="secno">3.5.11</span> <span class="content">reshape</span></a>
+        <li><a href="#api-neuralnetworkcontext-transpose"><span class="secno">3.5.12</span> <span class="content">transpose</span></a>
        </ol>
       <li><a href="#api-model"><span class="secno">3.6</span> <span class="content">Model</span></a>
       <li><a href="#api-compilation"><span class="secno">3.7</span> <span class="content">Compilation</span></a>
@@ -1896,20 +1899,46 @@ output_channels]</p>
 </pre>
     </div>
    </div>
-   <h4 class="heading settled" data-level="3.5.5" id="api-neuralnetworkcontext-matmul"><span class="secno">3.5.5. </span><span class="content">matmul</span><a class="self-link" href="#api-neuralnetworkcontext-matmul"></a></h4>
+   <h4 class="heading settled" data-level="3.5.5" id="api-neuralnetworkcontext-leakyrelu"><span class="secno">3.5.5. </span><span class="content">leakyRelu</span><a class="self-link" href="#api-neuralnetworkcontext-leakyrelu"></a></h4>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑤"><c- g>NeuralNetworkContext</c-></a> {
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand②⑧"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="matmul(a, b)" id="dom-neuralnetworkcontext-matmul"><code><c- g>matmul</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-matmul"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand②⑨"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/matmul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-matmul-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-matmul-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③⓪"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/matmul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-matmul-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-matmul-a-b-b"></a></dfn>);
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand②⑧"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="leakyRelu(x, alpha)|leakyRelu(x)" id="dom-neuralnetworkcontext-leakyrelu"><code><c- g>leakyRelu</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-leakyrelu"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand②⑨"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/leakyRelu(x, alpha), NeuralNetworkContext/leakyRelu(x)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-leakyrelu-x-alpha-x"><code><c- g>x</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-leakyrelu-x-alpha-x"></a></dfn>, <c- b>optional</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-float" id="ref-for-idl-float⑤"><c- b>float</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/leakyRelu(x, alpha), NeuralNetworkContext/leakyRelu(x)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-leakyrelu-x-alpha-alpha"><code><c- g>alpha</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-leakyrelu-x-alpha-alpha"></a></dfn> = 0.01);
+};
+</pre>
+   <div class="algorithm" data-algorithm="leakyrelu">
+     <strong>Arguments:</strong> 
+    <ul>
+     <li data-md>
+      <p><em>x</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③⓪">Operand</a></code>. The input tensor.</p>
+     <li data-md>
+      <p><em>alpha</em>: an optional <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-float" id="ref-for-idl-float⑥">float</a></code> scalar multiplier, default to 0.01.</p>
+    </ul>
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③①">Operand</a></code>. The output tensor of the same shape as <em>x</em>.</p>
+    <p>Calculate the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)#Leaky_ReLU"> leaky version of rectified linear function</a> on the input tensor
+    element-wise. The calculation follows the expression <code>max(0, x) + alpha ∗ min(0, x)</code>.</p>
+    <div class="note" role="note">
+      The behavior of this operation can be generically emulated from the usage of
+    other operations as follow. However, user agents typically have a more
+    efficient implementation for it, therefore its usage is encouraged from the
+    performance standpoint. 
+<pre class="highlight"><c- k>return</c-> nn<c- p>.</c->add<c- p>(</c->nn<c- p>.</c->max<c- p>(</c->nn<c- p>.</c->constant<c- p>(</c-><c- mi>0</c-><c- p>),</c-> x<c- p>),</c->
+              nn<c- p>.</c->mul<c- p>(</c->nn<c- p>.</c->constant<c- p>(</c->alpha<c- p>),</c-> nn<c- p>.</c->min<c- p>(</c->nn<c- p>.</c->constant<c- p>(</c-><c- mi>0</c-><c- p>),</c-> x<c- p>)));</c->
+</pre>
+    </div>
+   </div>
+   <h4 class="heading settled" data-level="3.5.6" id="api-neuralnetworkcontext-matmul"><span class="secno">3.5.6. </span><span class="content">matmul</span><a class="self-link" href="#api-neuralnetworkcontext-matmul"></a></h4>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑥"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③②"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="matmul(a, b)" id="dom-neuralnetworkcontext-matmul"><code><c- g>matmul</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-matmul"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③③"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/matmul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-matmul-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-matmul-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③④"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/matmul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-matmul-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-matmul-a-b-b"></a></dfn>);
 };
 </pre>
    <div class="algorithm" data-algorithm="matmul">
      <strong>Arguments:</strong> 
     <ul>
      <li data-md>
-      <p><em>a</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③①">Operand</a></code>. The first input N-D tensor.</p>
+      <p><em>a</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③⑤">Operand</a></code>. The first input N-D tensor.</p>
      <li data-md>
-      <p><em>b</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③②">Operand</a></code>. The second input N-D tensor.</p>
+      <p><em>b</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③⑥">Operand</a></code>. The second input N-D tensor.</p>
     </ul>
-    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③③">Operand</a></code>. The output N-D tensor that contains the matrix
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③⑦">Operand</a></code>. The output N-D tensor that contains the matrix
     product of two input tensors.</p>
     <p>Computes the matrix product of two input tensors. It behaves as following:</p>
     <ul>
@@ -1934,20 +1963,20 @@ its dimensions.</p>
 which produces a scalar output.</p>
     </ul>
    </div>
-   <h4 class="heading settled" data-level="3.5.6" id="api-neuralnetworkcontext-max"><span class="secno">3.5.6. </span><span class="content">max</span><a class="self-link" href="#api-neuralnetworkcontext-max"></a></h4>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑥"><c- g>NeuralNetworkContext</c-></a> {
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③④"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="max(a, b)" id="dom-neuralnetworkcontext-max"><code><c- g>max</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-max"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③⑤"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/max(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-max-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-max-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③⑥"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/max(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-max-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-max-a-b-b"></a></dfn>);
+   <h4 class="heading settled" data-level="3.5.7" id="api-neuralnetworkcontext-max"><span class="secno">3.5.7. </span><span class="content">max</span><a class="self-link" href="#api-neuralnetworkcontext-max"></a></h4>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑦"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③⑧"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="max(a, b)" id="dom-neuralnetworkcontext-max"><code><c- g>max</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-max"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand③⑨"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/max(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-max-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-max-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④⓪"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/max(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-max-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-max-a-b-b"></a></dfn>);
 };
 </pre>
    <div class="algorithm" data-algorithm="max">
      <strong>Arguments:</strong> 
     <ul>
      <li data-md>
-      <p><em>a</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③⑦">Operand</a></code>. The first input tensor.</p>
+      <p><em>a</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④①">Operand</a></code>. The first input tensor.</p>
      <li data-md>
-      <p><em>b</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③⑧">Operand</a></code>. The second input tensor.</p>
+      <p><em>b</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④②">Operand</a></code>. The second input tensor.</p>
     </ul>
-    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand③⑨">Operand</a></code>. The output tensor that contains the result of
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④③">Operand</a></code>. The output tensor that contains the result of
     element-wise maximum of the two input tensors.</p>
     <p>Computes the element-wise maximum of the two input tensors. The element-wise
     maximum will be broadcasted according to <a data-link-type="biblio" href="#biblio-numpy-broadcasting-rule">[numpy-broadcasting-rule]</a>. The
@@ -1955,40 +1984,61 @@ which produces a scalar output.</p>
     dimension of the output tensor, its size is the maximum size along that
     dimension of the input tensors.</p>
    </div>
-   <h4 class="heading settled" data-level="3.5.7" id="api-neuralnetworkcontext-mul"><span class="secno">3.5.7. </span><span class="content">mul</span><a class="self-link" href="#api-neuralnetworkcontext-mul"></a></h4>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑦"><c- g>NeuralNetworkContext</c-></a> {
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④⓪"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="mul(a, b)" id="dom-neuralnetworkcontext-mul"><code><c- g>mul</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④①"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④②"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-b"></a></dfn>);
+   <h4 class="heading settled" data-level="3.5.8" id="api-neuralnetworkcontext-min"><span class="secno">3.5.8. </span><span class="content">min</span><a class="self-link" href="#api-neuralnetworkcontext-min"></a></h4>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑧"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④④"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="min(a, b)" id="dom-neuralnetworkcontext-min"><code><c- g>min</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-min"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④⑤"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/min(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-min-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-min-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④⑥"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/min(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-min-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-min-a-b-b"></a></dfn>);
+};
+</pre>
+   <div class="algorithm" data-algorithm="min">
+     <strong>Arguments:</strong> 
+    <ul>
+     <li data-md>
+      <p><em>a</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④⑦">Operand</a></code>. The first input tensor.</p>
+     <li data-md>
+      <p><em>b</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④⑧">Operand</a></code>. The second input tensor.</p>
+    </ul>
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④⑨">Operand</a></code>. The output tensor that contains the result of
+    element-wise minimum of the two input tensors.</p>
+    <p>Computes the element-wise minimum of the two input tensors. The element-wise
+    minimum will be broadcasted according to <a data-link-type="biblio" href="#biblio-numpy-broadcasting-rule">[numpy-broadcasting-rule]</a>. The
+    rank of the output tensor is the maximum rank of the input tensors. For each
+    dimension of the output tensor, its size is the maximum size along that
+    dimension of the input tensors.</p>
+   </div>
+   <h4 class="heading settled" data-level="3.5.9" id="api-neuralnetworkcontext-mul"><span class="secno">3.5.9. </span><span class="content">mul</span><a class="self-link" href="#api-neuralnetworkcontext-mul"></a></h4>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑨"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑤⓪"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="mul(a, b)" id="dom-neuralnetworkcontext-mul"><code><c- g>mul</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑤①"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-a"><code><c- g>a</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-a"></a></dfn>, <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑤②"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/mul(a, b)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-mul-a-b-b"><code><c- g>b</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-mul-a-b-b"></a></dfn>);
 };
 </pre>
    <div class="algorithm" data-algorithm="mul">
      <strong>Arguments:</strong> 
     <ul>
      <li data-md>
-      <p><em>a</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④③">Operand</a></code>. The first input tensor.</p>
+      <p><em>a</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑤③">Operand</a></code>. The first input tensor.</p>
      <li data-md>
-      <p><em>b</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④④">Operand</a></code>. The second input tensor.</p>
+      <p><em>b</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑤④">Operand</a></code>. The second input tensor.</p>
     </ul>
-    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④⑤">Operand</a></code>. The output tensor that contains the result of
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑤⑤">Operand</a></code>. The output tensor that contains the result of
     element-wise binary multiplication of the two input tensors.</p>
     <p>Computes the element-wise binary multiplication of the two input tensors.
     The element-wise binary multiplication will be broadcasted according to <a data-link-type="biblio" href="#biblio-numpy-broadcasting-rule">[numpy-broadcasting-rule]</a>. The rank of the output tensor is the maximum
     rank of the input tensors. For each dimension of the output tensor, its size
     is the maximum size along that dimension of the input tensors.</p>
    </div>
-   <h4 class="heading settled" data-level="3.5.8" id="api-neuralnetworkcontext-relu"><span class="secno">3.5.8. </span><span class="content">relu</span><a class="self-link" href="#api-neuralnetworkcontext-relu"></a></h4>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑧"><c- g>NeuralNetworkContext</c-></a> {
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④⑥"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="relu(x)" id="dom-neuralnetworkcontext-relu"><code><c- g>relu</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-relu"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand④⑦"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/relu(x)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-relu-x-x"><code><c- g>x</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-relu-x-x"></a></dfn>);
+   <h4 class="heading settled" data-level="3.5.10" id="api-neuralnetworkcontext-relu"><span class="secno">3.5.10. </span><span class="content">relu</span><a class="self-link" href="#api-neuralnetworkcontext-relu"></a></h4>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext①⓪"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑤⑥"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="relu(x)" id="dom-neuralnetworkcontext-relu"><code><c- g>relu</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-relu"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑤⑦"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/relu(x)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-relu-x-x"><code><c- g>x</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-relu-x-x"></a></dfn>);
 };
 </pre>
    <div class="algorithm" data-algorithm="relu">
      <strong>Arguments:</strong> 
     <ul>
      <li data-md>
-      <p><em>x</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④⑧">Operand</a></code>. The input tensor.</p>
+      <p><em>x</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑤⑧">Operand</a></code>. The input tensor.</p>
     </ul>
-    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand④⑨">Operand</a></code>. The output tensor of the same shape as <em>x</em>.</p>
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑤⑨">Operand</a></code>. The output tensor of the same shape as <em>x</em>.</p>
     <p>Calculate the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)">rectified
-    linear</a> function on the input tensor element-wise. The calculation
+    linear function</a> on the input tensor element-wise. The calculation
     follows the expression <code>max(0, x)</code>.</p>
     <div class="note" role="note">
       The behavior of this operation can be generically emulated from the usage of
@@ -1999,16 +2049,16 @@ which produces a scalar output.</p>
 </pre>
     </div>
    </div>
-   <h4 class="heading settled" data-level="3.5.9" id="api-neuralnetworkcontext-reshape"><span class="secno">3.5.9. </span><span class="content">reshape</span><a class="self-link" href="#api-neuralnetworkcontext-reshape"></a></h4>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext⑨"><c- g>NeuralNetworkContext</c-></a> {
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑤⓪"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="reshape(input, newShape)" id="dom-neuralnetworkcontext-reshape"><code><c- g>reshape</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-reshape"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑤①"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/reshape(input, newShape)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-reshape-input-newshape-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-reshape-input-newshape-input"></a></dfn>, <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⓪"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/reshape(input, newShape)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-reshape-input-newshape-newshape"><code><c- g>newShape</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-reshape-input-newshape-newshape"></a></dfn>);
+   <h4 class="heading settled" data-level="3.5.11" id="api-neuralnetworkcontext-reshape"><span class="secno">3.5.11. </span><span class="content">reshape</span><a class="self-link" href="#api-neuralnetworkcontext-reshape"></a></h4>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext①①"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑥⓪"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="reshape(input, newShape)" id="dom-neuralnetworkcontext-reshape"><code><c- g>reshape</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-reshape"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑥①"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/reshape(input, newShape)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-reshape-input-newshape-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-reshape-input-newshape-input"></a></dfn>, <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①⓪"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/reshape(input, newShape)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-reshape-input-newshape-newshape"><code><c- g>newShape</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-reshape-input-newshape-newshape"></a></dfn>);
 };
 </pre>
    <div class="algorithm" data-algorithm="reshape">
      <strong>Arguments:</strong> 
     <ul>
      <li data-md>
-      <p><em>input</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑤②">Operand</a></code>. The input tensor.</p>
+      <p><em>input</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑥②">Operand</a></code>. The input tensor.</p>
      <li data-md>
       <p><em>newShape</em>: a sequence of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①①">long</a></code>. The shape of the output tensor.
 The number of elements implied by <em>newShape</em> must be the same as the
@@ -2016,25 +2066,25 @@ number of elements in the input tensor. Only one component of <em>newShape</em> 
 with the value -1 is computed so that the total size remains
 constant.</p>
     </ul>
-    <p><strong>Returns:</strong>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑤③">Operand</a></code>. The output tensor. The values of the output
+    <p><strong>Returns:</strong>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑥③">Operand</a></code>. The output tensor. The values of the output
     tensor are the same as values of the input tensor. The shape of the output
     tensor is specified by the <em>newShape</em> argument.</p>
     <p>Reshapes a tensor to a given new shape.</p>
    </div>
-   <h4 class="heading settled" data-level="3.5.10" id="api-neuralnetworkcontext-transpose"><span class="secno">3.5.10. </span><span class="content">transpose</span><a class="self-link" href="#api-neuralnetworkcontext-transpose"></a></h4>
-<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext①⓪"><c- g>NeuralNetworkContext</c-></a> {
-  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑤④"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="transpose(input, permutation)|transpose(input)" id="dom-neuralnetworkcontext-transpose"><code><c- g>transpose</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑤⑤"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/transpose(input, permutation), NeuralNetworkContext/transpose(input)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-transpose-input-permutation-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose-input-permutation-input"></a></dfn>, <c- b>optional</c-> <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①②"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/transpose(input, permutation), NeuralNetworkContext/transpose(input)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-transpose-input-permutation-permutation"><code><c- g>permutation</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose-input-permutation-permutation"></a></dfn>);
+   <h4 class="heading settled" data-level="3.5.12" id="api-neuralnetworkcontext-transpose"><span class="secno">3.5.12. </span><span class="content">transpose</span><a class="self-link" href="#api-neuralnetworkcontext-transpose"></a></h4>
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext①②"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑥④"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="transpose(input, permutation)|transpose(input)" id="dom-neuralnetworkcontext-transpose"><code><c- g>transpose</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose"></a></dfn>(<a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand⑥⑤"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/transpose(input, permutation), NeuralNetworkContext/transpose(input)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-transpose-input-permutation-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose-input-permutation-input"></a></dfn>, <c- b>optional</c-> <c- b>sequence</c->&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①②"><c- b>long</c-></a>> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/transpose(input, permutation), NeuralNetworkContext/transpose(input)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-transpose-input-permutation-permutation"><code><c- g>permutation</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-transpose-input-permutation-permutation"></a></dfn>);
 };
 </pre>
    <div class="algorithm" data-algorithm="transpose">
      <strong>Arguments:</strong> 
     <ul>
      <li data-md>
-      <p><em>input</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑤⑥">Operand</a></code>. The input N-D tensor.</p>
+      <p><em>input</em>: an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑥⑥">Operand</a></code>. The input N-D tensor.</p>
      <li data-md>
       <p><em>permutation</em>: an optional sequence of <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-long" id="ref-for-idl-long①③">long</a></code> values. The values used to permute the output shape. When it’s not specified, it’s set to <code>[N-1...0]</code>, where <code>N</code> is the rank of the input tensor. These default values cause the output to become a transposed tensor of the input. When specified, the number of values in the sequence must be the same as the rank of the input tensor, and the values in the sequence must be within the range from 0 to N-1 with no two or more same values found in the sequence.</p>
     </ul>
-    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑤⑦">Operand</a></code>. The permuted or transposed N-D tensor.</p>
+    <p><strong>Returns:</strong> an <code class="idl"><a data-link-type="idl" href="#operand" id="ref-for-operand⑥⑦">Operand</a></code>. The permuted or transposed N-D tensor.</p>
     <p>Permute the dimensions of the input tensor according to the <em>permutation</em> argument.</p>
    </div>
    <h3 class="heading settled" data-level="3.6" id="api-model"><span class="secno">3.6. </span><span class="content">Model</span><a class="self-link" href="#api-model"></a></h3>
@@ -2337,13 +2387,16 @@ API.</p>
    <li><a href="#dom-powerpreference-high-performance">"high-performance"</a><span>, in §3.6</span>
    <li><a href="#dom-neuralnetworkcontext-input">input(desc)</a><span>, in §3.5</span>
    <li><a href="#dom-operandtype-int32">"int32"</a><span>, in §3.3</span>
+   <li><a href="#dom-neuralnetworkcontext-leakyrelu">leakyRelu(x)</a><span>, in §3.5.5</span>
+   <li><a href="#dom-neuralnetworkcontext-leakyrelu">leakyRelu(x, alpha)</a><span>, in §3.5.5</span>
    <li><a href="#dom-powerpreference-low-power">"low-power"</a><span>, in §3.6</span>
-   <li><a href="#dom-neuralnetworkcontext-matmul">matmul(a, b)</a><span>, in §3.5.5</span>
-   <li><a href="#dom-neuralnetworkcontext-max">max(a, b)</a><span>, in §3.5.6</span>
+   <li><a href="#dom-neuralnetworkcontext-matmul">matmul(a, b)</a><span>, in §3.5.6</span>
+   <li><a href="#dom-neuralnetworkcontext-max">max(a, b)</a><span>, in §3.5.7</span>
+   <li><a href="#dom-neuralnetworkcontext-min">min(a, b)</a><span>, in §3.5.8</span>
    <li><a href="#ml">ML</a><span>, in §3.2</span>
    <li><a href="#dom-navigator-ml">ml</a><span>, in §3.1</span>
    <li><a href="#model">Model</a><span>, in §3.6</span>
-   <li><a href="#dom-neuralnetworkcontext-mul">mul(a, b)</a><span>, in §3.5.7</span>
+   <li><a href="#dom-neuralnetworkcontext-mul">mul(a, b)</a><span>, in §3.5.9</span>
    <li><a href="#dom-operandlayout-nchw">"nchw"</a><span>, in §3.3</span>
    <li><a href="#neuralnetworkcontext">NeuralNetworkContext</a><span>, in §3.5</span>
    <li><a href="#dom-operandlayout-nhwc">"nhwc"</a><span>, in §3.3</span>
@@ -2354,8 +2407,8 @@ API.</p>
    <li><a href="#enumdef-operandtype">OperandType</a><span>, in §3.3</span>
    <li><a href="#enumdef-powerpreference">PowerPreference</a><span>, in §3.6</span>
    <li><a href="#dom-compilationoptions-powerpreference">powerPreference</a><span>, in §3.6</span>
-   <li><a href="#dom-neuralnetworkcontext-relu">relu(x)</a><span>, in §3.5.8</span>
-   <li><a href="#dom-neuralnetworkcontext-reshape">reshape(input, newShape)</a><span>, in §3.5.9</span>
+   <li><a href="#dom-neuralnetworkcontext-relu">relu(x)</a><span>, in §3.5.10</span>
+   <li><a href="#dom-neuralnetworkcontext-reshape">reshape(input, newShape)</a><span>, in §3.5.11</span>
    <li><a href="#dom-operanddescriptor-scale">scale</a><span>, in §3.3</span>
    <li><a href="#dom-execution-setinput">setInput(index, data)</a><span>, in §3.8</span>
    <li><a href="#dom-execution-setoutput">setOutput(index, data)</a><span>, in §3.8</span>
@@ -2364,8 +2417,8 @@ API.</p>
    <li><a href="#dom-operandtype-tensor-float32">"tensor-float32"</a><span>, in §3.3</span>
    <li><a href="#dom-operandtype-tensor-int32">"tensor-int32"</a><span>, in §3.3</span>
    <li><a href="#dom-operandtype-tensor-quant8-asymm">"tensor-quant8-asymm"</a><span>, in §3.3</span>
-   <li><a href="#dom-neuralnetworkcontext-transpose">transpose(input)</a><span>, in §3.5.10</span>
-   <li><a href="#dom-neuralnetworkcontext-transpose">transpose(input, permutation)</a><span>, in §3.5.10</span>
+   <li><a href="#dom-neuralnetworkcontext-transpose">transpose(input)</a><span>, in §3.5.12</span>
+   <li><a href="#dom-neuralnetworkcontext-transpose">transpose(input, permutation)</a><span>, in §3.5.12</span>
    <li><a href="#dom-operanddescriptor-type">type</a><span>, in §3.3</span>
    <li><a href="#dom-operandtype-uint32">"uint32"</a><span>, in §3.3</span>
    <li><a href="#dom-operanddescriptor-zeropoint">zeroPoint</a><span>, in §3.3</span>
@@ -2400,6 +2453,7 @@ API.</p>
    <ul>
     <li><a href="#ref-for-idl-float">3.3. OperandDescriptor</a>
     <li><a href="#ref-for-idl-float①">3.5.4. gemm</a> <a href="#ref-for-idl-float②">(2)</a> <a href="#ref-for-idl-float③">(3)</a> <a href="#ref-for-idl-float④">(4)</a>
+    <li><a href="#ref-for-idl-float⑤">3.5.5. leakyRelu</a> <a href="#ref-for-idl-float⑥">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-long">
@@ -2408,8 +2462,8 @@ API.</p>
     <li><a href="#ref-for-idl-long">3.3. OperandDescriptor</a> <a href="#ref-for-idl-long①">(2)</a>
     <li><a href="#ref-for-idl-long②">3.5.2. concat</a> <a href="#ref-for-idl-long③">(2)</a>
     <li><a href="#ref-for-idl-long④">3.5.3. conv2d</a> <a href="#ref-for-idl-long⑤">(2)</a> <a href="#ref-for-idl-long⑥">(3)</a> <a href="#ref-for-idl-long⑦">(4)</a> <a href="#ref-for-idl-long⑧">(5)</a> <a href="#ref-for-idl-long⑨">(6)</a>
-    <li><a href="#ref-for-idl-long①⓪">3.5.9. reshape</a> <a href="#ref-for-idl-long①①">(2)</a>
-    <li><a href="#ref-for-idl-long①②">3.5.10. transpose</a> <a href="#ref-for-idl-long①③">(2)</a>
+    <li><a href="#ref-for-idl-long①⓪">3.5.11. reshape</a> <a href="#ref-for-idl-long①①">(2)</a>
+    <li><a href="#ref-for-idl-long①②">3.5.12. transpose</a> <a href="#ref-for-idl-long①③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
@@ -2567,11 +2621,19 @@ API.</p>
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-leakyrelu"><code><c- g>leakyRelu</c-></code></a>(<a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-leakyrelu-x-alpha-x"><code><c- g>x</c-></code></a>, <c- b>optional</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-float"><c- b>float</c-></a> <a href="#dom-neuralnetworkcontext-leakyrelu-x-alpha-alpha"><code><c- g>alpha</c-></code></a> = 0.01);
+};
+
+<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext"><c- g>NeuralNetworkContext</c-></a> {
   <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-matmul"><code><c- g>matmul</c-></code></a>(<a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-matmul-a-b-a"><code><c- g>a</c-></code></a>, <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-matmul-a-b-b"><code><c- g>b</c-></code></a>);
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext"><c- g>NeuralNetworkContext</c-></a> {
   <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-max"><code><c- g>max</c-></code></a>(<a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-max-a-b-a"><code><c- g>a</c-></code></a>, <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-max-a-b-b"><code><c- g>b</c-></code></a>);
+};
+
+<c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext"><c- g>NeuralNetworkContext</c-></a> {
+  <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-min"><code><c- g>min</c-></code></a>(<a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-min-a-b-a"><code><c- g>a</c-></code></a>, <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-min-a-b-b"><code><c- g>b</c-></code></a>);
 };
 
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="#neuralnetworkcontext"><c- g>NeuralNetworkContext</c-></a> {
@@ -2652,12 +2714,14 @@ API.</p>
     <li><a href="#ref-for-operand①⓪">3.5.2. concat</a> <a href="#ref-for-operand①①">(2)</a> <a href="#ref-for-operand①②">(3)</a> <a href="#ref-for-operand①③">(4)</a>
     <li><a href="#ref-for-operand①④">3.5.3. conv2d</a> <a href="#ref-for-operand①⑤">(2)</a> <a href="#ref-for-operand①⑥">(3)</a> <a href="#ref-for-operand①⑦">(4)</a> <a href="#ref-for-operand①⑧">(5)</a> <a href="#ref-for-operand①⑨">(6)</a>
     <li><a href="#ref-for-operand②⓪">3.5.4. gemm</a> <a href="#ref-for-operand②①">(2)</a> <a href="#ref-for-operand②②">(3)</a> <a href="#ref-for-operand②③">(4)</a> <a href="#ref-for-operand②④">(5)</a> <a href="#ref-for-operand②⑤">(6)</a> <a href="#ref-for-operand②⑥">(7)</a> <a href="#ref-for-operand②⑦">(8)</a>
-    <li><a href="#ref-for-operand②⑧">3.5.5. matmul</a> <a href="#ref-for-operand②⑨">(2)</a> <a href="#ref-for-operand③⓪">(3)</a> <a href="#ref-for-operand③①">(4)</a> <a href="#ref-for-operand③②">(5)</a> <a href="#ref-for-operand③③">(6)</a>
-    <li><a href="#ref-for-operand③④">3.5.6. max</a> <a href="#ref-for-operand③⑤">(2)</a> <a href="#ref-for-operand③⑥">(3)</a> <a href="#ref-for-operand③⑦">(4)</a> <a href="#ref-for-operand③⑧">(5)</a> <a href="#ref-for-operand③⑨">(6)</a>
-    <li><a href="#ref-for-operand④⓪">3.5.7. mul</a> <a href="#ref-for-operand④①">(2)</a> <a href="#ref-for-operand④②">(3)</a> <a href="#ref-for-operand④③">(4)</a> <a href="#ref-for-operand④④">(5)</a> <a href="#ref-for-operand④⑤">(6)</a>
-    <li><a href="#ref-for-operand④⑥">3.5.8. relu</a> <a href="#ref-for-operand④⑦">(2)</a> <a href="#ref-for-operand④⑧">(3)</a> <a href="#ref-for-operand④⑨">(4)</a>
-    <li><a href="#ref-for-operand⑤⓪">3.5.9. reshape</a> <a href="#ref-for-operand⑤①">(2)</a> <a href="#ref-for-operand⑤②">(3)</a> <a href="#ref-for-operand⑤③">(4)</a>
-    <li><a href="#ref-for-operand⑤④">3.5.10. transpose</a> <a href="#ref-for-operand⑤⑤">(2)</a> <a href="#ref-for-operand⑤⑥">(3)</a> <a href="#ref-for-operand⑤⑦">(4)</a>
+    <li><a href="#ref-for-operand②⑧">3.5.5. leakyRelu</a> <a href="#ref-for-operand②⑨">(2)</a> <a href="#ref-for-operand③⓪">(3)</a> <a href="#ref-for-operand③①">(4)</a>
+    <li><a href="#ref-for-operand③②">3.5.6. matmul</a> <a href="#ref-for-operand③③">(2)</a> <a href="#ref-for-operand③④">(3)</a> <a href="#ref-for-operand③⑤">(4)</a> <a href="#ref-for-operand③⑥">(5)</a> <a href="#ref-for-operand③⑦">(6)</a>
+    <li><a href="#ref-for-operand③⑧">3.5.7. max</a> <a href="#ref-for-operand③⑨">(2)</a> <a href="#ref-for-operand④⓪">(3)</a> <a href="#ref-for-operand④①">(4)</a> <a href="#ref-for-operand④②">(5)</a> <a href="#ref-for-operand④③">(6)</a>
+    <li><a href="#ref-for-operand④④">3.5.8. min</a> <a href="#ref-for-operand④⑤">(2)</a> <a href="#ref-for-operand④⑥">(3)</a> <a href="#ref-for-operand④⑦">(4)</a> <a href="#ref-for-operand④⑧">(5)</a> <a href="#ref-for-operand④⑨">(6)</a>
+    <li><a href="#ref-for-operand⑤⓪">3.5.9. mul</a> <a href="#ref-for-operand⑤①">(2)</a> <a href="#ref-for-operand⑤②">(3)</a> <a href="#ref-for-operand⑤③">(4)</a> <a href="#ref-for-operand⑤④">(5)</a> <a href="#ref-for-operand⑤⑤">(6)</a>
+    <li><a href="#ref-for-operand⑤⑥">3.5.10. relu</a> <a href="#ref-for-operand⑤⑦">(2)</a> <a href="#ref-for-operand⑤⑧">(3)</a> <a href="#ref-for-operand⑤⑨">(4)</a>
+    <li><a href="#ref-for-operand⑥⓪">3.5.11. reshape</a> <a href="#ref-for-operand⑥①">(2)</a> <a href="#ref-for-operand⑥②">(3)</a> <a href="#ref-for-operand⑥③">(4)</a>
+    <li><a href="#ref-for-operand⑥④">3.5.12. transpose</a> <a href="#ref-for-operand⑥⑤">(2)</a> <a href="#ref-for-operand⑥⑥">(3)</a> <a href="#ref-for-operand⑥⑦">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="typedefdef-number">
@@ -2674,12 +2738,14 @@ API.</p>
     <li><a href="#ref-for-neuralnetworkcontext②">3.5.2. concat</a>
     <li><a href="#ref-for-neuralnetworkcontext③">3.5.3. conv2d</a>
     <li><a href="#ref-for-neuralnetworkcontext④">3.5.4. gemm</a>
-    <li><a href="#ref-for-neuralnetworkcontext⑤">3.5.5. matmul</a>
-    <li><a href="#ref-for-neuralnetworkcontext⑥">3.5.6. max</a>
-    <li><a href="#ref-for-neuralnetworkcontext⑦">3.5.7. mul</a>
-    <li><a href="#ref-for-neuralnetworkcontext⑧">3.5.8. relu</a>
-    <li><a href="#ref-for-neuralnetworkcontext⑨">3.5.9. reshape</a>
-    <li><a href="#ref-for-neuralnetworkcontext①⓪">3.5.10. transpose</a>
+    <li><a href="#ref-for-neuralnetworkcontext⑤">3.5.5. leakyRelu</a>
+    <li><a href="#ref-for-neuralnetworkcontext⑥">3.5.6. matmul</a>
+    <li><a href="#ref-for-neuralnetworkcontext⑦">3.5.7. max</a>
+    <li><a href="#ref-for-neuralnetworkcontext⑧">3.5.8. min</a>
+    <li><a href="#ref-for-neuralnetworkcontext⑨">3.5.9. mul</a>
+    <li><a href="#ref-for-neuralnetworkcontext①⓪">3.5.10. relu</a>
+    <li><a href="#ref-for-neuralnetworkcontext①①">3.5.11. reshape</a>
+    <li><a href="#ref-for-neuralnetworkcontext①②">3.5.12. transpose</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="enumdef-powerpreference">


### PR DESCRIPTION
Per the [first wave models](https://github.com/webmachinelearning/webnn/blob/master/op_compatibility/first_wave_models.md), `leakyRelu` is required by TinyYOLOV2 model. `leakyRelu` can be implemented by element-wise `add`, `mul`, `max` and `min` where `min` is being added in this PR.

@wchao1115 @gramalingam, please take a look. Thanks!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/63.html" title="Last updated on Jun 5, 2020, 7:22 AM UTC (95866d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/63/d7b8e8d...huningxin:95866d2.html" title="Last updated on Jun 5, 2020, 7:22 AM UTC (95866d2)">Diff</a>