### PR TITLE
Add Permissions Policy Integration and initial createContext() hooks

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -474,12 +474,39 @@ interface ML {
 };
 </script>
 
+The {{ML/createContext()}} method steps are:
+1. If the [=responsible document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, then throw a "{{SecurityError!!exception}}" {{DOMException}} and abort these steps.
+1. Let |context| be a new {{MLContext}} object.
+1. Switch on the method's first argument:
+    <dl class=switch>
+    <dt>{{MLContextOptions}}
+    <dd>Set |context|'s [=context type=] to [=default-context|default=].
+
+    <dt>{{WebGLRenderingContext}}
+    <dd>Set |context|'s [=context type=] to [=webgl-context|webgl=].
+
+    <dt>{{GPUDevice}}
+    <dd>Set |context|'s [=context type=] to [=webgpu-context|webgpu=].
+
+    <dt>Otherwise
+    <dd>Set |context|'s [=context type=] to [=default-context|default=].
+    </dl>
+1. Return |context|.
+
+### Permissions Policy Integration ### {#permissions-policy-integration}
+
+This specification defines a <a>policy-controlled feature</a> identified by the
+string "<code><dfn data-lt="webnn-feature">webnn</dfn></code>".
+Its <a>default allowlist</a> is <code>'self'</code>.
+
 ## MLContext ## {#api-mlcontext}
 The {{MLContext}} interface represents a global state of neural network compute workload and execution processes.
 <script type=idl>
 [SecureContext, Exposed=Window]
 interface MLContext {};
 </script>
+
+The <dfn>context type</dfn> for an {{MLContext}} is either "<code><dfn data-lt="default-context">default</dfn></code>", "<code><dfn data-lt="webgl-context">webgl</dfn></code>" or "<code><dfn data-lt="webgpu-context">webgpu</dfn></code>".
 
 ## MLOperandDescriptor ## {#api-mloperanddescriptor}
 <script type=idl>


### PR DESCRIPTION
Fix #145

In addition to Permissions Policy Integration (per [integration best practices](https://github.com/w3c/webappsec-permissions-policy/blob/main/integration.md)), this also adds initial steps for `createContext()` to allow integration of the "allowed to use" check.

@wchao1115 you wanted to clarify the context creation prose so if this looks good to you you can base your further work on top of this and augment the steps with more context creation details.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/pull/159.html" title="Last updated on Apr 7, 2021, 3:22 PM UTC (ce01a73)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/159/0f913d6...ce01a73.html" title="Last updated on Apr 7, 2021, 3:22 PM UTC (ce01a73)">Diff</a>