### PR TITLE
Update LICENSE.md to match WG Charter Licensing section

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,22 +1,3 @@
-Contributions to this repository are intended to become part of Recommendation-track documents governed by the
-[W3C Patent Policy](https://www.w3.org/Consortium/Patent-Policy/) and
-[Software and Document License](https://www.w3.org/Consortium/Legal/copyright-software). To make substantive contributions to specifications, you must either participate
-in the relevant W3C Working Group or make a non-member patent licensing commitment.
-
-If you are not the sole contributor to a contribution (pull request), please identify all
-contributors in the pull request comment.
-
-To add a contributor (other than yourself, that's automatic), mark them one per line as follows:
-
-```
-+@github_username
-```
-
-If you added a contributor by mistake, you can remove them in a comment with:
-
-```
--@github_username
-```
-
-If you are making a pull request on behalf of someone else but you had no part in designing the
-feature, you can remove yourself with the above syntax.
+All documents in this Repository are licensed by contributors
+under the 
+[W3C Software and Document license](https://www.w3.org/Consortium/Legal/copyright-software).


### PR DESCRIPTION
This uses the WG license template https://github.com/w3c/licenses/blob/main/WG-LICENSE.md but updates the license from W3C Document License to W3C Software and Document license per https://www.w3.org/2021/04/web-machine-learning-charter.html#licensing