### PR TITLE
Replaced interface with partial interface in WebIDL

### DIFF
--- a/index.html
+++ b/index.html
@@ -1709,7 +1709,7 @@ so that the application loads the tiny model in the case of CPU-only devices.</p
 };
 </pre>
    <h3 class="heading settled" data-level="3.2" id="api-ml"><span class="secno">3.2. </span><span class="content">ML</span><a class="self-link" href="#api-ml"></a></h3>
-<pre class="idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="ml"><code><c- g>ML</c-></code></dfn> {
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="ml"><code><c- g>ML</c-></code></dfn> {
   <a class="n" data-link-type="idl-name" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext"><c- n>NeuralNetworkContext</c-></a> <dfn class="idl-code" data-dfn-for="ML" data-dfn-type="method" data-export data-lt="getNeuralNetworkContext()" id="dom-ml-getneuralnetworkcontext"><code><c- g>getNeuralNetworkContext</c-></code><a class="self-link" href="#dom-ml-getneuralnetworkcontext"></a></dfn>();
 };
 </pre>
@@ -1747,7 +1747,7 @@ so that the application loads the tiny model in the case of CPU-only devices.</p
 };
 </pre>
    <h3 class="heading settled" data-level="3.4" id="api-operand"><span class="secno">3.4. </span><span class="content">Operand</span><a class="self-link" href="#api-operand"></a></h3>
-<pre class="idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="operand"><code><c- g>Operand</c-></code></dfn> {};
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="operand"><code><c- g>Operand</c-></code></dfn> {};
 </pre>
    <h3 class="heading settled" data-level="3.5" id="api-neuralnetworkcontext"><span class="secno">3.5. </span><span class="content">NeuralNetworkContext</span><a class="self-link" href="#api-neuralnetworkcontext"></a></h3>
    <p>The <code class="idl"><a data-link-type="idl" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext①">NeuralNetworkContext</a></code> defines a set of operations derived from the first-wave models <a data-link-type="biblio" href="#biblio-models">[Models]</a> that address identified <a href="#usecases">§ 2 Use cases</a>.</p>
@@ -1758,7 +1758,7 @@ so that the application loads the tiny model in the case of CPU-only devices.</p
   <c- b>required</c-> <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NamedOperand" data-dfn-type="dict-member" data-export data-type="Operand " id="dom-namedoperand-operand"><code><c- g>operand</c-></code><a class="self-link" href="#dom-namedoperand-operand"></a></dfn>;
 };
 
-<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="neuralnetworkcontext"><code><c- g>NeuralNetworkContext</c-></code></dfn> {
+<c- b>partial</c-> <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="neuralnetworkcontext"><code><c- g>NeuralNetworkContext</c-></code></dfn> {
   // Create an Operand object that represents a model input.
   <a class="n" data-link-type="idl-name" href="#operand" id="ref-for-operand①"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="input(name, desc)" id="dom-neuralnetworkcontext-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-input"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/input(name, desc)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-input-name-desc-name"><code><c- g>name</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-input-name-desc-name"></a></dfn>, <a class="n" data-link-type="idl-name" href="#dictdef-operanddescriptor" id="ref-for-dictdef-operanddescriptor"><c- n>OperandDescriptor</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext/input(name, desc)" data-dfn-type="argument" data-export id="dom-neuralnetworkcontext-input-name-desc-desc"><code><c- g>desc</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-input-name-desc-desc"></a></dfn>);
 
@@ -2615,17 +2615,17 @@ the 2-D input tensor along axis 1.
   <a class="n" data-link-type="idl-name" href="#enumdef-powerpreference" id="ref-for-enumdef-powerpreference"><c- n>PowerPreference</c-></a> <dfn class="idl-code" data-default="&quot;default&quot;" data-dfn-for="CompilationOptions" data-dfn-type="dict-member" data-export data-type="PowerPreference " id="dom-compilationoptions-powerpreference"><code><c- g>powerPreference</c-></code><a class="self-link" href="#dom-compilationoptions-powerpreference"></a></dfn> = "default";
 };
 
-<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="model"><code><c- g>Model</c-></code></dfn> {
+<c- b>partial</c-> <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="model"><code><c- g>Model</c-></code></dfn> {
   <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#compilation" id="ref-for-compilation"><c- n>Compilation</c-></a>> <dfn class="idl-code" data-dfn-for="Model" data-dfn-type="method" data-export data-lt="createCompilation(options)|createCompilation()" id="dom-model-createcompilation"><code><c- g>createCompilation</c-></code><a class="self-link" href="#dom-model-createcompilation"></a></dfn>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-compilationoptions" id="ref-for-dictdef-compilationoptions"><c- n>CompilationOptions</c-></a> <dfn class="idl-code" data-dfn-for="Model/createCompilation(options), Model/createCompilation()" data-dfn-type="argument" data-export id="dom-model-createcompilation-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-model-createcompilation-options-options"></a></dfn> = {});
 };
 </pre>
    <h3 class="heading settled" data-level="3.7" id="api-compilation"><span class="secno">3.7. </span><span class="content">Compilation</span><a class="self-link" href="#api-compilation"></a></h3>
-<pre class="idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="compilation"><code><c- g>Compilation</c-></code></dfn> {
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="compilation"><code><c- g>Compilation</c-></code></dfn> {
   <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#execution" id="ref-for-execution"><c- n>Execution</c-></a>> <dfn class="idl-code" data-dfn-for="Compilation" data-dfn-type="method" data-export data-lt="createExecution()" id="dom-compilation-createexecution"><code><c- g>createExecution</c-></code><a class="self-link" href="#dom-compilation-createexecution"></a></dfn>();
 };
 </pre>
    <h3 class="heading settled" data-level="3.8" id="api-execution"><span class="secno">3.8. </span><span class="content">Execution</span><a class="self-link" href="#api-execution"></a></h3>
-<pre class="idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="execution"><code><c- g>Execution</c-></code></dfn> {
+<pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="execution"><code><c- g>Execution</c-></code></dfn> {
   <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-void" id="ref-for-idl-void"><c- n>void</c-></a> <dfn class="idl-code" data-dfn-for="Execution" data-dfn-type="method" data-export data-lt="setInput(name, data)" id="dom-execution-setinput"><code><c- g>setInput</c-></code><a class="self-link" href="#dom-execution-setinput"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="Execution/setInput(name, data)" data-dfn-type="argument" data-export id="dom-execution-setinput-name-data-name"><code><c- g>name</c-></code><a class="self-link" href="#dom-execution-setinput-name-data-name"></a></dfn>, <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#ArrayBufferView" id="ref-for-ArrayBufferView①"><c- n>ArrayBufferView</c-></a> <dfn class="idl-code" data-dfn-for="Execution/setInput(name, data)" data-dfn-type="argument" data-export id="dom-execution-setinput-name-data-data"><code><c- g>data</c-></code><a class="self-link" href="#dom-execution-setinput-name-data-data"></a></dfn>);
   <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-void" id="ref-for-idl-void①"><c- n>void</c-></a> <dfn class="idl-code" data-dfn-for="Execution" data-dfn-type="method" data-export data-lt="setOutput(name, data)" id="dom-execution-setoutput"><code><c- g>setOutput</c-></code><a class="self-link" href="#dom-execution-setoutput"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="Execution/setOutput(name, data)" data-dfn-type="argument" data-export id="dom-execution-setoutput-name-data-name"><code><c- g>name</c-></code><a class="self-link" href="#dom-execution-setoutput-name-data-name"></a></dfn>, <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#ArrayBufferView" id="ref-for-ArrayBufferView②"><c- n>ArrayBufferView</c-></a> <dfn class="idl-code" data-dfn-for="Execution/setOutput(name, data)" data-dfn-type="argument" data-export id="dom-execution-setoutput-name-data-data"><code><c- g>data</c-></code><a class="self-link" href="#dom-execution-setoutput-name-data-data"></a></dfn>);
   <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-void" id="ref-for-idl-void②"><c- n>void</c-></a>> <dfn class="idl-code" data-dfn-for="Execution" data-dfn-type="method" data-export data-lt="startCompute()" id="dom-execution-startcompute"><code><c- g>startCompute</c-></code><a class="self-link" href="#dom-execution-startcompute"></a></dfn>();
@@ -3186,7 +3186,7 @@ Benjamin Poulain for their contributions to the API specification.</p>
   <c- b>readonly</c-> <c- b>attribute</c-> <a class="n" data-link-type="idl-name" href="#ml"><c- n>ML</c-></a> <a data-readonly data-type="ML" href="#dom-navigator-ml"><code><c- g>ml</c-></code></a>;
 };
 
-<c- b>interface</c-> <a href="#ml"><code><c- g>ML</c-></code></a> {
+<c- b>partial</c-> <c- b>interface</c-> <a href="#ml"><code><c- g>ML</c-></code></a> {
   <a class="n" data-link-type="idl-name" href="#neuralnetworkcontext"><c- n>NeuralNetworkContext</c-></a> <a href="#dom-ml-getneuralnetworkcontext"><code><c- g>getNeuralNetworkContext</c-></code></a>();
 };
 
@@ -3222,7 +3222,7 @@ Benjamin Poulain for their contributions to the API specification.</p>
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><c- b>long</c-></a> <a data-type="long " href="#dom-operanddescriptor-zeropoint"><code><c- g>zeroPoint</c-></code></a>;
 };
 
-<c- b>interface</c-> <a href="#operand"><code><c- g>Operand</c-></code></a> {};
+<c- b>partial</c-> <c- b>interface</c-> <a href="#operand"><code><c- g>Operand</c-></code></a> {};
 
 <c- b>typedef</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double"><c- b>double</c-></a> <a href="#typedefdef-number"><code><c- g>number</c-></code></a>;
 
@@ -3231,7 +3231,7 @@ Benjamin Poulain for their contributions to the API specification.</p>
   <c- b>required</c-> <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a data-type="Operand " href="#dom-namedoperand-operand"><code><c- g>operand</c-></code></a>;
 };
 
-<c- b>interface</c-> <a href="#neuralnetworkcontext"><code><c- g>NeuralNetworkContext</c-></code></a> {
+<c- b>partial</c-> <c- b>interface</c-> <a href="#neuralnetworkcontext"><code><c- g>NeuralNetworkContext</c-></code></a> {
   // Create an Operand object that represents a model input.
   <a class="n" data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-neuralnetworkcontext-input"><code><c- g>input</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a> <a href="#dom-neuralnetworkcontext-input-name-desc-name"><code><c- g>name</c-></code></a>, <a class="n" data-link-type="idl-name" href="#dictdef-operanddescriptor"><c- n>OperandDescriptor</c-></a> <a href="#dom-neuralnetworkcontext-input-name-desc-desc"><code><c- g>desc</c-></code></a>);
 
@@ -3402,15 +3402,15 @@ Benjamin Poulain for their contributions to the API specification.</p>
   <a class="n" data-link-type="idl-name" href="#enumdef-powerpreference"><c- n>PowerPreference</c-></a> <a data-default="&quot;default&quot;" data-type="PowerPreference " href="#dom-compilationoptions-powerpreference"><code><c- g>powerPreference</c-></code></a> = "default";
 };
 
-<c- b>interface</c-> <a href="#model"><code><c- g>Model</c-></code></a> {
+<c- b>partial</c-> <c- b>interface</c-> <a href="#model"><code><c- g>Model</c-></code></a> {
   <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#compilation"><c- n>Compilation</c-></a>> <a href="#dom-model-createcompilation"><code><c- g>createCompilation</c-></code></a>(<c- b>optional</c-> <a class="n" data-link-type="idl-name" href="#dictdef-compilationoptions"><c- n>CompilationOptions</c-></a> <a href="#dom-model-createcompilation-options-options"><code><c- g>options</c-></code></a> = {});
 };
 
-<c- b>interface</c-> <a href="#compilation"><code><c- g>Compilation</c-></code></a> {
+<c- b>partial</c-> <c- b>interface</c-> <a href="#compilation"><code><c- g>Compilation</c-></code></a> {
   <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="#execution"><c- n>Execution</c-></a>> <a href="#dom-compilation-createexecution"><code><c- g>createExecution</c-></code></a>();
 };
 
-<c- b>interface</c-> <a href="#execution"><code><c- g>Execution</c-></code></a> {
+<c- b>partial</c-> <c- b>interface</c-> <a href="#execution"><code><c- g>Execution</c-></code></a> {
   <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-void"><c- n>void</c-></a> <a href="#dom-execution-setinput"><code><c- g>setInput</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a> <a href="#dom-execution-setinput-name-data-name"><code><c- g>name</c-></code></a>, <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#ArrayBufferView"><c- n>ArrayBufferView</c-></a> <a href="#dom-execution-setinput-name-data-data"><code><c- g>data</c-></code></a>);
   <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-void"><c- n>void</c-></a> <a href="#dom-execution-setoutput"><code><c- g>setOutput</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a> <a href="#dom-execution-setoutput-name-data-name"><code><c- g>name</c-></code></a>, <a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#ArrayBufferView"><c- n>ArrayBufferView</c-></a> <a href="#dom-execution-setoutput-name-data-data"><code><c- g>data</c-></code></a>);
   <c- b>Promise</c->&lt;<a class="n" data-link-type="idl-name" href="https://heycam.github.io/webidl/#idl-void"><c- n>void</c-></a>> <a href="#dom-execution-startcompute"><code><c- g>startCompute</c-></code></a>();


### PR DESCRIPTION
- For all of WebIDL definition in this spec, partial interface probably need to be used rather then interface according to WebIDL spec [1]
- Because the definition of an interface is separated over more than one section of the document
[1] https://heycam.github.io/webidl/