### PR TITLE
Add the spec text and examples for MLGraph.compute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -30,6 +30,142 @@ urlPrefix: https://gpuweb.github.io/gpuweb/; spec: WEBGPU
         text: GPUTexture; url: texture-interface
 </pre>
 
+<pre class="link-defaults">
+spec:html;
+    type:interface; text:Navigator
+spec:webidl;
+    type:dfn; text:record
+</pre>
+
+<style>
+/* Make <dl> blocks more distinct from their surroundings. */
+dl:not(.switch) {
+    border-left: thin solid #f3e48c;
+    padding-left: .5em;
+}
+
+/* <p> by default has these margins. Update ul/ol/dl to match,
+ * since they are also put in places where paragraphs go. */
+p, ul, ol, dl {
+    margin: 1em 0;
+}
+
+/* Box for Valid Usage requirements. */
+div.validusage {
+    padding: .5em;
+    border: thin solid #88e !important;
+    border-radius: .5em;
+}
+
+/*
+ * Stylistic labels, for clarity of presentation of these blocks.
+ *
+ * NOTE: This text is non-accessible and non-selectable; surrounding
+ * text must also explain the context.
+ */
+.validusage {
+    position: relative;
+}
+.validusage::before {
+    font-weight: bold;
+    font-style: italic;
+    font-size: 130%;
+    color: rgba(0, 0, 0, 0.15);
+    color: var(--watermark-text);
+    position: absolute;
+    right: .3em;
+    top: -.1em;
+}
+.validusage::before {
+    content: "Valid Usage";
+}
+
+/*
+ * Ensure that argumentdef blocks don't overflow algorithm section borders. This is made far harder
+ * than it needs to be because the top-level W3C stylesheet has several @media + min-width variants
+ * that mark themselves as !important and then proceed to do the wrong thing.
+ */
+@media screen and (min-width: 78em) {
+    body:not(.toc-inline) .algorithm .overlarge {
+        margin-right: auto !important;
+    }
+}
+@media screen and (min-width: 90em) {
+    body:not(.toc-inline) .algorithm .overlarge {
+        margin-right: auto !important;
+    }
+}
+.algorithm .overlarge {
+    margin-right: auto !important;
+}
+
+/*
+ * The default algorithm style has a caption that doesn't suit this spec's
+ * formatting particularly well. Hide it.
+ */
+.algorithm .argumentdef {
+    margin-top: 0;
+}
+.algorithm .argumentdef>caption {
+    display: none;
+}
+
+/*
+ * Add vertical lines to demarcate multi-column cells.
+ */
+table.data td[colspan] {
+    border-left-style: dotted;
+    border-right-style: dotted;
+}
+
+table.data.no-colspan-center td[colspan],
+table.data.no-colspan-center th[colspan] {
+    text-align: unset;
+}
+
+table.data tr.row-continuation td,
+table.data tr.row-continuation th {
+    border-top: none;
+}
+
+/*
+ * Sticky table headers.
+ */
+.overlarge {
+    /* position: sticky doesn't work inside scrollable elements. */
+    overflow-x: unset;
+}
+thead.stickyheader th, th.stickyheader {
+    position: sticky;
+    top: 0;
+    background: #f8f8f8;
+    background: var(--stickyheader-background);
+}
+
+/*
+ * Darkmode colors
+ */
+:root {
+    --watermark-text: rgba(0, 0, 0, 15%);
+    --stickyheader-background: #f8f8f8;
+    --tint-red: rgba(255, 0, 0, 6%);
+    --tint-green: rgba(0, 255, 0, 10%);
+    --tint-blue: rgba(0, 0, 255, 5%);
+    --tint-purple: rgba(255, 0, 255, 5%);
+}
+@media (prefers-color-scheme:dark) {
+    :root {
+        --watermark-text: rgba(255, 255, 255, 25%);
+        --stickyheader-background: #181818;
+        --tint-red: rgba(255, 0, 0, 20%);
+        --tint-green: rgba(0, 255, 0, 18%);
+        --tint-blue: rgba(0, 130, 255, 24%);
+        --tint-purple: rgba(255, 0, 255, 22%);
+    }
+}
+
+</style>
+
 Introduction {#intro}
 =====================
 
@@ -1396,6 +1532,218 @@ interface MLGraph {
 };
 </script>
 
+{{Compilation}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="Compilation">
+    : <dfn>\[[inputOperands]]</dfn> of type [=record=]&lt;{{DOMString}}, {{OperandDescriptor}}&gt;.
+    ::
+        Maps the name of an input {{Operand}} to its {{OperandDescriptor}} for all input {{Operand}}s of the {{Model}} that this {{Compilation}} is compiled from.
+
+    : <dfn>\[[outputOperands]]</dfn> of type [=sequence=]&lt;{{DOMString}}&gt;.
+    ::
+        Contains the names of all output {{Operand}}s of the {{Model}} that this {{Compilation}} is compiled from.
+
+    : <dfn>\[[implementation]]</dfn>
+    ::
+        Underlying compilation implemenation provided by the User Agent.
+</dl>
+
+<dl dfn-type=method dfn-for=Compilation>
+    : <dfn>compute(inputs, outputs)</dfn>
+    ::
+        Schedules an asynchronous computation of the {{Compilation}} given {{NamedInputs}} and optional {{NamedOutputs}}. The returned {{Promise}} resolves when the computaton results in {{NamedOutputs}} are ready to be consumed.
+
+        <div algorithm=Compilation.compute>
+            **Called on:** {{Compilation}} |this|.
+
+            **Arguments:**
+            <pre class=argumentdef for="Compilation/compute(inputs, outputs)">
+                |inputs|: The given computation inputs of type {{NamedInputs}}. Specifies the input buffers and optional dimensions.
+                |outputs|: The optional given outputs of type {{NamedOutputs}}. Specifies the output names and pre-allocated buffers. Default to be an empty [=record=].
+            </pre>
+
+            **Returns:** {{Promise}}&lt;{{NamedOutputs}}&gt;
+
+            1. Let |promise| be [=a new promise=].
+            <!-- Validate inputs and outputs -->
+            1. If any of the following requirements are unmet, [=reject=] |promise| with a {{TypeError}} and stop.
+
+                <div class=validusage>
+                    1. For each |key| -> |value| of |inputs|:
+                        1. |this|.{{Compilation/[[inputOperands]]}}[|key|] must exist.
+                        1. Let |inputOperand| be |this|.{{Compilation/[[inputOperands]]}}[|key|].
+                        1. The |value|.{{Input/buffer}} of type {{ArrayBufferView}} must be compatible to |inputOperand|.{{OperandDescriptor/type}} according to [this table](#operandtype-arraybufferview-compatibility).
+                        1. If |value|.{{Input/dimensions}} was given, then:
+                            1. The size of |value|.{{Input/dimensions}} must be the same as the size of |inputOperand|.{{OperandDescriptor/dimensions}}.
+                            1. Let |i| be 0.
+                            1. While true:
+                                1. Let |dimension| be |value|.{{Input/dimensions}}[|i|].
+                                1. The value of |dimension| must be greater than 0.
+                                1. If the value of |inputOperand|.{{OperandDescriptor/dimensions}}[|i|] is greater than 0, then:
+                                    1. The value of |dimension| must be the same as the value of |inputOperand|.{{OperandDescriptor/dimensions}}[|i|].
+                                1. Set |i| to |i| + 1.
+                                1. If |i| equals to the size of |value|.{{Input/dimensions}}, then break.
+                        1. Otherwise:
+                            1. For each |dimension| of |inputOperand|.{{OperandDescriptor/dimensions}}:
+                                1. The value of |dimension| must be greater than 0.
+
+                    1. If |outputs| was not an empty [=record=], then:
+                        1. For each |key| -> |value| of |outputs|:
+                            1. |this|.{{Compilation/[[outputOperands]]}}[|key|] must exist.
+                            1. If |value|.{{Output/buffer}} was given, then:
+                                1. Let |outputOperand| be |this|.{{Compilation/[[outputOperands]]}}[|key|].
+                                1. The |value|.{{Output/buffer}} of type {{ArrayBufferView}} must be compatible to |outputOperand|.{{OperandDescriptor/type}} according to [this table](#operandtype-arraybufferview-compatibility).
+                </div>
+            <!-- Filter the required outputs -->
+            1. Let |requiredOutputNames| be a new [=ordered set=]&lt;{{DOMString}}&gt;.
+            1. If |outputs| was not an empty [=record=], then:
+                1. For each |key| -> |value| of |outputs|:
+                    1. Append |key| to |requiredOutputNames|.
+            1. Otherwise:
+                1. For each |key| -> |value| of |this|.{{Compilation/[[outputOperands]]}}:
+                    1. Append |key| to |requiredOutputNames|.
+            <!-- Copy the inputs -->
+            1. Let |copiedInputs| be a new {{NamedInputs}}.
+            1. For each |key| -> |value| of |inputs|:
+                1. Let |input| be a new {{Input}}.
+                1. Let |input|.{{Input/buffer}} be a new {{ArrayBufferView}} that has the same kind as |value|.{{Input/buffer}}'s.
+                1. Copy the bytes held by |value|.{{Input/buffer}} to |input|.{{Input/buffer}}.
+                1. Let |input|.{{Input/dimensions}} be a new [=sequence=]&lt;{{long}}&gt;.
+                1. Copy the values heold by |value|.{{Input/dimensions}} to |input|.{{Input/dimensions}}.
+                1. Set |copiedInputs|[key] to |input|.
+            <!-- Compute -->
+            1. Let |results| be a new {{NamedOutputs}}.
+            1. Let |remainingOutputNames| be a new [=ordered set=]&lt;{{DOMString}}&gt;.
+            1. For each |outputName| of |requiredOutputNames|:
+                1. Append |outputName| to |remainingOutputNames|.
+            1. For each |outputName| of |requiredOutputNames|:
+                1. Issue an asynchronous computation of |this|.{{Compilation/[[implementation]]}} for output whose name is |outputName| with given |copiedInputs|.
+                1. When the asynchronous computation is completed:
+                    1. If there is an error returned by |this|.{{Compilation/[[implementation]]}}, then:
+                        1. [=reject=] |promise| with an {{OperationError}} and stop.
+                    1. Otherwise:
+                      1. Let |outputDemisions| be a new [=sequence=]&lt;{{long}}&gt; that contains the dimensions returned by |this|.{{Compilation/[[implementation]]}} for |outputName|.
+                      1. Let |outputBuffer| be a new {{ArrayBufferView}} that holds the bytes returned by |this|.{{Compilation/[[implementation]]}} for |outputName|.
+                      1. Set |results|[|outputName|].{{Output/dimensions}} to |outputDemisions|.
+                      1. If |outputs|[|outputName|].{{Output/buffer}} was given, then:
+                          1. If the kind of |outputs|[|outputName|].{{Output/buffer}} is not the same as |outputBuffer|, then:
+                              1. [=reject=] |promise| with a {{TypeError}} and stop.
+                          1. If the length of |outputs|[|outputName|].{{Output/buffer}} is not the same as |outputBuffer|, then:
+                              1. [=reject=] |promise| with a {{TypeError}} and stop.
+                          1. Copy the bytes held by |outputBuffer| to |outputs|[|outputName|].{{Output/buffer}}.
+                      1. Otherwise:
+                          1. Let |buffer| be a new {{ArrayBufferView}} that has the same kind and length as |outputBuffer|.
+                          1. Copy the bytes held by |outputBuffer| to |buffer|.
+                          1. Set |results|[|outputName|].{{Output/buffer}} to |buffer|.
+                      1. Remove |outputName| from |remainingOutputNames|.
+                      1. If |remainingOutputNames| is empty, then:
+                          1. Resolve |promise| with |results|.
+            1. Return |promise|.
+        </div>
+</dl>
+
+### Examples ### {#compilation-examples}
+
+<div class="example">
+The following code showcases the computation with dynamic input dimensions.
+<pre highlight="js">
+const nn = navigator.ml.getNeuralNetworkContext();
+
+// Create a model with dynamic shaped inputs.
+const builder = nn.createModelBuilder();
+const descA = {type: 'float32', dimensions: [-1, 4]};
+const a = builder.input('a', descA);
+const descB = {type: 'float32', dimensions: [4, -1]};
+const b = builder.input('b', descB);
+const c = builder.matmul(a, b);
+const model = builder.createModel({c});
+
+const compiledModel = await model.compile();
+
+async function compute(shapeA, shapeB) {
+  const bufferA = new Float32Array(sizeOfShape(shapeA)).fill(0.5);
+  const bufferB = new Float32Array(sizeOfShape(shapeB)).fill(0.5);
+
+  // Specify the shape of inputs when computing.
+  const inputs = {
+    'a': {buffer: bufferA, dimensions: shapeA},
+    'b': {buffer: bufferB, dimensions: shapeB},
+  };
+  const outputs = await compiledModel.compute(inputs);
+  console.log(&#96;shape: [${outputs.c.dimensions}], values: ${outputs.c.buffer}&#96;);
+}
+
+await compute([3, 4], [4, 3]);
+await compute([4, 4], [4, 4]);
+await compute([5, 4], [4, 5]);
+</pre>
+</div>
+
+<div class="example">
+The following code showcases the computation with pre-allocated output buffers.
+<pre highlight="js">
+const nn = navigator.ml.getNeuralNetworkContext();
+
+// The following code multiplies matrix a [3, 4] with matrix b [4, 3]
+// into matrix c [3, 3].
+const builder = nn.createModelBuilder();
+const descA = {type: 'float32', dimensions: [3, 4]};
+const a = builder.input('a', descA);
+const descB = {type: 'float32', dimensions: [4, 3]};
+const bufferB = new Float32Array(sizeOfShape(descB.dimensions)).fill(0.5);
+const b = builder.constant(descB, bufferB);
+const c = builder.matmul(a, b);
+const model = builder.createModel({c});
+
+const compiledModel = await model.compile();
+const bufferA = new Float32Array(sizeOfShape(descA.dimensions)).fill(0.5);
+const inputs = {'a': {buffer: bufferA}};
+// Pre-allocate output buffer for c.
+const outputs = {'c': {buffer: new Float32Array(sizeOfShape([3, 3]))}};
+await compiledModel.compute(inputs, outputs);
+console.log(&#96;values: ${outputs.c.buffer}&#96;);
+</pre>
+</div>
+
+<div class="example">
+The following code showcases the computation with optional outputs.
+<pre highlight="js">
+const nn = navigator.ml.getNeuralNetworkContext();
+
+// Build a model with two outputs.
+const builder = nn.createModelBuilder();
+const descA = {type: 'float32', dimensions: [3, 4]};
+const a = builder.input('a', descA);
+const descB = {type: 'float32', dimensions: [4, 3]};
+const bufferB = new Float32Array(sizeOfShape(descB.dimensions)).fill(0.5);
+const b = builder.constant(descB, bufferB);
+const descC = {type: 'float32', dimensions: [3, 3]};
+const bufferC = new Float32Array(sizeOfShape(descC.dimensions)).fill(1);
+const c = builder.constant(descC, bufferC);
+const d = builder.matmul(a, b);
+const e = builder.add(d, c);
+const model = builder.createModel({d, e});
+
+const compiledModel = await model.compile();
+const bufferA = new Float32Array(sizeOfShape(descA.dimensions)).fill(0.5);
+const inputs = {'a': {buffer: bufferA}};
+
+// Compute both d and e.
+let outputs = await compiledModel.compute(inputs);
+console.log(&#96;outputs include ${Object.keys(outputs)}&#96;);
+
+// Compute d.
+outputs = await compiledModel.compute(inputs, {d});
+console.log(&#96;outputs include ${Object.keys(outputs)}&#96;);
+console.log(&#96;shape: [${outputs.d.dimensions}], values: ${outputs.d.buffer}&#96;);
+
+// Compute e.
+outputs = await compiledModel.compute(inputs, {e});
+console.log(&#96;outputs include ${Object.keys(outputs)}&#96;);
+console.log(&#96;shape: [${outputs.e.dimensions}], values: ${outputs.e.buffer}&#96;);
+</pre>
+</div>
+
 Examples {#examples}
 =====================
 
@@ -1481,6 +1829,35 @@ console.log('Output value: ' + outputs.output.data);
 // Output value: 2.25,2.25,2.25,2.25,2.25,2.25,2.25,2.25
 </pre>
 </div>
+
+# Appendices # {#appendices}
+
+## {{OperandType}} and {{ArrayBufferView}} compatibility ## {#operandtype-arraybufferview-compatibility}
+
+<table class='data'>
+    <thead class=stickyheader>
+        <tr>
+            <th>{{OperandType}}
+            <th>{{ArrayBufferView}}
+    </thead>
+    <tr>
+        <td>{{OperandType/float32}}
+        <td>{{Float32Array}}
+    <tr>
+        <td>{{OperandType/int32}}
+        <td>{{Int32Array}}
+    <tr>
+        <td>{{OperandType/uint32}}
+        <td>{{Uint32Array}}
+    <tr>
+        <td>{{OperandType/int8}}
+        <td>{{Int8Array}}
+    <tr>
+        <td>{{OperandType/uint8}}
+        <td>{{Uint8Array}}
+</table>
+
+Issue(webmachinelearning/webnn#127): clarify the usage of {{ArrayBufferView}} for {{OperandType/float16}}.
 
 <h2 id="acknowledgements">Acknowledgements</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -1566,7 +1566,7 @@ interface MLGraph {
 
             1. Let |promise| be [=a new promise=].
             <!-- Validate inputs and outputs -->
-            1. If any of the following requirements are unmet, [=reject=] |promise| with a {{TypeError}} and stop.
+            1. If any of the following requirements are unmet, then [=reject=] |promise| with a {{TypeError}} and stop.
 
                 <div class=validusage>
                     1. For each |key| -> |value| of |inputs|:
@@ -1622,22 +1622,19 @@ interface MLGraph {
                     1. If there is an error returned by |this|.{{Compilation/[[implementation]]}}, then:
                         1. [=reject=] |promise| with an {{OperationError}} and stop.
                     1. Otherwise:
-                      1. Let |outputDemisions| be a new [=sequence=]&lt;{{long}}&gt; that contains the dimensions returned by |this|.{{Compilation/[[implementation]]}} for |outputName|.
-                      1. Let |outputBuffer| be a new {{ArrayBufferView}} that holds the bytes returned by |this|.{{Compilation/[[implementation]]}} for |outputName|.
-                      1. Set |results|[|outputName|].{{Output/dimensions}} to |outputDemisions|.
-                      1. If |outputs|[|outputName|].{{Output/buffer}} was given, then:
-                          1. If the kind of |outputs|[|outputName|].{{Output/buffer}} is not the same as |outputBuffer|, then:
-                              1. [=reject=] |promise| with a {{TypeError}} and stop.
-                          1. If the length of |outputs|[|outputName|].{{Output/buffer}} is not the same as |outputBuffer|, then:
-                              1. [=reject=] |promise| with a {{TypeError}} and stop.
-                          1. Copy the bytes held by |outputBuffer| to |outputs|[|outputName|].{{Output/buffer}}.
-                      1. Otherwise:
-                          1. Let |buffer| be a new {{ArrayBufferView}} that has the same kind and length as |outputBuffer|.
-                          1. Copy the bytes held by |outputBuffer| to |buffer|.
-                          1. Set |results|[|outputName|].{{Output/buffer}} to |buffer|.
-                      1. Remove |outputName| from |remainingOutputNames|.
-                      1. If |remainingOutputNames| is empty, then:
-                          1. Resolve |promise| with |results|.
+                        1. Let |outputDemisions| be a new [=sequence=]&lt;{{long}}&gt; that contains the dimensions returned by |this|.{{Compilation/[[implementation]]}} for |outputName|.
+                        1. Let |outputBuffer| be a new {{ArrayBufferView}} that holds the bytes returned by |this|.{{Compilation/[[implementation]]}} for |outputName|.
+                        1. Set |results|[|outputName|].{{Output/dimensions}} to |outputDemisions|.
+                        1. If |outputs|[|outputName|].{{Output/buffer}} was given, then:
+                            1. If the kind of |outputs|[|outputName|].{{Output/buffer}} is not the same as |outputBuffer|, then [=reject=] |promise| with a {{TypeError}} and stop.
+                            1. If the length of |outputs|[|outputName|].{{Output/buffer}} is not the same as |outputBuffer|, then [=reject=] |promise| with a {{TypeError}} and stop.
+                            1. Copy the bytes held by |outputBuffer| to |outputs|[|outputName|].{{Output/buffer}}.
+                        1. Otherwise:
+                            1. Let |buffer| be a new {{ArrayBufferView}} that has the same kind and length as |outputBuffer|.
+                            1. Copy the bytes held by |outputBuffer| to |buffer|.
+                            1. Set |results|[|outputName|].{{Output/buffer}} to |buffer|.
+                        1. Remove |outputName| from |remainingOutputNames|.
+                        1. If |remainingOutputNames| is empty, then resolve |promise| with |results|.
             1. Return |promise|.
         </div>
 </dl>
@@ -1645,7 +1642,7 @@ interface MLGraph {
 ### Examples ### {#compilation-examples}
 
 <div class="example">
-The following code showcases the computation with dynamic input dimensions.
+The following code showcases the computation with dynamic input dimensions. Check out [a live version](https://webmachinelearning.github.io/webnn-samples/code/?example=dynamic_shape.js) of this example in WebNN Code Editor.
 <pre highlight="js">
 const nn = navigator.ml.getNeuralNetworkContext();
 
@@ -1680,7 +1677,7 @@ await compute([5, 4], [4, 5]);
 </div>
 
 <div class="example">
-The following code showcases the computation with pre-allocated output buffers.
+The following code showcases the computation with pre-allocated output buffers. Check out [a live version](https://webmachinelearning.github.io/webnn-samples/code/?example=preallocated_outputs.js) of this example in WebNN Code Editor.
 <pre highlight="js">
 const nn = navigator.ml.getNeuralNetworkContext();
 
@@ -1706,7 +1703,7 @@ console.log(&#96;values: ${outputs.c.buffer}&#96;);
 </div>
 
 <div class="example">
-The following code showcases the computation with optional outputs.
+The following code showcases the computation with optional outputs. Check out [a live version](https://webmachinelearning.github.io/webnn-samples/code/?example=optional_outputs.js) of this example in WebNN Code Editor.
 <pre highlight="js">
 const nn = navigator.ml.getNeuralNetworkContext();
 

--- a/index.bs
+++ b/index.bs
@@ -1751,20 +1751,18 @@ interface MLGraph {
 ### Examples ### {#compilation-examples}
 
 <div class="example">
-The following code showcases the computation with dynamic input dimensions. Check out [a live version](https://webmachinelearning.github.io/webnn-samples/code/?example=dynamic_shape.js) of this example in WebNN Code Editor.
+The following code showcases the computation with dynamic input dimensions.
 <pre highlight="js">
-const nn = navigator.ml.getNeuralNetworkContext();
+const context = navigator.ml.createContext();
 
-// Create a model with dynamic shaped inputs.
-const builder = nn.createModelBuilder();
+// Create a graph with dynamic shaped inputs.
+const builder = new MLGraphBuilder(context);
 const descA = {type: 'float32', dimensions: [-1, 4]};
 const a = builder.input('a', descA);
 const descB = {type: 'float32', dimensions: [4, -1]};
 const b = builder.input('b', descB);
 const c = builder.matmul(a, b);
-const model = builder.createModel({c});
-
-const compiledModel = await model.compile();
+const graph = await builder.build({c});
 
 async function compute(shapeA, shapeB) {
   const bufferA = new Float32Array(sizeOfShape(shapeA)).fill(0.5);
@@ -1772,11 +1770,11 @@ async function compute(shapeA, shapeB) {
 
   // Specify the shape of inputs when computing.
   const inputs = {
-    'a': {buffer: bufferA, dimensions: shapeA},
-    'b': {buffer: bufferB, dimensions: shapeB},
+    'a': {data: bufferA, dimensions: shapeA},
+    'b': {data: bufferB, dimensions: shapeB},
   };
-  const outputs = await compiledModel.compute(inputs);
-  console.log(&#96;shape: [${outputs.c.dimensions}], values: ${outputs.c.buffer}&#96;);
+  const outputs = await graph.compute(inputs);
+  console.log(&#96;shape: [${outputs.c.dimensions}], values: ${outputs.c.data}&#96;);
 }
 
 await compute([3, 4], [4, 3]);
@@ -1786,38 +1784,37 @@ await compute([5, 4], [4, 5]);
 </div>
 
 <div class="example">
-The following code showcases the computation with pre-allocated output buffers. Check out [a live version](https://webmachinelearning.github.io/webnn-samples/code/?example=preallocated_outputs.js) of this example in WebNN Code Editor.
+The following code showcases the computation with pre-allocated output buffers.
 <pre highlight="js">
-const nn = navigator.ml.getNeuralNetworkContext();
+const context = navigator.ml.createContext();
 
-// The following code multiplies matrix a [3, 4] with matrix b [4, 3]
-// into matrix c [3, 3].
-const builder = nn.createModelBuilder();
+// The following code multiplies matrix a of shape [3, 4] with matrix b of shape [4, 3]
+// into matrix c of shape [3, 3].
+const builder = new MLGraphBuilder(context);
 const descA = {type: 'float32', dimensions: [3, 4]};
 const a = builder.input('a', descA);
 const descB = {type: 'float32', dimensions: [4, 3]};
 const bufferB = new Float32Array(sizeOfShape(descB.dimensions)).fill(0.5);
 const b = builder.constant(descB, bufferB);
 const c = builder.matmul(a, b);
-const model = builder.createModel({c});
+const graph = await builder.build({c});
 
-const compiledModel = await model.compile();
 const bufferA = new Float32Array(sizeOfShape(descA.dimensions)).fill(0.5);
-const inputs = {'a': {buffer: bufferA}};
+const inputs = {'a': {data: bufferA}};
 // Pre-allocate output buffer for c.
-const outputs = {'c': {buffer: new Float32Array(sizeOfShape([3, 3]))}};
-await compiledModel.compute(inputs, outputs);
-console.log(&#96;values: ${outputs.c.buffer}&#96;);
+const outputs = {'c': {data: new Float32Array(sizeOfShape([3, 3]))}};
+await graph.compute(inputs, outputs);
+console.log(&#96;values: ${outputs.c.data}&#96;);
 </pre>
 </div>
 
 <div class="example">
-The following code showcases the computation with optional outputs. Check out [a live version](https://webmachinelearning.github.io/webnn-samples/code/?example=optional_outputs.js) of this example in WebNN Code Editor.
+The following code showcases the computation with optional outputs.
 <pre highlight="js">
-const nn = navigator.ml.getNeuralNetworkContext();
+const context = navigator.ml.createContext();
 
-// Build a model with two outputs.
-const builder = nn.createModelBuilder();
+// Build a graph with two outputs.
+const builder = new MLGraphBuilder(context);
 const descA = {type: 'float32', dimensions: [3, 4]};
 const a = builder.input('a', descA);
 const descB = {type: 'float32', dimensions: [4, 3]};
@@ -1828,25 +1825,24 @@ const bufferC = new Float32Array(sizeOfShape(descC.dimensions)).fill(1);
 const c = builder.constant(descC, bufferC);
 const d = builder.matmul(a, b);
 const e = builder.add(d, c);
-const model = builder.createModel({d, e});
+const graph = await builder.build({d, e});
 
-const compiledModel = await model.compile();
 const bufferA = new Float32Array(sizeOfShape(descA.dimensions)).fill(0.5);
-const inputs = {'a': {buffer: bufferA}};
+const inputs = {'a': {data: bufferA}};
 
 // Compute both d and e.
-let outputs = await compiledModel.compute(inputs);
+let outputs = await graph.compute(inputs);
 console.log(&#96;outputs include ${Object.keys(outputs)}&#96;);
 
 // Compute d.
-outputs = await compiledModel.compute(inputs, {d});
+outputs = await graph.compute(inputs, {d});
 console.log(&#96;outputs include ${Object.keys(outputs)}&#96;);
-console.log(&#96;shape: [${outputs.d.dimensions}], values: ${outputs.d.buffer}&#96;);
+console.log(&#96;shape: [${outputs.d.dimensions}], values: ${outputs.d.data}&#96;);
 
 // Compute e.
-outputs = await compiledModel.compute(inputs, {e});
+outputs = await graph.compute(inputs, {e});
 console.log(&#96;outputs include ${Object.keys(outputs)}&#96;);
-console.log(&#96;shape: [${outputs.e.dimensions}], values: ${outputs.e.buffer}&#96;);
+console.log(&#96;shape: [${outputs.e.dimensions}], values: ${outputs.e.data}&#96;);
 </pre>
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -35,6 +35,7 @@ spec:html;
     type:interface; text:Navigator
 spec:webidl;
     type:dfn; text:record
+    type:dfn; text:resolve
 </pre>
 
 <style>
@@ -56,6 +57,35 @@ div.validusage {
     border: thin solid #88e !important;
     border-radius: .5em;
 }
+/*
+ * If the Valid Usage requirements are the first child of a *-timeline block give it a larger top
+ * margin to prevent the block labels from overlapping.
+ */
+.content-timeline>.validusage:first-child,
+.device-timeline>.validusage:first-child,
+.queue-timeline>.validusage:first-child {
+    margin-top: 1.5em;
+}
+
+/*
+ * Boxes for steps that occur on a particular timeline.
+ */
+div.content-timeline, div.device-timeline, div.queue-timeline {
+    padding: .5em;
+    border-radius: .5em;
+}
+.content-timeline {
+    background: rgba(0, 255, 0, 0.05);
+    background: var(--tint-green);
+}
+.device-timeline {
+    background: rgba(255, 0, 0, 0.05);
+    background: var(--tint-red);
+}
+.queue-timeline {
+    background: rgba(255, 0, 255, 0.05);
+    background: var(--tint-purple);
+}
 
 /*
  * Stylistic labels, for clarity of presentation of these blocks.
@@ -63,10 +93,13 @@ div.validusage {
  * NOTE: This text is non-accessible and non-selectable; surrounding
  * text must also explain the context.
  */
-.validusage {
+.validusage, .content-timeline, .device-timeline, .queue-timeline {
     position: relative;
 }
-.validusage::before {
+.validusage::before,
+.content-timeline::before,
+.device-timeline::before,
+.queue-timeline::before {
     font-weight: bold;
     font-style: italic;
     font-size: 130%;
@@ -78,6 +111,15 @@ div.validusage {
 }
 .validusage::before {
     content: "Valid Usage";
+}
+.content-timeline::before {
+    content: "Content Timeline";
+}
+.device-timeline::before {
+    content: "Device Timeline";
+}
+.queue-timeline::before {
+    content: "Queue Timeline";
 }
 
 /*
@@ -326,6 +368,55 @@ so that the application loads the tiny model in the case of CPU-only devices.
 ### Operation Level Execution ### {#usecase-op-level-exec}
 
 A JavaScript ML framework is responsible for loading, interpreting and executing a ML model. During the model execution phase, the framework iterates through the operations of the model and executes each operation on the hardware device, like CPU, GPU or ML accelerator. To avoid the unnecessary data copying across devices, the framework selects the same device to execute the operations. For a compute intensive operation, such as convolution 2D or matrix multiplication, the framework uses WebNN API to execute it with the ML-specific acceleration available on that selected device.
+
+# Programming Model # {#programming-model}
+## Timelines ## {#programming-model-timelines}
+
+*This section is non-normative.*
+
+A computer system with a user agent at the front-end and ML device at the back-end
+has components working on different timelines in parallel:
+
+: <dfn dfn>Content timeline</dfn>
+:: Associated with the execution of the Web script.
+    It includes calling all methods described by this specification.
+
+    <div class=content-timeline>
+        Steps executed on the content timeline look like this.
+    </div>
+
+: <dfn dfn>Device timeline</dfn>
+:: Associated with the ML device operations
+    that are issued by the user agent.
+    It includes creation of ML devices and resources
+    and state objects, which are typically synchronous operations from the point
+    of view of the user agent part that controls the ML device,
+    but can live in a separate OS process.
+
+    <div class=device-timeline>
+        Steps executed on the device timeline look like this.
+    </div>
+
+: <dfn dfn>Queue timeline</dfn>
+:: Associated with the execution of operations on the compute units of the ML device.
+    It includes actual copy and compute jobs that run on the ML device.
+
+    <div class=queue-timeline>
+        Steps executed on the queue timeline look like this.
+    </div>
+
+In this specification, asynchronous operations are used when the result value
+depends on work that happens on any timeline other than the [=Content timeline=].
+They are represented by callbacks and promises in JavaScript.
+
+<div class="example">
+{{Compilation/compute()|Compilation.compute()}}:
+
+  1. User issues a compute request by calling {{Compilation/compute()|Compilation.compute()}} on the [=Content timeline=] and gets a promise in return.
+  2. User agent processes the compute request on the [=Device timeline=] by calling the OS ML API.
+  3. After the ML device operating on [=Queue timeline=] is done, the user agent makes the results ready to be consumed by user and [=resolves=] the promise.
+
+</div>
 
 API {#api}
 =====================
@@ -1551,18 +1642,18 @@ interface MLGraph {
 <dl dfn-type=method dfn-for=Compilation>
     : <dfn>compute(inputs, outputs)</dfn>
     ::
-        Schedules an asynchronous computation of the {{Compilation}} given {{NamedInputs}} and optional {{NamedOutputs}}. The returned {{Promise}} resolves when the computaton results in {{NamedOutputs}} are ready to be consumed.
+        Issue a compute request of the {{Compilation}} given {{NamedInputs}} and optional {{NamedOutputs}}. The returned {{Promise}} resolves when the results in {{NamedOutputs}} are ready to be consumed.
 
         <div algorithm=Compilation.compute>
             **Called on:** {{Compilation}} |this|.
 
             **Arguments:**
             <pre class=argumentdef for="Compilation/compute(inputs, outputs)">
-                |inputs|: The given computation inputs of type {{NamedInputs}}. Specifies the input buffers and optional dimensions.
-                |outputs|: The optional given outputs of type {{NamedOutputs}}. Specifies the output names and pre-allocated buffers. Default to be an empty [=record=].
+                |inputs|: a {{NamedInputs}}. The buffers and optional dimensions of inputs for the compute request.
+                |outputs|: an optional {{NamedOutputs}}. The names and pre-allocated buffers of required outputs for the compute request. Default to be an empty [=record=] which means that the compute request is for all outputs.
             </pre>
 
-            **Returns:** {{Promise}}&lt;{{NamedOutputs}}&gt;
+            **Returns:** {{Promise}}&lt;{{NamedOutputs}}&gt;. The dimensions and buffers of outputs returned by the compute request.
 
             1. Let |promise| be [=a new promise=].
             <!-- Validate inputs and outputs -->
@@ -1572,69 +1663,78 @@ interface MLGraph {
                     1. For each |key| -> |value| of |inputs|:
                         1. |this|.{{Compilation/[[inputOperands]]}}[|key|] must exist.
                         1. Let |inputOperand| be |this|.{{Compilation/[[inputOperands]]}}[|key|].
-                        1. The |value|.{{Input/buffer}} of type {{ArrayBufferView}} must be compatible to |inputOperand|.{{OperandDescriptor/type}} according to [this table](#operandtype-arraybufferview-compatibility).
+                        1. The kind of |value|.{{Input/buffer}} must be compatible to |inputOperand|.{{OperandDescriptor/type}} according to [this table](#appendices-operandtype-arraybufferview-compatibility).
                         1. If |value|.{{Input/dimensions}} was given, then:
-                            1. The size of |value|.{{Input/dimensions}} must be the same as the size of |inputOperand|.{{OperandDescriptor/dimensions}}.
+                            1. The length of |value|.{{Input/dimensions}} must be the same as the length of |inputOperand|.{{OperandDescriptor/dimensions}}.
                             1. Let |i| be 0.
                             1. While true:
                                 1. Let |dimension| be |value|.{{Input/dimensions}}[|i|].
-                                1. The value of |dimension| must be greater than 0.
-                                1. If the value of |inputOperand|.{{OperandDescriptor/dimensions}}[|i|] is greater than 0, then:
-                                    1. The value of |dimension| must be the same as the value of |inputOperand|.{{OperandDescriptor/dimensions}}[|i|].
+                                1. |dimension| must be greater than 0.
+                                1. If |inputOperand|.{{OperandDescriptor/dimensions}}[|i|] is greater than 0, then |dimension| must be equal to |inputOperand|.{{OperandDescriptor/dimensions}}[|i|].
                                 1. Set |i| to |i| + 1.
-                                1. If |i| equals to the size of |value|.{{Input/dimensions}}, then break.
-                        1. Otherwise:
+                                1. If |i| if equal to the length of |value|.{{Input/dimensions}}, then break.
+                        1. Else:
                             1. For each |dimension| of |inputOperand|.{{OperandDescriptor/dimensions}}:
                                 1. The value of |dimension| must be greater than 0.
 
                     1. If |outputs| was not an empty [=record=], then:
                         1. For each |key| -> |value| of |outputs|:
                             1. |this|.{{Compilation/[[outputOperands]]}}[|key|] must exist.
-                            1. If |value|.{{Output/buffer}} was given, then:
-                                1. Let |outputOperand| be |this|.{{Compilation/[[outputOperands]]}}[|key|].
-                                1. The |value|.{{Output/buffer}} of type {{ArrayBufferView}} must be compatible to |outputOperand|.{{OperandDescriptor/type}} according to [this table](#operandtype-arraybufferview-compatibility).
+                            1. If |value|.{{Output/buffer}} was given, then the kind of |value|.{{Output/buffer}} must be compatible to |this|.{{Compilation/[[outputOperands]]}}[|key|] according to [this table](#appendices-operandtype-arraybufferview-compatibility).
                 </div>
             <!-- Filter the required outputs -->
             1. Let |requiredOutputNames| be a new [=ordered set=]&lt;{{DOMString}}&gt;.
             1. If |outputs| was not an empty [=record=], then:
                 1. For each |key| -> |value| of |outputs|:
                     1. Append |key| to |requiredOutputNames|.
-            1. Otherwise:
+            1. Else:
                 1. For each |key| -> |value| of |this|.{{Compilation/[[outputOperands]]}}:
                     1. Append |key| to |requiredOutputNames|.
             <!-- Copy the inputs -->
             1. Let |copiedInputs| be a new {{NamedInputs}}.
             1. For each |key| -> |value| of |inputs|:
-                1. Let |input| be a new {{Input}}.
-                1. Let |input|.{{Input/buffer}} be a new {{ArrayBufferView}} that has the same kind as |value|.{{Input/buffer}}'s.
-                1. Copy the bytes held by |value|.{{Input/buffer}} to |input|.{{Input/buffer}}.
-                1. Let |input|.{{Input/dimensions}} be a new [=sequence=]&lt;{{long}}&gt;.
-                1. Copy the values heold by |value|.{{Input/dimensions}} to |input|.{{Input/dimensions}}.
-                1. Set |copiedInputs|[key] to |input|.
+                1. Let |copyiedInput| be a new {{Input}}.
+                1. Let |copyiedInput|.{{Input/buffer}} be a new {{ArrayBufferView}} that has the same kind and length as |value|.{{Input/buffer}}'s.
+                1. Set the content of |copyiedInput|.{{Input/buffer}} to the content of |value|.{{Input/buffer}}.
+                1. Let |copyiedInput|.{{Input/dimensions}} be a new [=sequence=]&lt;{{long}}&gt; that has the same length of |value|.{{Input/dimensions}}'s.
+                1. Set the content of |copyiedInput|.{{Input/dimensions}} to the content of |value|.{{Input/dimensions}}.
+                1. Set |copiedInputs|[key] to |copyiedInput|.
             <!-- Compute -->
             1. Let |results| be a new {{NamedOutputs}}.
             1. Let |remainingOutputNames| be a new [=ordered set=]&lt;{{DOMString}}&gt;.
-            1. For each |outputName| of |requiredOutputNames|:
-                1. Append |outputName| to |remainingOutputNames|.
-            1. For each |outputName| of |requiredOutputNames|:
-                1. Issue an asynchronous computation of |this|.{{Compilation/[[implementation]]}} for output whose name is |outputName| with given |copiedInputs|.
-                1. When the asynchronous computation is completed:
-                    1. If there is an error returned by |this|.{{Compilation/[[implementation]]}}, then:
-                        1. [=reject=] |promise| with an {{OperationError}} and stop.
-                    1. Otherwise:
-                        1. Let |outputDemisions| be a new [=sequence=]&lt;{{long}}&gt; that contains the dimensions returned by |this|.{{Compilation/[[implementation]]}} for |outputName|.
-                        1. Let |outputBuffer| be a new {{ArrayBufferView}} that holds the bytes returned by |this|.{{Compilation/[[implementation]]}} for |outputName|.
-                        1. Set |results|[|outputName|].{{Output/dimensions}} to |outputDemisions|.
-                        1. If |outputs|[|outputName|].{{Output/buffer}} was given, then:
-                            1. If the kind of |outputs|[|outputName|].{{Output/buffer}} is not the same as |outputBuffer|, then [=reject=] |promise| with a {{TypeError}} and stop.
-                            1. If the length of |outputs|[|outputName|].{{Output/buffer}} is not the same as |outputBuffer|, then [=reject=] |promise| with a {{TypeError}} and stop.
-                            1. Copy the bytes held by |outputBuffer| to |outputs|[|outputName|].{{Output/buffer}}.
-                        1. Otherwise:
-                            1. Let |buffer| be a new {{ArrayBufferView}} that has the same kind and length as |outputBuffer|.
-                            1. Copy the bytes held by |outputBuffer| to |buffer|.
-                            1. Set |results|[|outputName|].{{Output/buffer}} to |buffer|.
-                        1. Remove |outputName| from |remainingOutputNames|.
-                        1. If |remainingOutputNames| is empty, then resolve |promise| with |results|.
+            1. Set the content of |remainingOutputNames| to the content of |requiredOutputNames|.
+            1. Issue the following steps on the [=Device timeline=] of |this|.{{Compilation/[[implementation]]}}:
+                <div class=device-timeline>
+                    1. For each |outputName| of |requiredOutputNames|:
+                        1. Issue a compute request of |this|.{{Compilation/[[implementation]]}} for output whose name is |outputName| with given |copiedInputs|.
+                        1. When the compute request is completed, issue the following steps on the appropriate [=Queue timeline=]:
+                            <div class=queue-timeline>
+                                1. If there is an error returned by |this|.{{Compilation/[[implementation]]}}, then:
+                                    1. [=reject=] |promise| with an {{OperationError}} and stop.
+                                1. Else:
+                                    1. Let |outputRank| be a {{unsigned long}}.
+                                    1. Set |outputRank| to the rank of output tensor returned by |this|.{{Compilation/[[implementation]]}}.
+                                    1. Let |outputDemisions| be a new [=sequence=]&lt;{{long}}&gt; of size |outputRank|.
+                                    1. Let |i| be 0.
+                                    1. Let |outputSize| to 1.
+                                    1. While true:
+                                        1. Set |outputDimensions|[|i|] to the dimension at |i|th axis of output tensor returned by |this|.{{Compilation/[[implementation]]}}.
+                                        1. Set |outputSize| to |outputSize| * |outputDimensions|[|i|].
+                                        1. Set |i| to |i| + 1.
+                                        1. If |i| is equal to |outputRank|, then break.
+                                    1. Set |results|[|outputName|].{{Output/dimensions}} to |outputDemisions|.
+                                    1. If |outputs|[|outputName|].{{Output/buffer}} was given, then:
+                                        1. If the kind of |outputs|[|outputName|].{{Output/buffer}} is not compatible to output tensor according to [this table](#appendices-operandtype-arraybufferview-compatibility), then [=reject=] |promise| with a {{TypeError}} and stop.
+                                        1. If the length of |outputs|[|outputName|].{{Output/buffer}} is less than |outputSize|, then [=reject=] |promise| with a {{TypeError}} and stop.
+                                        1. Set the content of |outputs|[|outputName|].{{Output/buffer}} to the content of output tensor returned by |this|.{{Compilation/[[implementation]]}}.
+                                    1. Else:
+                                        1. Let |results|[|outputName|].{{Output/buffer}} be a new {{ArrayBufferView}} of size |outputSize| and  kind that is compatible to output tensor according to [this table](#appendices-operandtype-arraybufferview-compatibility).
+                                        1. Set the content of |results|[|outputName|].{{Output/buffer}} to the content of output tensor returned by |this|.{{Compilation/[[implementation]]}}.
+                                    1. Remove |outputName| from |remainingOutputNames|.
+                                    1. If |remainingOutputNames| is empty, then resolve |promise| with |results| and stop.
+                            </div>
+                </div>
+
             1. Return |promise|.
         </div>
 </dl>
@@ -1829,7 +1929,7 @@ console.log('Output value: ' + outputs.output.data);
 
 # Appendices # {#appendices}
 
-## {{OperandType}} and {{ArrayBufferView}} compatibility ## {#operandtype-arraybufferview-compatibility}
+## {{OperandType}} and {{ArrayBufferView}} compatibility ## {#appendices-operandtype-arraybufferview-compatibility}
 
 <table class='data'>
     <thead class=stickyheader>

--- a/index.bs
+++ b/index.bs
@@ -410,9 +410,9 @@ depends on work that happens on any timeline other than the [=Content timeline=]
 They are represented by callbacks and promises in JavaScript.
 
 <div class="example">
-{{Compilation/compute()|Compilation.compute()}}:
+{{MLGraph/compute()|MLGraph.compute()}}:
 
-  1. User issues a compute request by calling {{Compilation/compute()|Compilation.compute()}} on the [=Content timeline=] and gets a promise in return.
+  1. User issues a compute request by calling {{MLGraph/compute()|MLGraph.compute()}} on the [=Content timeline=] and gets a promise in return.
   2. User agent processes the compute request on the [=Device timeline=] by calling the OS ML API.
   3. After the ML device operating on [=Queue timeline=] is done, the user agent makes the results ready to be consumed by user and [=resolves=] the promise.
 
@@ -1623,37 +1623,37 @@ interface MLGraph {
 };
 </script>
 
-{{Compilation}} has the following internal slots:
+{{MLGraph}} has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="Compilation">
-    : <dfn>\[[inputOperands]]</dfn> of type [=record=]&lt;{{DOMString}}, {{OperandDescriptor}}&gt;.
+<dl dfn-type=attribute dfn-for="MLGraph">
+    : <dfn>\[[inputOperands]]</dfn> of type [=record=]&lt;{{DOMString}}, {{MLOperandDescriptor}}&gt;
     ::
-        Maps the name of an input {{Operand}} to its {{OperandDescriptor}} for all input {{Operand}}s of the {{Model}} that this {{Compilation}} is compiled from.
+        Maps the name of an input {{MLOperand}} to its {{MLOperandDescriptor}} for all input {{MLOperand}}s of this {{MLGraph}}.
 
-    : <dfn>\[[outputOperands]]</dfn> of type [=sequence=]&lt;{{DOMString}}&gt;.
+    : <dfn>\[[outputOperands]]</dfn> of type [=sequence=]&lt;{{DOMString}}&gt;
     ::
-        Contains the names of all output {{Operand}}s of the {{Model}} that this {{Compilation}} is compiled from.
+        Contains the names of all output {{MLOperand}}s of this {{MLGraph}}.
 
     : <dfn>\[[implementation]]</dfn>
     ::
         Underlying compilation implemenation provided by the User Agent.
 </dl>
 
-<dl dfn-type=method dfn-for=Compilation>
+<dl dfn-type=method dfn-for=MLGraph>
     : <dfn>compute(inputs, outputs)</dfn>
     ::
-        Issue a compute request of the {{Compilation}} given {{NamedInputs}} and optional {{NamedOutputs}}. The returned {{Promise}} resolves when the results in {{NamedOutputs}} are ready to be consumed.
+        Issue a compute request of the {{MLGraph}} given {{MLNamedInputs}} and optional {{MLNamedOutputs}}. The returned {{Promise}} resolves when the results in {{MLNamedOutputs}} are ready to be consumed.
 
-        <div algorithm=Compilation.compute>
-            **Called on:** {{Compilation}} |this|.
+        <div algorithm=MLGraph.compute>
+            **Called on:** {{MLGraph}} |this|.
 
             **Arguments:**
-            <pre class=argumentdef for="Compilation/compute(inputs, outputs)">
-                |inputs|: a {{NamedInputs}}. The buffers and optional dimensions of inputs for the compute request.
-                |outputs|: an optional {{NamedOutputs}}. The names and pre-allocated buffers of required outputs for the compute request. Default to be an empty [=record=] which means that the compute request is for all outputs.
+            <pre class=argumentdef for="MLGraph/compute(inputs, outputs)">
+                |inputs|: a {{MLNamedInputs}}. The buffers and optional dimensions of inputs for the compute request.
+                |outputs|: an optional {{MLNamedOutputs}}. The names and pre-allocated buffers of required outputs for the compute request. Default to be an empty [=record=] which means that the compute request is for all outputs.
             </pre>
 
-            **Returns:** {{Promise}}&lt;{{NamedOutputs}}&gt;. The dimensions and buffers of outputs returned by the compute request.
+            **Returns:** {{Promise}}&lt;{{MLNamedOutputs}}&gt;. The dimensions and buffers of outputs returned by the compute request.
 
             1. Let |promise| be [=a new promise=].
             <!-- Validate inputs and outputs -->
@@ -1661,26 +1661,26 @@ interface MLGraph {
 
                 <div class=validusage>
                     1. For each |key| -> |value| of |inputs|:
-                        1. |this|.{{Compilation/[[inputOperands]]}}[|key|] must exist.
-                        1. Let |inputOperand| be |this|.{{Compilation/[[inputOperands]]}}[|key|].
-                        1. The kind of |value|.{{Input/buffer}} must be compatible to |inputOperand|.{{OperandDescriptor/type}} according to [this table](#appendices-operandtype-arraybufferview-compatibility).
-                        1. If |value|.{{Input/dimensions}} was given, then:
-                            1. The length of |value|.{{Input/dimensions}} must be the same as the length of |inputOperand|.{{OperandDescriptor/dimensions}}.
+                        1. |this|.{{MLGraph/[[inputOperands]]}}[|key|] must exist.
+                        1. Let |inputOperand| be |this|.{{MLGraph/[[inputOperands]]}}[|key|].
+                        1. The kind of |value|.{{MLInput/data}} must be compatible to |inputOperand|.{{MLOperandDescriptor/type}} according to [this table](#appendices-mloperandtype-arraybufferview-compatibility).
+                        1. If |value|.{{MLInput/dimensions}} was given, then:
+                            1. The length of |value|.{{MLInput/dimensions}} must be the same as the length of |inputOperand|.{{MLOperandDescriptor/dimensions}}.
                             1. Let |i| be 0.
                             1. While true:
-                                1. Let |dimension| be |value|.{{Input/dimensions}}[|i|].
+                                1. Let |dimension| be |value|.{{MLInput/dimensions}}[|i|].
                                 1. |dimension| must be greater than 0.
-                                1. If |inputOperand|.{{OperandDescriptor/dimensions}}[|i|] is greater than 0, then |dimension| must be equal to |inputOperand|.{{OperandDescriptor/dimensions}}[|i|].
+                                1. If |inputOperand|.{{MLOperandDescriptor/dimensions}}[|i|] is greater than 0, then |dimension| must be equal to |inputOperand|.{{MLOperandDescriptor/dimensions}}[|i|].
                                 1. Set |i| to |i| + 1.
-                                1. If |i| if equal to the length of |value|.{{Input/dimensions}}, then break.
+                                1. If |i| if equal to the length of |value|.{{MLInput/dimensions}}, then break.
                         1. Else:
-                            1. For each |dimension| of |inputOperand|.{{OperandDescriptor/dimensions}}:
+                            1. For each |dimension| of |inputOperand|.{{MLOperandDescriptor/dimensions}}:
                                 1. The value of |dimension| must be greater than 0.
 
                     1. If |outputs| was not an empty [=record=], then:
                         1. For each |key| -> |value| of |outputs|:
-                            1. |this|.{{Compilation/[[outputOperands]]}}[|key|] must exist.
-                            1. If |value|.{{Output/buffer}} was given, then the kind of |value|.{{Output/buffer}} must be compatible to |this|.{{Compilation/[[outputOperands]]}}[|key|] according to [this table](#appendices-operandtype-arraybufferview-compatibility).
+                            1. |this|.{{MLGraph/[[outputOperands]]}}[|key|] must exist.
+                            1. If |value|.{{MLOutput/data}} was given, then the kind of |value|.{{MLOutput/data}} must be compatible to |this|.{{MLGraph/[[outputOperands]]}}[|key|] according to [this table](#appendices-mloperandtype-arraybufferview-compatibility).
                 </div>
             <!-- Filter the required outputs -->
             1. Let |requiredOutputNames| be a new [=ordered set=]&lt;{{DOMString}}&gt;.
@@ -1688,48 +1688,48 @@ interface MLGraph {
                 1. For each |key| -> |value| of |outputs|:
                     1. Append |key| to |requiredOutputNames|.
             1. Else:
-                1. For each |key| -> |value| of |this|.{{Compilation/[[outputOperands]]}}:
+                1. For each |key| -> |value| of |this|.{{MLGraph/[[outputOperands]]}}:
                     1. Append |key| to |requiredOutputNames|.
             <!-- Copy the inputs -->
-            1. Let |copiedInputs| be a new {{NamedInputs}}.
+            1. Let |copiedInputs| be a new {{MLNamedInputs}}.
             1. For each |key| -> |value| of |inputs|:
-                1. Let |copyiedInput| be a new {{Input}}.
-                1. Let |copyiedInput|.{{Input/buffer}} be a new {{ArrayBufferView}} that has the same kind and length as |value|.{{Input/buffer}}'s.
-                1. Set the content of |copyiedInput|.{{Input/buffer}} to the content of |value|.{{Input/buffer}}.
-                1. Let |copyiedInput|.{{Input/dimensions}} be a new [=sequence=]&lt;{{long}}&gt; that has the same length of |value|.{{Input/dimensions}}'s.
-                1. Set the content of |copyiedInput|.{{Input/dimensions}} to the content of |value|.{{Input/dimensions}}.
+                1. Let |copyiedInput| be a new {{MLInput}}.
+                1. Let |copyiedInput|.{{MLInput/data}} be a new {{ArrayBufferView}} that has the same kind and length as |value|.{{MLInput/data}}'s.
+                1. Set the content of |copyiedInput|.{{MLInput/data}} to the content of |value|.{{MLInput/data}}.
+                1. Let |copyiedInput|.{{MLInput/dimensions}} be a new [=sequence=]&lt;{{long}}&gt; that has the same length of |value|.{{MLInput/dimensions}}'s.
+                1. Set the content of |copyiedInput|.{{MLInput/dimensions}} to the content of |value|.{{MLInput/dimensions}}.
                 1. Set |copiedInputs|[key] to |copyiedInput|.
             <!-- Compute -->
-            1. Let |results| be a new {{NamedOutputs}}.
+            1. Let |results| be a new {{MLNamedOutputs}}.
             1. Let |remainingOutputNames| be a new [=ordered set=]&lt;{{DOMString}}&gt;.
             1. Set the content of |remainingOutputNames| to the content of |requiredOutputNames|.
-            1. Issue the following steps on the [=Device timeline=] of |this|.{{Compilation/[[implementation]]}}:
+            1. Issue the following steps on the [=Device timeline=] of |this|.{{MLGraph/[[implementation]]}}:
                 <div class=device-timeline>
                     1. For each |outputName| of |requiredOutputNames|:
-                        1. Issue a compute request of |this|.{{Compilation/[[implementation]]}} for output whose name is |outputName| with given |copiedInputs|.
+                        1. Issue a compute request of |this|.{{MLGraph/[[implementation]]}} for output whose name is |outputName| with given |copiedInputs|.
                         1. When the compute request is completed, issue the following steps on the appropriate [=Queue timeline=]:
                             <div class=queue-timeline>
-                                1. If there is an error returned by |this|.{{Compilation/[[implementation]]}}, then:
+                                1. If there is an error returned by |this|.{{MLGraph/[[implementation]]}}, then:
                                     1. [=reject=] |promise| with an {{OperationError}} and stop.
                                 1. Else:
                                     1. Let |outputRank| be a {{unsigned long}}.
-                                    1. Set |outputRank| to the rank of output tensor returned by |this|.{{Compilation/[[implementation]]}}.
+                                    1. Set |outputRank| to the rank of output tensor returned by |this|.{{MLGraph/[[implementation]]}}.
                                     1. Let |outputDemisions| be a new [=sequence=]&lt;{{long}}&gt; of size |outputRank|.
                                     1. Let |i| be 0.
                                     1. Let |outputSize| to 1.
                                     1. While true:
-                                        1. Set |outputDimensions|[|i|] to the dimension at |i|th axis of output tensor returned by |this|.{{Compilation/[[implementation]]}}.
+                                        1. Set |outputDimensions|[|i|] to the dimension at |i|th axis of output tensor returned by |this|.{{MLGraph/[[implementation]]}}.
                                         1. Set |outputSize| to |outputSize| * |outputDimensions|[|i|].
                                         1. Set |i| to |i| + 1.
                                         1. If |i| is equal to |outputRank|, then break.
-                                    1. Set |results|[|outputName|].{{Output/dimensions}} to |outputDemisions|.
-                                    1. If |outputs|[|outputName|].{{Output/buffer}} was given, then:
-                                        1. If the kind of |outputs|[|outputName|].{{Output/buffer}} is not compatible to output tensor according to [this table](#appendices-operandtype-arraybufferview-compatibility), then [=reject=] |promise| with a {{TypeError}} and stop.
-                                        1. If the length of |outputs|[|outputName|].{{Output/buffer}} is less than |outputSize|, then [=reject=] |promise| with a {{TypeError}} and stop.
-                                        1. Set the content of |outputs|[|outputName|].{{Output/buffer}} to the content of output tensor returned by |this|.{{Compilation/[[implementation]]}}.
+                                    1. Set |results|[|outputName|].{{MLOutput/dimensions}} to |outputDemisions|.
+                                    1. If |outputs|[|outputName|].{{MLOutput/data}} was given, then:
+                                        1. If the kind of |outputs|[|outputName|].{{MLOutput/data}} is not compatible to output tensor according to [this table](#appendices-mloperandtype-arraybufferview-compatibility), then [=reject=] |promise| with a {{TypeError}} and stop.
+                                        1. If the length of |outputs|[|outputName|].{{MLOutput/data}} is less than |outputSize|, then [=reject=] |promise| with a {{TypeError}} and stop.
+                                        1. Set the content of |outputs|[|outputName|].{{MLOutput/data}} to the content of output tensor returned by |this|.{{MLGraph/[[implementation]]}}.
                                     1. Else:
-                                        1. Let |results|[|outputName|].{{Output/buffer}} be a new {{ArrayBufferView}} of size |outputSize| and  kind that is compatible to output tensor according to [this table](#appendices-operandtype-arraybufferview-compatibility).
-                                        1. Set the content of |results|[|outputName|].{{Output/buffer}} to the content of output tensor returned by |this|.{{Compilation/[[implementation]]}}.
+                                        1. Let |results|[|outputName|].{{MLOutput/data}} be a new {{ArrayBufferView}} of size |outputSize| and  kind that is compatible to output tensor according to [this table](#appendices-mloperandtype-arraybufferview-compatibility).
+                                        1. Set the content of |results|[|outputName|].{{MLOutput/data}} to the content of output tensor returned by |this|.{{MLGraph/[[implementation]]}}.
                                     1. Remove |outputName| from |remainingOutputNames|.
                                     1. If |remainingOutputNames| is empty, then resolve |promise| with |results| and stop.
                             </div>
@@ -1929,32 +1929,32 @@ console.log('Output value: ' + outputs.output.data);
 
 # Appendices # {#appendices}
 
-## {{OperandType}} and {{ArrayBufferView}} compatibility ## {#appendices-operandtype-arraybufferview-compatibility}
+## {{MLOperandType}} and {{ArrayBufferView}} compatibility ## {#appendices-mloperandtype-arraybufferview-compatibility}
 
 <table class='data'>
     <thead class=stickyheader>
         <tr>
-            <th>{{OperandType}}
+            <th>{{MLOperandType}}
             <th>{{ArrayBufferView}}
     </thead>
     <tr>
-        <td>{{OperandType/float32}}
+        <td>{{MLOperandType/float32}}
         <td>{{Float32Array}}
     <tr>
-        <td>{{OperandType/int32}}
+        <td>{{MLOperandType/int32}}
         <td>{{Int32Array}}
     <tr>
-        <td>{{OperandType/uint32}}
+        <td>{{MLOperandType/uint32}}
         <td>{{Uint32Array}}
     <tr>
-        <td>{{OperandType/int8}}
+        <td>{{MLOperandType/int8}}
         <td>{{Int8Array}}
     <tr>
-        <td>{{OperandType/uint8}}
+        <td>{{MLOperandType/uint8}}
         <td>{{Uint8Array}}
 </table>
 
-Issue(webmachinelearning/webnn#127): clarify the usage of {{ArrayBufferView}} for {{OperandType/float16}}.
+Issue(webmachinelearning/webnn#127): clarify the usage of {{ArrayBufferView}} for {{MLOperandType/float16}}.
 
 <h2 id="acknowledgements">Acknowledgements</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -1626,6 +1626,10 @@ interface MLGraph {
 {{MLGraph}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="MLGraph">
+    : <dfn>\[[context]]</dfn> of type {{MLContext}}
+    ::
+        The context of type {{MLContext}} associated with this {{MLGraph}}.
+
     : <dfn>\[[inputOperands]]</dfn> of type [=record=]&lt;{{DOMString}}, {{MLOperandDescriptor}}&gt;
     ::
         Maps the name of an input {{MLOperand}} to its {{MLOperandDescriptor}} for all input {{MLOperand}}s of this {{MLGraph}}.
@@ -1636,7 +1640,7 @@ interface MLGraph {
 
     : <dfn>\[[implementation]]</dfn>
     ::
-        Underlying compilation implemenation provided by the User Agent.
+        The underlying implemenation provided by the User Agent.
 </dl>
 
 <dl dfn-type=method dfn-for=MLGraph>
@@ -1649,11 +1653,11 @@ interface MLGraph {
 
             **Arguments:**
             <pre class=argumentdef for="MLGraph/compute(inputs, outputs)">
-                |inputs|: a {{MLNamedInputs}}. The buffers and optional dimensions of inputs for the compute request.
-                |outputs|: an optional {{MLNamedOutputs}}. The names and pre-allocated buffers of required outputs for the compute request. Default to be an empty [=record=] which means that the compute request is for all outputs.
+                |inputs|: a {{MLNamedInputs}}. The data and optional dimensions of inputs for the compute request.
+                |outputs|: an optional {{MLNamedOutputs}}. The names and pre-allocated resources of required outputs for the compute request. Default to be an empty [=record=] which means that the compute request is for all outputs.
             </pre>
 
-            **Returns:** {{Promise}}&lt;{{MLNamedOutputs}}&gt;. The dimensions and buffers of outputs returned by the compute request.
+            **Returns:** {{Promise}}&lt;{{MLNamedOutputs}}&gt;. The dimensions and data of outputs returned by the compute request.
 
             1. Let |promise| be [=a new promise=].
             <!-- Validate inputs and outputs -->
@@ -1663,7 +1667,8 @@ interface MLGraph {
                     1. For each |key| -> |value| of |inputs|:
                         1. |this|.{{MLGraph/[[inputOperands]]}}[|key|] must exist.
                         1. Let |inputOperand| be |this|.{{MLGraph/[[inputOperands]]}}[|key|].
-                        1. The kind of |value|.{{MLInput/data}} must be compatible to |inputOperand|.{{MLOperandDescriptor/type}} according to [this table](#appendices-mloperandtype-arraybufferview-compatibility).
+                        1. If |value|.{{MLInput/data}} is an {{ArrayBufferView}}, then:
+                            1. The kind of |value|.{{MLInput/data}} must be compatible to |inputOperand|.{{MLOperandDescriptor/type}} according to [this table](#appendices-mloperandtype-arraybufferview-compatibility).
                         1. If |value|.{{MLInput/dimensions}} was given, then:
                             1. The length of |value|.{{MLInput/dimensions}} must be the same as the length of |inputOperand|.{{MLOperandDescriptor/dimensions}}.
                             1. Let |i| be 0.
@@ -1693,12 +1698,12 @@ interface MLGraph {
             <!-- Copy the inputs -->
             1. Let |copiedInputs| be a new {{MLNamedInputs}}.
             1. For each |key| -> |value| of |inputs|:
-                1. Let |copyiedInput| be a new {{MLInput}}.
-                1. Let |copyiedInput|.{{MLInput/data}} be a new {{ArrayBufferView}} that has the same kind and length as |value|.{{MLInput/data}}'s.
-                1. Set the content of |copyiedInput|.{{MLInput/data}} to the content of |value|.{{MLInput/data}}.
-                1. Let |copyiedInput|.{{MLInput/dimensions}} be a new [=sequence=]&lt;{{long}}&gt; that has the same length of |value|.{{MLInput/dimensions}}'s.
-                1. Set the content of |copyiedInput|.{{MLInput/dimensions}} to the content of |value|.{{MLInput/dimensions}}.
-                1. Set |copiedInputs|[key] to |copyiedInput|.
+                1. Let |copiedInputs| be a new {{MLInput}}.
+                1. Let |copiedInputs|.{{MLInput/data}} be a new {{ArrayBufferView}} that has the same kind and length as |value|.{{MLInput/data}}'s.
+                1. Set the content of |copiedInputs|.{{MLInput/data}} to the content of |value|.{{MLInput/data}}.
+                1. Let |copiedInputs|.{{MLInput/dimensions}} be a new [=sequence=]&lt;{{long}}&gt; that has the same length of |value|.{{MLInput/dimensions}}'s.
+                1. Set the content of |copiedInputs|.{{MLInput/dimensions}} to the content of |value|.{{MLInput/dimensions}}.
+                1. Set |copiedInputs|[key] to |copiedInputs|.
             <!-- Compute -->
             1. Let |results| be a new {{MLNamedOutputs}}.
             1. Let |remainingOutputNames| be a new [=ordered set=]&lt;{{DOMString}}&gt;.
@@ -1723,19 +1728,23 @@ interface MLGraph {
                                         1. Set |i| to |i| + 1.
                                         1. If |i| is equal to |outputRank|, then break.
                                     1. Set |results|[|outputName|].{{MLOutput/dimensions}} to |outputDemisions|.
-                                    1. If |outputs|[|outputName|].{{MLOutput/data}} was given, then:
-                                        1. If the kind of |outputs|[|outputName|].{{MLOutput/data}} is not compatible to output tensor according to [this table](#appendices-mloperandtype-arraybufferview-compatibility), then [=reject=] |promise| with a {{TypeError}} and stop.
-                                        1. If the length of |outputs|[|outputName|].{{MLOutput/data}} is less than |outputSize|, then [=reject=] |promise| with a {{TypeError}} and stop.
-                                        1. Set the content of |outputs|[|outputName|].{{MLOutput/data}} to the content of output tensor returned by |this|.{{MLGraph/[[implementation]]}}.
-                                    1. Else:
-                                        1. Let |results|[|outputName|].{{MLOutput/data}} be a new {{ArrayBufferView}} of size |outputSize| and  kind that is compatible to output tensor according to [this table](#appendices-mloperandtype-arraybufferview-compatibility).
-                                        1. Set the content of |results|[|outputName|].{{MLOutput/data}} to the content of output tensor returned by |this|.{{MLGraph/[[implementation]]}}.
+                                    1. If |this|.{{MLGraph/[[context]]}} is created from {{MLContextOptions}}, then:
+                                        1. If |outputs|[|outputName|].{{MLOutput/data}} was given, then:
+                                            1. If outputs|[|outputName|].{{MLOutput/data}} is not an {{ArrayBufferView}}, then [=reject=] |promise| with an {{TypeError}} and stop.
+                                            1. If the kind of |outputs|[|outputName|].{{MLOutput/data}} is not compatible to output tensor according to [this table](#appendices-mloperandtype-arraybufferview-compatibility), then [=reject=] |promise| with a {{TypeError}} and stop.
+                                            1. If the length of |outputs|[|outputName|].{{MLOutput/data}} is less than |outputSize|, then [=reject=] |promise| with a {{TypeError}} and stop.
+                                            1. Set the content of |outputs|[|outputName|].{{MLOutput/data}} to the content of output tensor returned by |this|.{{MLGraph/[[implementation]]}}.
+                                        1. Else:
+                                            1. Let |results|[|outputName|].{{MLOutput/data}} be a new {{ArrayBufferView}} of size |outputSize| and kind that is compatible to output tensor according to [this table](#appendices-mloperandtype-arraybufferview-compatibility).
+                                            1. Set the content of |results|[|outputName|].{{MLOutput/data}} to the content of output tensor returned by |this|.{{MLGraph/[[implementation]]}}.
                                     1. Remove |outputName| from |remainingOutputNames|.
                                     1. If |remainingOutputNames| is empty, then resolve |promise| with |results| and stop.
                             </div>
                 </div>
 
             1. Return |promise|.
+
+            Issue: Describe the algorithm steps for |this|.{{MLGraph/[[context]]}} created from {{WebGLRenderingContext}} and {{GPUDevice}}.
         </div>
 </dl>
 


### PR DESCRIPTION
@wchao1115 @pyu10055 @anssiko , PTAL.

Hopefully, it would fix #140 @cynthia, please also take a look.

Another note is, for the spec of ML device interactions, I found the [timelines](https://gpuweb.github.io/gpuweb/#programming-model-timelines) of WebGPU spec is quite useful. So I adapted and included it in this PR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/147.html" title="Last updated on Apr 1, 2021, 3:13 PM UTC (380379c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/147/880cd8a...huningxin:380379c.html" title="Last updated on Apr 1, 2021, 3:13 PM UTC (380379c)">Diff</a>