### PR TITLE
Add polyfill and samples to spec header

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10,6 +10,7 @@ Editor: Chai Chaoweeraprasit 120203, Microsoft Corporation https://microsoft.com
 Abstract: This document describes a dedicated low-level API for neural network inference hardware acceleration.
 Repository: https://github.com/webmachinelearning/webnn
 !Explainer: <a href="https://github.com/webmachinelearning/webnn/blob/master/explainer.md">explainer.md</a>
+!Polyfill: <a href="https://github.com/webmachinelearning/webnn-polyfill">webnn-polyfill</a> / <a href="https://github.com/webmachinelearning/webnn-samples">webnn-samples</a>
 Markup Shorthands: markdown yes
 Markup Shorthands: dfn yes
 Markup Shorthands: idl yes

--- a/index.html
+++ b/index.html
@@ -1223,7 +1223,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 703d95ed, updated Wed Aug 26 21:59:02 2020 +0300" name="generator">
   <link href="https://webmachinelearning.github.io/webnn/" rel="canonical">
-  <meta content="eb07f349cf465fc31a9d0aecb49e08bf36739b9f" name="document-revision">
+  <meta content="059dff1744ea9589338650e2be8897464ab2c99c" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1470,7 +1470,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://webmachinelearning.github.io/"> <img alt="Logo" height="100" src="https://webmachinelearning.github.io/webmachinelearning-logo.png" width="100"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web Neural Network API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-09-07">7 September 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-09-21">21 September 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1482,6 +1482,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <dd class="editor p-author h-card vcard" data-editor-id="120203"><span class="p-name fn">Chai Chaoweeraprasit</span> (<a class="p-org org" href="https://microsoft.com">Microsoft Corporation</a>)
      <dt>Explainer:
      <dd><a href="https://github.com/webmachinelearning/webnn/blob/master/explainer.md">explainer.md</a>
+     <dt>Polyfill:
+     <dd><a href="https://github.com/webmachinelearning/webnn-polyfill">webnn-polyfill</a> / <a href="https://github.com/webmachinelearning/webnn-samples">webnn-samples</a>
     </dl>
    </div>
    <div data-fill-with="warning"></div>


### PR DESCRIPTION
It is appropriate to note the polyfill and samples in the spec header to raise awareness of these closely related projects.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/pull/91.html" title="Last updated on Sep 21, 2020, 2:00 PM UTC (decfa58)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/91/059dff1...decfa58.html" title="Last updated on Sep 21, 2020, 2:00 PM UTC (decfa58)">Diff</a>