### PR TITLE
Add MLOperand and update MLOperator description

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -604,7 +604,7 @@ interface MLOperator {};
 </script>
 
 <div class="note">
-{{MLGraphBuilder}} operations whose `options` dictionary contains an `activation` or `activations` dictionary member accepts these activation function types: {{clamp()}}, {{elu()}}, {{hardSigmoid()}}, {{hardSwish()}}, {{leakyRelu()}}, {{linear()}}, {{relu()}}, {{sigmoid()}}, {{softplus()}}, {{softsign()}}, {{tanh()}}.
+These activations function types are used to create other operations such as [[#api-mlgraphbuilder-conv2d]] or [[#api-mlgraphbuilder-batchnorm]].
 </div>
 
 <div class="note">

--- a/index.bs
+++ b/index.bs
@@ -586,6 +586,9 @@ dictionary MLOperandDescriptor {
 </script>
 
 ## MLOperand ## {#api-mloperand}
+
+The {{MLOperand}} interface represents data that flows within the computational graph. See [[#programming-model]].
+
 <script type=idl>
 [SecureContext, Exposed=(Window, DedicatedWorker)]
 interface MLOperand {};
@@ -593,7 +596,7 @@ interface MLOperand {};
 
 ## MLOperator ## {#api-mloperator}
 
-The {{MLOperator}} interface defines a type of operation such as the various types of activation function used to create other operations such as [[#api-mlgraphbuilder-conv2d]] or [[#api-mlgraphbuilder-batchnorm]].
+Objects implementing the {{MLOperator}} interface represent activation function types: {{clamp()}}, {{elu()}}, {{hardSigmoid()}}, {{hardSwish()}}, {{leakyRelu()}}, {{linear()}}, {{relu()}}, {{sigmoid()}}, {{softplus()}}, {{softsign()}}, {{tanh()}}.
 
 <script type=idl>
 [SecureContext, Exposed=(Window, DedicatedWorker)]
@@ -601,7 +604,7 @@ interface MLOperator {};
 </script>
 
 <div class="note">
-The implementation of this interface can simply be a struct that holds a string type of the operation along with other properties needed. The actual creation of the operation e.g. a [[#api-mlgraphbuilder-sigmoid]] or [[#api-mlgraphbuilder-relu]] can then be deferred until when the rest of the graph is ready to connect with it such as during the construction of [[#api-mlgraphbuilder-conv2d]] for example.
+The implementation of the {{MLOperator}} interface can simply be a struct that holds a string type of the activation function along with other properties needed. The actual creation of the activation function e.g. a [[#api-mlgraphbuilder-sigmoid]] or [[#api-mlgraphbuilder-relu]] can then be deferred until when the rest of the graph is ready to connect with it such as during the construction of [[#api-mlgraphbuilder-conv2d]] for example.
 </div>
 
 ## MLGraphBuilder ## {#api-mlgraphbuilder}

--- a/index.bs
+++ b/index.bs
@@ -596,12 +596,16 @@ interface MLOperand {};
 
 ## MLOperator ## {#api-mloperator}
 
-Objects implementing the {{MLOperator}} interface represent activation function types: {{clamp()}}, {{elu()}}, {{hardSigmoid()}}, {{hardSwish()}}, {{leakyRelu()}}, {{linear()}}, {{relu()}}, {{sigmoid()}}, {{softplus()}}, {{softsign()}}, {{tanh()}}.
+Objects implementing the {{MLOperator}} interface represent activation function types.
 
 <script type=idl>
 [SecureContext, Exposed=(Window, DedicatedWorker)]
 interface MLOperator {};
 </script>
+
+<div class="note">
+{{MLGraphBuilder}} operations whose `options` dictionary contains an `activation` or `activations` dictionary member accepts these activation function types: {{clamp()}}, {{elu()}}, {{hardSigmoid()}}, {{hardSwish()}}, {{leakyRelu()}}, {{linear()}}, {{relu()}}, {{sigmoid()}}, {{softplus()}}, {{softsign()}}, {{tanh()}}.
+</div>
 
 <div class="note">
 The implementation of the {{MLOperator}} interface can simply be a struct that holds a string type of the activation function along with other properties needed. The actual creation of the activation function e.g. a [[#api-mlgraphbuilder-sigmoid]] or [[#api-mlgraphbuilder-relu]] can then be deferred until when the rest of the graph is ready to connect with it such as during the construction of [[#api-mlgraphbuilder-conv2d]] for example.

--- a/index.bs
+++ b/index.bs
@@ -587,7 +587,9 @@ dictionary MLOperandDescriptor {
 
 ## MLOperand ## {#api-mloperand}
 
-The {{MLOperand}} interface represents data that flows within the computational graph. See [[#programming-model]].
+An {{MLOperand}} represents an intermediary graph being constructed as a result of compositing parts of an operation into a fully composed operation.
+
+For instance, an {{MLOperand}} may represent a constant feeding to an operation or the result from combining multiple constants together into an operation. See also [[#programming-model]].
 
 <script type=idl>
 [SecureContext, Exposed=(Window, DedicatedWorker)]

--- a/index.bs
+++ b/index.bs
@@ -598,7 +598,7 @@ interface MLOperand {};
 
 ## MLOperator ## {#api-mloperator}
 
-Objects implementing the {{MLOperator}} interface represent activation function types.
+Objects implementing the {{MLOperator}} interface represent activation function types. As a generic construct, this interface may be reused for other types in a future version of this specification.
 
 <script type=idl>
 [SecureContext, Exposed=(Window, DedicatedWorker)]
@@ -606,7 +606,7 @@ interface MLOperator {};
 </script>
 
 <div class="note">
-These activations function types are used to create other operations such as [[#api-mlgraphbuilder-conv2d]] or [[#api-mlgraphbuilder-batchnorm]].
+These activations function types are used to create other operations. One such use of this interface is for when an activation function is fused into another operation such as [[#api-mlgraphbuilder-conv2d]] or [[#api-mlgraphbuilder-batchnorm]] during a graph construction session.
 </div>
 
 <div class="note">


### PR DESCRIPTION
I started filling in a high-level description for the MLOperand that was missing referring to the programming model section for a more elaborate description. As a drive-by, I reworked the MLOperator description a bit to refer to the activation functions explicitly. Perhaps having this list here helps the readers? I hope it is not too hard to maintain if we add more activation functions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/pull/237.html" title="Last updated on Jan 17, 2022, 3:51 PM UTC (b08444a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/237/fd171b5...b08444a.html" title="Last updated on Jan 17, 2022, 3:51 PM UTC (b08444a)">Diff</a>