### PR TITLE
Added extended attributes to Web IDL definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -181,12 +181,13 @@ API {#api}
 ## Navigator ## {#api-navigator}
 <script type=idl>
 partial interface Navigator {
-  readonly attribute ML ml;
+  [SecureContext] readonly attribute ML ml;
 };
 </script>
 
 ## ML ## {#api-ml}
 <script type=idl>
+[SecureContext, Exposed=Window]
 interface ML {
   NeuralNetworkContext getNeuralNetworkContext();
 };
@@ -220,6 +221,7 @@ dictionary OperandDescriptor {
 
 ## Operand ## {#api-operand}
 <script type=idl>
+[SecureContext, Exposed=Window]
 interface Operand {};
 </script>
 
@@ -228,6 +230,7 @@ interface Operand {};
 The {{NeuralNetworkContext}} interface represents a global state of neural network compute workload and execution processes.
 
 <script type=idl>
+[SecureContext, Exposed=Window]
 interface NeuralNetworkContext {
   ModelBuilder createModelBuilder();
 };
@@ -240,6 +243,7 @@ The {{ModelBuilder}} interface defines a set of operations as identified by the 
 <script type=idl>
 typedef record<DOMString, Operand> NamedOperands;
 
+[SecureContext, Exposed=Window]
 interface ModelBuilder {
   // Create an operand that represents a model input.
   Operand input(DOMString name, OperandDescriptor desc);
@@ -1093,6 +1097,7 @@ dictionary CompilationOptions {
   PowerPreference powerPreference = "default";
 };
 
+[SecureContext, Exposed=Window]
 interface Model {
   Promise<Compilation> compile(optional CompilationOptions options = {});
 };
@@ -1115,6 +1120,7 @@ dictionary Output {
 typedef record<DOMString, Input> NamedInputs;
 typedef record<DOMString, Output> NamedOutputs;
 
+[SecureContext, Exposed=Window]
 interface Compilation {
   Promise<NamedOutputs> compute(NamedInputs inputs, optional NamedOutputs outputs);
 };

--- a/index.html
+++ b/index.html
@@ -1198,7 +1198,7 @@ Possible extra rowspan handling
 	ul.index ul,
 	ul.index dl { font-size: smaller; }
 	@media not print {
-		ul.index li span:not(.dfn-paneled) {
+		ul.index li span {
 			white-space: nowrap;
 			color: transparent; }
 		ul.index li a:hover + span,
@@ -1323,6 +1323,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version f9f60c8f, updated Fri Sep 25 16:39:03 2020 -0700" name="generator">
   <link href="https://webmachinelearning.github.io/webnn/" rel="canonical">
+  <meta content="f7f4452b834af1f23f671c1c90ea8806adbba5d0" name="document-revision">
 <style>/* darkmode */
 
             @media (prefers-color-scheme: dark) {
@@ -1552,7 +1553,7 @@ figcaption:not(.no-marker)::before {
 .dfn-panel:not(.on) { display: none; }
 .dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
 .dfn-panel > b { display: block; }
-.dfn-panel a { color: var(--dfnpanel-text); }
+.dfn-panel a { color: black; }
 .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
 .dfn-panel > b + b { margin-top: 0.25em; }
 .dfn-panel ul { padding: 0; }
@@ -1881,7 +1882,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://webmachinelearning.github.io/"> <img alt="Logo" height="100" src="https://webmachinelearning.github.io/webmachinelearning-logo.png" width="100"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web Neural Network API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-10-08">8 October 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-10-13">13 October 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2118,11 +2119,12 @@ so that the application loads the tiny model in the case of CPU-only devices.</p
    <h2 class="heading settled" data-level="3" id="api"><span class="secno">3. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
    <h3 class="heading settled" data-level="3.1" id="api-navigator"><span class="secno">3.1. </span><span class="content">Navigator</span><a class="self-link" href="#api-navigator"></a></h3>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/system-state.html#navigator" id="ref-for-navigator"><c- g>Navigator</c-></a> {
-  <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#ml" id="ref-for-ml"><c- n>ML</c-></a> <dfn class="idl-code" data-dfn-for="Navigator" data-dfn-type="attribute" data-export data-readonly data-type="ML" id="dom-navigator-ml"><code><c- g>ml</c-></code><a class="self-link" href="#dom-navigator-ml"></a></dfn>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext"><c- g>SecureContext</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#ml" id="ref-for-ml"><c- n>ML</c-></a> <dfn class="idl-code" data-dfn-for="Navigator" data-dfn-type="attribute" data-export data-readonly data-type="ML" id="dom-navigator-ml"><code><c- g>ml</c-></code><a class="self-link" href="#dom-navigator-ml"></a></dfn>;
 };
 </pre>
    <h3 class="heading settled" data-level="3.2" id="api-ml"><span class="secno">3.2. </span><span class="content">ML</span><a class="self-link" href="#api-ml"></a></h3>
-<pre class="idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="ml"><code><c- g>ML</c-></code></dfn> {
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="ml"><code><c- g>ML</c-></code></dfn> {
   <a data-link-type="idl-name" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext"><c- n>NeuralNetworkContext</c-></a> <dfn class="idl-code" data-dfn-for="ML" data-dfn-type="method" data-export data-lt="getNeuralNetworkContext()" id="dom-ml-getneuralnetworkcontext"><code><c- g>getNeuralNetworkContext</c-></code><a class="self-link" href="#dom-ml-getneuralnetworkcontext"></a></dfn>();
 };
 </pre>
@@ -2151,11 +2153,13 @@ so that the application loads the tiny model in the case of CPU-only devices.</p
 };
 </pre>
    <h3 class="heading settled" data-level="3.4" id="api-operand"><span class="secno">3.4. </span><span class="content">Operand</span><a class="self-link" href="#api-operand"></a></h3>
-<pre class="idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="operand"><code><c- g>Operand</c-></code></dfn> {};
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext②"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="operand"><code><c- g>Operand</c-></code></dfn> {};
 </pre>
    <h3 class="heading settled" data-level="3.5" id="api-neuralnetworkcontext"><span class="secno">3.5. </span><span class="content">NeuralNetworkContext</span><a class="self-link" href="#api-neuralnetworkcontext"></a></h3>
    <p>The <code class="idl"><a data-link-type="idl" href="#neuralnetworkcontext" id="ref-for-neuralnetworkcontext①">NeuralNetworkContext</a></code> interface represents a global state of neural network compute workload and execution processes.</p>
-<pre class="idl highlight def"><c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="neuralnetworkcontext"><code><c- g>NeuralNetworkContext</c-></code></dfn> {
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext③"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②"><c- g>Exposed</c-></a>=<c- n>Window</c->]
+<c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="neuralnetworkcontext"><code><c- g>NeuralNetworkContext</c-></code></dfn> {
   <a data-link-type="idl-name" href="#modelbuilder" id="ref-for-modelbuilder"><c- n>ModelBuilder</c-></a> <dfn class="idl-code" data-dfn-for="NeuralNetworkContext" data-dfn-type="method" data-export data-lt="createModelBuilder()" id="dom-neuralnetworkcontext-createmodelbuilder"><code><c- g>createModelBuilder</c-></code><a class="self-link" href="#dom-neuralnetworkcontext-createmodelbuilder"></a></dfn>();
 };
 </pre>
@@ -2163,6 +2167,7 @@ so that the application loads the tiny model in the case of CPU-only devices.</p
    <p>The <code class="idl"><a data-link-type="idl" href="#modelbuilder" id="ref-for-modelbuilder①">ModelBuilder</a></code> interface defines a set of operations as identified by the <a href="#usecases">§ 2 Use cases</a> that can be composed into a computational graph. It also represents the intermediate state of a graph building session.</p>
 <pre class="idl highlight def"><c- b>typedef</c-> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-record" id="ref-for-idl-record"><c- b>record</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a>, <a data-link-type="idl-name" href="#operand" id="ref-for-operand"><c- n>Operand</c-></a>> <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-namedoperands"><code><c- g>NamedOperands</c-></code></dfn>;
 
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext④"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed③"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="modelbuilder"><code><c- g>ModelBuilder</c-></code></dfn> {
   // Create an operand that represents a model input.
   <a data-link-type="idl-name" href="#operand" id="ref-for-operand①"><c- n>Operand</c-></a> <dfn class="idl-code" data-dfn-for="ModelBuilder" data-dfn-type="method" data-export data-lt="input(name, desc)" id="dom-modelbuilder-input"><code><c- g>input</c-></code><a class="self-link" href="#dom-modelbuilder-input"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="ModelBuilder/input(name, desc)" data-dfn-type="argument" data-export id="dom-modelbuilder-input-name-desc-name"><code><c- g>name</c-></code><a class="self-link" href="#dom-modelbuilder-input-name-desc-name"></a></dfn>, <a data-link-type="idl-name" href="#dictdef-operanddescriptor" id="ref-for-dictdef-operanddescriptor"><c- n>OperandDescriptor</c-></a> <dfn class="idl-code" data-dfn-for="ModelBuilder/input(name, desc)" data-dfn-type="argument" data-export id="dom-modelbuilder-input-name-desc-desc"><code><c- g>desc</c-></code><a class="self-link" href="#dom-modelbuilder-input-name-desc-desc"></a></dfn>);
@@ -3083,6 +3088,7 @@ the 2-D input tensor along axis 1.
   <a data-link-type="idl-name" href="#enumdef-powerpreference" id="ref-for-enumdef-powerpreference"><c- n>PowerPreference</c-></a> <dfn class="idl-code" data-default="&quot;default&quot;" data-dfn-for="CompilationOptions" data-dfn-type="dict-member" data-export data-type="PowerPreference " id="dom-compilationoptions-powerpreference"><code><c- g>powerPreference</c-></code><a class="self-link" href="#dom-compilationoptions-powerpreference"></a></dfn> = "default";
 };
 
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext⑤"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed④"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="model"><code><c- g>Model</c-></code></dfn> {
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#compilation" id="ref-for-compilation"><c- n>Compilation</c-></a>> <dfn class="idl-code" data-dfn-for="Model" data-dfn-type="method" data-export data-lt="compile(options)|compile()" id="dom-model-compile"><code><c- g>compile</c-></code><a class="self-link" href="#dom-model-compile"></a></dfn>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-compilationoptions" id="ref-for-dictdef-compilationoptions"><c- n>CompilationOptions</c-></a> <dfn class="idl-code" data-dfn-for="Model/compile(options), Model/compile()" data-dfn-type="argument" data-export id="dom-model-compile-options-options"><code><c- g>options</c-></code><a class="self-link" href="#dom-model-compile-options-options"></a></dfn> = {});
 };
@@ -3102,6 +3108,7 @@ the 2-D input tensor along axis 1.
 <c- b>typedef</c-> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-record" id="ref-for-idl-record①"><c- b>record</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString②"><c- b>DOMString</c-></a>, <a data-link-type="idl-name" href="#dictdef-input" id="ref-for-dictdef-input"><c- n>Input</c-></a>> <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-namedinputs"><code><c- g>NamedInputs</c-></code></dfn>;
 <c- b>typedef</c-> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-record" id="ref-for-idl-record②"><c- b>record</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString③"><c- b>DOMString</c-></a>, <a data-link-type="idl-name" href="#dictdef-output" id="ref-for-dictdef-output"><c- n>Output</c-></a>> <dfn class="dfn-paneled idl-code" data-dfn-type="typedef" data-export id="typedefdef-namedoutputs"><code><c- g>NamedOutputs</c-></code></dfn>;
 
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext⑥"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed⑤"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="compilation"><code><c- g>Compilation</c-></code></dfn> {
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise①"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#typedefdef-namedoutputs" id="ref-for-typedefdef-namedoutputs"><c- n>NamedOutputs</c-></a>> <dfn class="idl-code" data-dfn-for="Compilation" data-dfn-type="method" data-export data-lt="compute(inputs, outputs)|compute(inputs)" id="dom-compilation-compute"><code><c- g>compute</c-></code><a class="self-link" href="#dom-compilation-compute"></a></dfn>(<a data-link-type="idl-name" href="#typedefdef-namedinputs" id="ref-for-typedefdef-namedinputs"><c- n>NamedInputs</c-></a> <dfn class="idl-code" data-dfn-for="Compilation/compute(inputs, outputs), Compilation/compute(inputs)" data-dfn-type="argument" data-export id="dom-compilation-compute-inputs-outputs-inputs"><code><c- g>inputs</c-></code><a class="self-link" href="#dom-compilation-compute-inputs-outputs-inputs"></a></dfn>, <c- b>optional</c-> <a data-link-type="idl-name" href="#typedefdef-namedoutputs" id="ref-for-typedefdef-namedoutputs①"><c- n>NamedOutputs</c-></a> <dfn class="idl-code" data-dfn-for="Compilation/compute(inputs, outputs), Compilation/compute(inputs)" data-dfn-type="argument" data-export id="dom-compilation-compute-inputs-outputs-outputs"><code><c- g>outputs</c-></code><a class="self-link" href="#dom-compilation-compute-inputs-outputs-outputs"></a></dfn>);
 };
@@ -3535,11 +3542,34 @@ Benjamin Poulain for their contributions to the API specification.</p>
     <li><a href="#ref-for-idl-DOMString②">3.8. Compilation</a> <a href="#ref-for-idl-DOMString③">(2)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-Exposed">
+   <a href="https://heycam.github.io/webidl/#Exposed">https://heycam.github.io/webidl/#Exposed</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-Exposed">3.2. ML</a>
+    <li><a href="#ref-for-Exposed①">3.4. Operand</a>
+    <li><a href="#ref-for-Exposed②">3.5. NeuralNetworkContext</a>
+    <li><a href="#ref-for-Exposed③">3.6. ModelBuilder</a>
+    <li><a href="#ref-for-Exposed④">3.7. Model</a>
+    <li><a href="#ref-for-Exposed⑤">3.8. Compilation</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-idl-promise">
    <a href="https://heycam.github.io/webidl/#idl-promise">https://heycam.github.io/webidl/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3.7. Model</a>
     <li><a href="#ref-for-idl-promise①">3.8. Compilation</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-SecureContext">
+   <a href="https://heycam.github.io/webidl/#SecureContext">https://heycam.github.io/webidl/#SecureContext</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-SecureContext">3.1. Navigator</a>
+    <li><a href="#ref-for-SecureContext①">3.2. ML</a>
+    <li><a href="#ref-for-SecureContext②">3.4. Operand</a>
+    <li><a href="#ref-for-SecureContext③">3.5. NeuralNetworkContext</a>
+    <li><a href="#ref-for-SecureContext④">3.6. ModelBuilder</a>
+    <li><a href="#ref-for-SecureContext⑤">3.7. Model</a>
+    <li><a href="#ref-for-SecureContext⑥">3.8. Compilation</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-boolean">
@@ -3620,21 +3650,23 @@ Benjamin Poulain for their contributions to the API specification.</p>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-navigator">Navigator</span>
+     <li><span class="dfn-paneled" id="term-for-navigator" style="color:initial">Navigator</span>
     </ul>
    <li>
     <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-ArrayBufferView">ArrayBufferView</span>
-     <li><span class="dfn-paneled" id="term-for-idl-DOMString">DOMString</span>
-     <li><span class="dfn-paneled" id="term-for-idl-promise">Promise</span>
-     <li><span class="dfn-paneled" id="term-for-idl-boolean">boolean</span>
-     <li><span class="dfn-paneled" id="term-for-idl-double">double</span>
-     <li><span class="dfn-paneled" id="term-for-idl-float">float</span>
-     <li><span class="dfn-paneled" id="term-for-idl-long">long</span>
-     <li><span class="dfn-paneled" id="term-for-idl-record">record</span>
-     <li><span class="dfn-paneled" id="term-for-idl-sequence">sequence</span>
-     <li><span class="dfn-paneled" id="term-for-idl-unsigned-long">unsigned long</span>
+     <li><span class="dfn-paneled" id="term-for-ArrayBufferView" style="color:initial">ArrayBufferView</span>
+     <li><span class="dfn-paneled" id="term-for-idl-DOMString" style="color:initial">DOMString</span>
+     <li><span class="dfn-paneled" id="term-for-Exposed" style="color:initial">Exposed</span>
+     <li><span class="dfn-paneled" id="term-for-idl-promise" style="color:initial">Promise</span>
+     <li><span class="dfn-paneled" id="term-for-SecureContext" style="color:initial">SecureContext</span>
+     <li><span class="dfn-paneled" id="term-for-idl-boolean" style="color:initial">boolean</span>
+     <li><span class="dfn-paneled" id="term-for-idl-double" style="color:initial">double</span>
+     <li><span class="dfn-paneled" id="term-for-idl-float" style="color:initial">float</span>
+     <li><span class="dfn-paneled" id="term-for-idl-long" style="color:initial">long</span>
+     <li><span class="dfn-paneled" id="term-for-idl-record" style="color:initial">record</span>
+     <li><span class="dfn-paneled" id="term-for-idl-sequence" style="color:initial">sequence</span>
+     <li><span class="dfn-paneled" id="term-for-idl-unsigned-long" style="color:initial">unsigned long</span>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -3696,9 +3728,10 @@ Benjamin Poulain for their contributions to the API specification.</p>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/system-state.html#navigator"><c- g>Navigator</c-></a> {
-  <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#ml"><c- n>ML</c-></a> <a data-readonly data-type="ML" href="#dom-navigator-ml"><code><c- g>ml</c-></code></a>;
+  [<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext"><c- g>SecureContext</c-></a>] <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#ml"><c- n>ML</c-></a> <a data-readonly data-type="ML" href="#dom-navigator-ml"><code><c- g>ml</c-></code></a>;
 };
 
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <a href="#ml"><code><c- g>ML</c-></code></a> {
   <a data-link-type="idl-name" href="#neuralnetworkcontext"><c- n>NeuralNetworkContext</c-></a> <a href="#dom-ml-getneuralnetworkcontext"><code><c- g>getNeuralNetworkContext</c-></code></a>();
 };
@@ -3726,14 +3759,17 @@ Benjamin Poulain for their contributions to the API specification.</p>
   <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence"><c- b>sequence</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-long"><c- b>long</c-></a>> <a data-type="sequence<long> " href="#dom-operanddescriptor-dimensions"><code><c- g>dimensions</c-></code></a>;
 };
 
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <a href="#operand"><code><c- g>Operand</c-></code></a> {};
 
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <a href="#neuralnetworkcontext"><code><c- g>NeuralNetworkContext</c-></code></a> {
   <a data-link-type="idl-name" href="#modelbuilder"><c- n>ModelBuilder</c-></a> <a href="#dom-neuralnetworkcontext-createmodelbuilder"><code><c- g>createModelBuilder</c-></code></a>();
 };
 
 <c- b>typedef</c-> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-record"><c- b>record</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a>, <a data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a>> <a href="#typedefdef-namedoperands"><code><c- g>NamedOperands</c-></code></a>;
 
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <a href="#modelbuilder"><code><c- g>ModelBuilder</c-></code></a> {
   // Create an operand that represents a model input.
   <a data-link-type="idl-name" href="#operand"><c- n>Operand</c-></a> <a href="#dom-modelbuilder-input"><code><c- g>input</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a> <a href="#dom-modelbuilder-input-name-desc-name"><code><c- g>name</c-></code></a>, <a data-link-type="idl-name" href="#dictdef-operanddescriptor"><c- n>OperandDescriptor</c-></a> <a href="#dom-modelbuilder-input-name-desc-desc"><code><c- g>desc</c-></code></a>);
@@ -3915,6 +3951,7 @@ Benjamin Poulain for their contributions to the API specification.</p>
   <a data-link-type="idl-name" href="#enumdef-powerpreference"><c- n>PowerPreference</c-></a> <a data-default="&quot;default&quot;" data-type="PowerPreference " href="#dom-compilationoptions-powerpreference"><code><c- g>powerPreference</c-></code></a> = "default";
 };
 
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <a href="#model"><code><c- g>Model</c-></code></a> {
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#compilation"><c- n>Compilation</c-></a>> <a href="#dom-model-compile"><code><c- g>compile</c-></code></a>(<c- b>optional</c-> <a data-link-type="idl-name" href="#dictdef-compilationoptions"><c- n>CompilationOptions</c-></a> <a href="#dom-model-compile-options-options"><code><c- g>options</c-></code></a> = {});
 };
@@ -3932,6 +3969,7 @@ Benjamin Poulain for their contributions to the API specification.</p>
 <c- b>typedef</c-> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-record"><c- b>record</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a>, <a data-link-type="idl-name" href="#dictdef-input"><c- n>Input</c-></a>> <a href="#typedefdef-namedinputs"><code><c- g>NamedInputs</c-></code></a>;
 <c- b>typedef</c-> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-record"><c- b>record</c-></a>&lt;<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a>, <a data-link-type="idl-name" href="#dictdef-output"><c- n>Output</c-></a>> <a href="#typedefdef-namedoutputs"><code><c- g>NamedOutputs</c-></code></a>;
 
+[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext"><c- g>SecureContext</c-></a>, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->]
 <c- b>interface</c-> <a href="#compilation"><code><c- g>Compilation</c-></code></a> {
   <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name" href="#typedefdef-namedoutputs"><c- n>NamedOutputs</c-></a>> <a href="#dom-compilation-compute"><code><c- g>compute</c-></code></a>(<a data-link-type="idl-name" href="#typedefdef-namedinputs"><c- n>NamedInputs</c-></a> <a href="#dom-compilation-compute-inputs-outputs-inputs"><code><c- g>inputs</c-></code></a>, <c- b>optional</c-> <a data-link-type="idl-name" href="#typedefdef-namedoutputs"><c- n>NamedOutputs</c-></a> <a href="#dom-compilation-compute-inputs-outputs-outputs"><code><c- g>outputs</c-></code></a>);
 };


### PR DESCRIPTION
- Web NN API is to access the hardware acceleration for machine learning. So it is only need to be exposed in secure contexts. It means that this API is only available over HTTPS.
- removed "Models" from biblio because it isn't unused any more


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wonsuk73/webnn/pull/101.html" title="Last updated on Oct 13, 2020, 1:21 PM UTC (20dc95c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/101/d070638...wonsuk73:20dc95c.html" title="Last updated on Oct 13, 2020, 1:21 PM UTC (20dc95c)">Diff</a>