### PR TITLE
Add [WEBGPU] custom bibliography entry

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -29,6 +29,23 @@ urlPrefix: https://gpuweb.github.io/gpuweb/; spec: WEBGPU
         text: GPUBuffer; url: buffer-interface
         text: GPUTexture; url: texture-interface
 </pre>
+<pre class="biblio">
+{
+	"WEBGPU": {
+		"authors": [
+			"Dzmitry Malyshau",
+			"Kai Ninomiya"
+		],
+		"href": "https://gpuweb.github.io/gpuweb/",
+		"title": "WebGPU",
+		"status": "ED",
+		"publisher": "W3C",
+		"deliveredBy": [
+			"https://www.w3.org/2020/gpu/"
+		]
+	}
+}
+</pre>
 
 Introduction {#intro}
 =====================


### PR DESCRIPTION
The WebGPU API spec is not in the bibliography databases yet,
so it must be manually added to make it appear in the Normative
References section.

https://tabatkins.github.io/bikeshed/#biblio
https://tabatkins.github.io/bikeshed/#biblio-manual


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/pull/155.html" title="Last updated on Mar 22, 2021, 7:31 AM UTC (c430fb3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/155/8a564a1...c430fb3.html" title="Last updated on Mar 22, 2021, 7:31 AM UTC (c430fb3)">Diff</a>