### PR TITLE
Add real-time video processing use case

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -372,6 +372,10 @@ so that the application loads the tiny model in the case of CPU-only devices.
 
 A JavaScript ML framework is responsible for loading, interpreting and executing a ML model. During the model execution phase, the framework iterates through the operations of the model and executes each operation on the hardware device, like CPU, GPU or ML accelerator. To avoid the unnecessary data copying across devices, the framework selects the same device to execute the operations. For a compute intensive operation, such as convolution 2D or matrix multiplication, the framework uses WebNN API to execute it with the ML-specific acceleration available on that selected device.
 
+### Integration with real-time video processing ### {#usecase-real-time-video-processing}
+
+The user experience of WebRTC-based video conferencing is enhanced using real-time video processing. For example, background blur implemented using a [[#usecase-segmentation]] model blurs the background in the user's live camera feed. To satisfy the performance requirements of this use case, the WebNN API integrates with primitives from other Web APIs that make up the media pipeline to allow WebNN API-based transformation of real-time video streams.
+
 Security Considerations {#security}
 ===================================
 


### PR DESCRIPTION
In https://www.w3.org/2022/01/13-webmachinelearning-minutes.html#t06 it was suggested we add a real-time video processing use case. Here's a proposal for that.

A few questions:

- I put this in the "Framework Use Cases" section. Not a perfect fit but I wanted to differentiate from the "Application Use Cases" that in the context of this spec refer to various ML models. Maybe we can find a better name for the "Framework Use Cases" section?
- In this proposal, I did not explicitly define what makes up "the media pipeline" given the details of that are still WIP. Should we instead refer informatively the specs that we currently think will make up this pipeline and maintain this use case as our understanding evolves?