### PR TITLE
Scope dl highlight to body of spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -58,7 +58,7 @@ spec:webidl;
 
 <style>
 /* Make <dl> blocks more distinct from their surroundings. */
-dl:not(.switch) {
+main dl:not(.switch) {
     border-left: thin solid #f3e48c;
     padding-left: .5em;
 }


### PR DESCRIPTION
The yellow left border otherwise appears also on the top metadata of the spec, making it at odds with the regular look of W3C specs


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/pull/186.html" title="Last updated on Jun 24, 2021, 11:14 AM UTC (35ed6be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/186/a913875...35ed6be.html" title="Last updated on Jun 24, 2021, 11:14 AM UTC (35ed6be)">Diff</a>