### PR TITLE
Add Test Suite metadata

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10,6 +10,7 @@ Editor: Ningxin Hu 68202, Intel Corporation https://intel.com
 Editor: Chai Chaoweeraprasit 120203, Microsoft Corporation https://microsoft.com
 Abstract: This document describes a dedicated low-level API for neural network inference hardware acceleration.
 Repository: https://github.com/webmachinelearning/webnn
+Test Suite: https://github.com/web-platform-tests/wpt/tree/master/webnn
 !Explainer: <a href="https://github.com/webmachinelearning/webnn/blob/master/explainer.md">explainer.md</a>
 !Polyfill: <a href="https://github.com/webmachinelearning/webnn-polyfill">webnn-polyfill</a> / <a href="https://github.com/webmachinelearning/webnn-samples">webnn-samples</a>
 Markup Shorthands: markdown yes


### PR DESCRIPTION
Now that we have `webnn` in the wpt tree it is appropriate to link to it from the spec so folks who want to contribute will find the right place. The expectation is the linked test suite at this point of development is WIP.

FYI @brucedai


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/pull/238.html" title="Last updated on Dec 8, 2021, 1:50 PM UTC (736a5f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/238/062b55c...736a5f7.html" title="Last updated on Dec 8, 2021, 1:50 PM UTC (736a5f7)">Diff</a>