### PR TITLE
Add the initial CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,11 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: touch index.bs
+    - run: make online=1

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![build](https://github.com/webmachinelearning/webnn/workflows/build/badge.svg)](https://github.com/webmachinelearning/webnn/actions)
+
 Web Neural Network API
 =======
 


### PR DESCRIPTION
Add the bikeshield build as the initial CI (continuous integration). It would help us to detect the spec issue such as https://github.com/webmachinelearning/webnn/pull/100 and https://github.com/webmachinelearning/webnn/pull/101#discussion_r502984105 as early as possible. For example, it could report spec error as https://github.com/huningxin/webnn/runs/1239704785?check_suite_focus=true.

@anssiko @wchao1115 @pyu10055 @wonsuk73 , PTAL. Thanks!