### PR TITLE
Set up for automatic publication using Echidna

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -18,4 +18,8 @@ jobs:
           TOOLCHAIN: bikeshed
           VALIDATE_LINKS: false
           BUILD_FAIL_ON: link-error
-          VALIDATE_MARKUP: false
+          W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-webmachinelearning-wg/2021Jun/0011.html
+          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_BUILD_OVERRIDE: |
+            TR: https://www.w3.org/TR/webnn/
+            status: W3C/WD

--- a/index.bs
+++ b/index.bs
@@ -4,6 +4,7 @@ Shortname: webnn
 Level: None
 Status: ED
 Group: webmlwg
+TR: https://www.w3.org/TR/webnn/
 URL: https://webmachinelearning.github.io/webnn/
 Editor: Ningxin Hu 68202, Intel Corporation https://intel.com
 Editor: Chai Chaoweeraprasit 120203, Microsoft Corporation https://microsoft.com


### PR DESCRIPTION
Per https://lists.w3.org/Archives/Public/public-webmachinelearning-wg/2021Jun/0011.html
Following FPWD published at https://www.w3.org/TR/2021/WD-webnn-20210622/

(we should probably wait until June 23rd to merge this, to make sure the FPWD isn't overridden by a simple WD)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/pull/183.html" title="Last updated on Jun 22, 2021, 7:09 AM UTC (19cbf8e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/183/7dd419e...19cbf8e.html" title="Last updated on Jun 22, 2021, 7:09 AM UTC (19cbf8e)">Diff</a>