### PR TITLE
Added extended attributes to Web IDL definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -181,12 +181,13 @@ API {#api}
 ## Navigator ## {#api-navigator}
 <script type=idl>
 partial interface Navigator {
-  readonly attribute ML ml;
+  [SecureContext] readonly attribute ML ml;
 };
 </script>
 
 ## ML ## {#api-ml}
 <script type=idl>
+[SecureContext, Exposed=Window]
 interface ML {
   NeuralNetworkContext getNeuralNetworkContext();
 };
@@ -220,6 +221,7 @@ dictionary OperandDescriptor {
 
 ## Operand ## {#api-operand}
 <script type=idl>
+[SecureContext, Exposed=Window]
 interface Operand {};
 </script>
 
@@ -228,6 +230,7 @@ interface Operand {};
 The {{NeuralNetworkContext}} interface represents a global state of neural network compute workload and execution processes.
 
 <script type=idl>
+[SecureContext, Exposed=Window]
 interface NeuralNetworkContext {
   ModelBuilder createModelBuilder();
 };
@@ -240,6 +243,7 @@ The {{ModelBuilder}} interface defines a set of operations as identified by the 
 <script type=idl>
 typedef record<DOMString, Operand> NamedOperands;
 
+[SecureContext, Exposed=Window]
 interface ModelBuilder {
   // Create an operand that represents a model input.
   Operand input(DOMString name, OperandDescriptor desc);
@@ -1162,6 +1166,7 @@ dictionary CompilationOptions {
   PowerPreference powerPreference = "default";
 };
 
+[SecureContext, Exposed=Window]
 interface Model {
   Promise<Compilation> compile(optional CompilationOptions options = {});
 };
@@ -1184,6 +1189,7 @@ dictionary Output {
 typedef record<DOMString, Input> NamedInputs;
 typedef record<DOMString, Output> NamedOutputs;
 
+[SecureContext, Exposed=Window]
 interface Compilation {
   Promise<NamedOutputs> compute(NamedInputs inputs, optional NamedOutputs outputs = {});
 };


### PR DESCRIPTION
- Web NN API is to access the hardware acceleration for machine learning. So it is only need to be exposed in secure contexts. It means that this API is only available over HTTPS.
- removed "Models" from biblio because it isn't unused any more


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wonsuk73/webnn/pull/115.html" title="Last updated on Oct 30, 2020, 5:32 AM UTC (25088bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/115/058a81a...wonsuk73:25088bd.html" title="Last updated on Oct 30, 2020, 5:32 AM UTC (25088bd)">Diff</a>