### PR TITLE
Fix output size calculation of conv2d and convTranspose2d

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -831,7 +831,7 @@ partial interface MLGraphBuilder {
 
     **Returns:** an {{MLOperand}}. The output 4-D tensor that contains the convolution result. The output shape is interpreted according to the *options.inputLayout* value. More specifically, the spatial dimensions or the sizes of the last two dimensions of the output tensor for the *nchw* input layout can be calculated as follow:
 
-    *output size = 1 + (input size - filter size + beginning padding + ending padding) / stride*
+    *output size = 1 + (input size - filter size - (filter size - 1) ** *(dilation - 1) + beginning padding + ending padding) / stride*
 
     <div class="note">
     A *depthwise* conv2d operation is a variant of grouped convolution, used in models like the MobileNet, where the *options.groups* = input_channels = output_channels and the shape of filter tensor is [options.groups, 1, height, width]
@@ -908,7 +908,7 @@ partial interface MLGraphBuilder {
 
     **Returns:** an {{MLOperand}}. The output 4-D tensor that contains the transposed convolution result. The output shape is interpreted according to the *options.inputLayout* value. More specifically, unless the *options.outputSizes* values are explicitly specified, the *options.outputPadding* may be needed to compute the spatial dimension values of the output tensor as follow:
 
-    *output size = (input size - 1) ** *stride + filter size - beginning padding - ending padding + output padding*
+    *output size = (input size - 1) ** *stride + filter size + (filter size - 1) ** *(dilation - 1) - beginning padding - ending padding + output padding*
 </div>
 
 ### element-wise binary operations ### {#api-mlgraphbuilder-binary}


### PR DESCRIPTION
Include the dilation into the calculation.

fix #222

@wchao1115 @pyu10055 @anssiko , PTAL.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/232.html" title="Last updated on Nov 23, 2021, 6:58 AM UTC (483afef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/232/aaddda1...huningxin:483afef.html" title="Last updated on Nov 23, 2021, 6:58 AM UTC (483afef)">Diff</a>