### PR TITLE
Add default values of scales into resample op

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1702,7 +1702,7 @@ partial interface MLGraphBuilder {
         - *options*: an optional {{MLResampleOptions}}. The optional parameters of the operation.
             - *mode*: an {{MLInterpolationMode}}. The interpolation algorithm used to fill the output tensor values.
                 If not set, it is assumed to be the *Nearest Neighbor* interpolation.
-            - *scales*: a sequence of {{float}} of length 4. Each value represents the scaling factor used to scale in each input dimensions.
+            - *scales*: a sequence of {{float}} of length 4. Each value represents the scaling factor used to scale in each input dimensions. If not set, the values are assumed to be [1.0, 1.0, 1.0, 1.0].
             - *sizes*: a sequence of {{long}} of length 4. The target sizes for each input dimensions. When the target sizes are specified, the *options.scales* argument is ignored as the scaling factor values are derived from the target sizes of each input dimension.
 
     **Returns:** an {{MLOperand}}. The output 4-D tensor.


### PR DESCRIPTION
fix #192 

@wchao1115 @pyu10055 @anssiko , PTAL. Thanks.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/204.html" title="Last updated on Aug 29, 2021, 12:54 AM UTC (006f05f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/204/dc85541...huningxin:006f05f.html" title="Last updated on Aug 29, 2021, 12:54 AM UTC (006f05f)">Diff</a>