### PR TITLE
Fix the gru pseudo sample code

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -634,11 +634,13 @@ partial interface ModelBuilder {
         let slice = (slot == 1 || options.direction == "backward" ? steps - step - 1 : step);
         let cellInput = builder.squeeze(builder.slice(input, [slice, 0, 0], [1, -1, -1]), { axes: [0] });
 
-        let result = builder.gruCell(
-          cellInput, cellWeight[slot], cellRecurrentWeight[slot], 
-          cellHidden[slot], hiddenSize, { bias: cellBias[slot], 
-          recurrentBias: cellRecurrentBias[slot], resetAfter: options.resetAfter, 
-          layout: options.layout, activations: options.activations });
+        let result = builder.reshape(
+          builder.gruCell(
+            cellInput, cellWeight[slot], cellRecurrentWeight[slot],
+            cellHidden[slot], hiddenSize, { bias: cellBias[slot],
+            recurrentBias: cellRecurrentBias[slot], resetAfter: options.resetAfter,
+            layout: options.layout, activations: options.activations }),
+          [1, -1, hiddenSize]);
 
         cellOutput = (cellOutput ? builder.concat([cellOutput, result], 0) : result);
       }


### PR DESCRIPTION
It should reshape the 2-D output of gruCell to 3-D tensor.

The fix is verified by the webnn-polyfill gru implementation: https://github.com/huningxin/webnn-polyfill/blob/gru/src/nn/ops/gru.ts#L113


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/117.html" title="Last updated on Oct 31, 2020, 5:11 AM UTC (bcdb16b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/117/3dd5bbf...huningxin:bcdb16b.html" title="Last updated on Oct 31, 2020, 5:11 AM UTC (bcdb16b)">Diff</a>