### PR TITLE
Simplify the examples

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -816,20 +816,16 @@ const TENSOR_SIZE = 16;
 // Create OperandDescriptor object.
 const float32TensorType = {type: 'tensor-float32', dimensions: TENSOR_DIMS};
 
-// constant1 is a constant tensor. Set its value from an ArrayBuffer object.
-// The ArrayBuffer object may contain the training data loaded before hand.
-const constant1 = nn.constant(float32TensorType,
-                              new Float32Array(arrayBuffer, 0, TENSOR_SIZE));
+// constant1 is a constant tensor with the value 0.5.
+const constantBuffer1 = new Float32Array(TENSOR_SIZE).fill(0.5);
+const constant1 = nn.constant(float32TensorType, constantBuffer1);
 
 // input1 is one of the input tensors. Its value will be set before execution.
 const input1 = nn.input('input1', float32TensorType);
 
-// constant2 is another constant tensor. Set its value from same ArrayBuffer
-// object with offset.
-const constant2 = nn.constant(float32TensorType,
-                              new Float32Array(arrayBuffer,
-                                               TENSOR_SIZE * Float32Array.BYTES_PER_ELEMENT,
-                                               TENSOR_SIZE));
+// constant2 is another constant tensor with the value 0.5.
+const constantBuffer2 = new Float32Array(TENSOR_SIZE).fill(0.5);
+const constant2 = nn.constant(float32TensorType, constantBuffer2);
 
 // input2 is another input tensor. Its value will be set before execution.
 const input2 = nn.input('input2', float32TensorType);
@@ -864,11 +860,9 @@ The following code executes the compiled graph.
 // Create an Execution object for the compiled model.
 const execution = await compilation.createExecution();
 
-// Setup the input buffers that contain the input data provided by the user.
-const inputBuffer1 = new Float32Array(TENSOR_SIZE);
-inputBuffer1.fill(inputValue1);
-const inputBuffer2 = new Float32Array(TENSOR_SIZE);
-inputBuffer2.fill(inputValue2);
+// Setup the input buffers with value 1.
+const inputBuffer1 = new Float32Array(TENSOR_SIZE).fill(1);
+const inputBuffer2 = new Float32Array(TENSOR_SIZE).fill(1);
 
 // Associate the input buffers to model's inputs.
 execution.setInput('input1', inputBuffer1);
@@ -881,6 +875,7 @@ execution.setOutput('output', outputBuffer);
 // Start the asynchronous computation.
 await execution.startCompute();
 // The computed result is now in outputBuffer.
+console.log(outputBuffer);
 </pre>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -1221,9 +1221,8 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version fbb89527, updated Wed Jun 24 18:56:26 2020 +0300" name="generator">
+  <meta content="Bikeshed version 40de15f9, updated Thu Jun 11 17:47:04 2020 -0700" name="generator">
   <link href="https://webmachinelearning.github.io/webnn/" rel="canonical">
-  <meta content="84e1b0bcc174c18bcc15912b00e121c0fa122e33" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1470,7 +1469,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://webmachinelearning.github.io/"> <img alt="Logo" height="100" src="https://webmachinelearning.github.io/webmachinelearning-logo.png" width="100"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web Neural Network API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-06-30">30 June 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-07-01">1 July 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2341,8 +2340,8 @@ the 2-D input tensor along axis 1.
 <pre class="highlight"><c- kr>const</c-> nn <c- o>=</c-> navigator<c- p>.</c->ml<c- p>.</c->getNeuralNetworkContext<c- p>();</c->
 </pre>
    </div>
-   <div class="example" id="example-0856a61b">
-    <a class="self-link" href="#example-0856a61b"></a> The following code builds a graph as: 
+   <div class="example" id="example-3b065651">
+    <a class="self-link" href="#example-3b065651"></a> The following code builds a graph as: 
 <pre>constant1 ---+
              +--- Add ---> intermediateOutput1 ---+
 input1    ---+                                    |
@@ -2358,20 +2357,16 @@ input2    ---+
 <c- c1>// Create OperandDescriptor object.</c->
 <c- kr>const</c-> float32TensorType <c- o>=</c-> <c- p>{</c->type<c- o>:</c-> <c- t>'tensor-float32'</c-><c- p>,</c-> dimensions<c- o>:</c-> TENSOR_DIMS<c- p>};</c->
 
-<c- c1>// constant1 is a constant tensor. Set its value from an ArrayBuffer object.</c->
-<c- c1>// The ArrayBuffer object may contain the training data loaded before hand.</c->
-<c- kr>const</c-> constant1 <c- o>=</c-> nn<c- p>.</c->constant<c- p>(</c->float32TensorType<c- p>,</c->
-                              <c- k>new</c-> Float32Array<c- p>(</c->arrayBuffer<c- p>,</c-> <c- mi>0</c-><c- p>,</c-> TENSOR_SIZE<c- p>));</c->
+<c- c1>// constant1 is a constant tensor with the value 0.5.</c->
+<c- kr>const</c-> constantBuffer1 <c- o>=</c-> <c- k>new</c-> Float32Array<c- p>(</c->TENSOR_SIZE<c- p>).</c->fill<c- p>(</c-><c- mf>0.5</c-><c- p>);</c->
+<c- kr>const</c-> constant1 <c- o>=</c-> nn<c- p>.</c->constant<c- p>(</c->float32TensorType<c- p>,</c-> constantBuffer1<c- p>);</c->
 
 <c- c1>// input1 is one of the input tensors. Its value will be set before execution.</c->
 <c- kr>const</c-> input1 <c- o>=</c-> nn<c- p>.</c->input<c- p>(</c-><c- t>'input1'</c-><c- p>,</c-> float32TensorType<c- p>);</c->
 
-<c- c1>// constant2 is another constant tensor. Set its value from same ArrayBuffer</c->
-<c- c1>// object with offset.</c->
-<c- kr>const</c-> constant2 <c- o>=</c-> nn<c- p>.</c->constant<c- p>(</c->float32TensorType<c- p>,</c->
-                              <c- k>new</c-> Float32Array<c- p>(</c->arrayBuffer<c- p>,</c->
-                                               TENSOR_SIZE <c- o>*</c-> Float32Array<c- p>.</c->BYTES_PER_ELEMENT<c- p>,</c->
-                                               TENSOR_SIZE<c- p>));</c->
+<c- c1>// constant2 is another constant tensor with the value 0.5.</c->
+<c- kr>const</c-> constantBuffer2 <c- o>=</c-> <c- k>new</c-> Float32Array<c- p>(</c->TENSOR_SIZE<c- p>).</c->fill<c- p>(</c-><c- mf>0.5</c-><c- p>);</c->
+<c- kr>const</c-> constant2 <c- o>=</c-> nn<c- p>.</c->constant<c- p>(</c->float32TensorType<c- p>,</c-> constantBuffer2<c- p>);</c->
 
 <c- c1>// input2 is another input tensor. Its value will be set before execution.</c->
 <c- kr>const</c-> input2 <c- o>=</c-> nn<c- p>.</c->input<c- p>(</c-><c- t>'input2'</c-><c- p>,</c-> float32TensorType<c- p>);</c->
@@ -2397,16 +2392,14 @@ over time. This option could be particularly useful for long-running models.
 <c- kr>const</c-> compilation <c- o>=</c-> await model<c- p>.</c->createCompilation<c- p>(</c->options<c- p>);</c->
 </pre>
    </div>
-   <div class="example" id="example-3c8f72ec">
-    <a class="self-link" href="#example-3c8f72ec"></a> The following code executes the compiled graph. 
+   <div class="example" id="example-68ac6d9e">
+    <a class="self-link" href="#example-68ac6d9e"></a> The following code executes the compiled graph. 
 <pre class="highlight"><c- c1>// Create an Execution object for the compiled model.</c->
 <c- kr>const</c-> execution <c- o>=</c-> await compilation<c- p>.</c->createExecution<c- p>();</c->
 
-<c- c1>// Setup the input buffers that contain the input data provided by the user.</c->
-<c- kr>const</c-> inputBuffer1 <c- o>=</c-> <c- k>new</c-> Float32Array<c- p>(</c->TENSOR_SIZE<c- p>);</c->
-inputBuffer1<c- p>.</c->fill<c- p>(</c->inputValue1<c- p>);</c->
-<c- kr>const</c-> inputBuffer2 <c- o>=</c-> <c- k>new</c-> Float32Array<c- p>(</c->TENSOR_SIZE<c- p>);</c->
-inputBuffer2<c- p>.</c->fill<c- p>(</c->inputValue2<c- p>);</c->
+<c- c1>// Setup the input buffers with value 1.</c->
+<c- kr>const</c-> inputBuffer1 <c- o>=</c-> <c- k>new</c-> Float32Array<c- p>(</c->TENSOR_SIZE<c- p>).</c->fill<c- p>(</c-><c- mi>1</c-><c- p>);</c->
+<c- kr>const</c-> inputBuffer2 <c- o>=</c-> <c- k>new</c-> Float32Array<c- p>(</c->TENSOR_SIZE<c- p>).</c->fill<c- p>(</c-><c- mi>1</c-><c- p>);</c->
 
 <c- c1>// Associate the input buffers to model’s inputs.</c->
 execution<c- p>.</c->setInput<c- p>(</c-><c- t>'input1'</c-><c- p>,</c-> inputBuffer1<c- p>);</c->
@@ -2419,6 +2412,7 @@ execution<c- p>.</c->setOutput<c- p>(</c-><c- t>'output'</c-><c- p>,</c-> output
 <c- c1>// Start the asynchronous computation.</c->
 await execution<c- p>.</c->startCompute<c- p>();</c->
 <c- c1>// The computed result is now in outputBuffer.</c->
+console<c- p>.</c->log<c- p>(</c->outputBuffer<c- p>);</c->
 </pre>
    </div>
    <h2 class="heading settled" data-level="5" id="acknowledgements"><span class="secno">5. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>


### PR DESCRIPTION
This PR is a follow-up to @pyu10055 's suggestion in [WebML CG June 25 meeting](https://www.w3.org/2020/06/25-webmachinelearning-minutes.html#t04)

> Ping: having the weights directly in the code would make for a clearer example

This PR changes to set the concrete values for constant and input tensors.

There is a [running version](https://jsfiddle.net/ningxinhu/kd1wvjop/) by using an API polyfill based on TF.js. I suppose it would be help for code review.

@pyu10055, @wchao1115 and @anssiko , please take a look. Thanks!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/80.html" title="Last updated on Jul 2, 2020, 4:13 AM UTC (a568ca5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/80/68af5cd...huningxin:a568ca5.html" title="Last updated on Jul 2, 2020, 4:13 AM UTC (a568ca5)">Diff</a>