### PR TITLE
Add "Ethical Content Filtering" use case to WebNN specs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2674,6 +2674,20 @@ Thanks to W3C Privacy Interest Group for privacy and security review and feedbac
     ],
     "date": "January 2019"
   },
+  "Privacy study on Ad-blockers": {
+    "href": "https://www.researchgate.net/publication/318330749_Ad-blocking_A_Study_on_Performance_Privacy_and_Counter-measures",
+    "title": "Ad-blocking: A Study on Performance, Privacy and Counter-measures",
+    "authors": [
+      "Kiran Garimella",
+      "Orestis Kostakis",
+      "Michael Mathioudakis"
+    ],
+    "date": "June 2017"
+  },
+  "W3C Ethical Web Principles": {
+    "href": "https://www.w3.org/2001/tag/doc/ethical-web-principles/#render",
+    "title": "People should be able to render web content as they want"
+  }
   "MobileNetV3": {
     "href": "https://arxiv.org/pdf/1905.02244",
     "title": "Searching for MobileNetV3",

--- a/index.bs
+++ b/index.bs
@@ -2687,7 +2687,7 @@ Thanks to W3C Privacy Interest Group for privacy and security review and feedbac
   "W3C Ethical Web Principles": {
     "href": "https://www.w3.org/2001/tag/doc/ethical-web-principles/#render",
     "title": "People should be able to render web content as they want"
-  }
+  },
   "MobileNetV3": {
     "href": "https://arxiv.org/pdf/1905.02244",
     "title": "Searching for MobileNetV3",

--- a/index.bs
+++ b/index.bs
@@ -327,7 +327,7 @@ detection application alerts her of the fraud video in real-time.
 
 ### Ethical Content Filtering ### {#usecase-ethical-content-filtering}
 
-A user is cautious about her online privacy and wants to be protected from the online trackers, malware and any third-parties present on the web pages that she visits. She activates her content-filter [[Privacy study on Ad-blockers]] that blocks the third party content, while allowing her to safely surf her favorite websites. Thus she is safe and more in control of her online experience [[W3C Ethical Web Principles]].
+A user is cautious about her online privacy and wants to be protected from the online trackers, malware and any third-parties present on the web pages that she visits. She activates her content-filter [[Privacy-study-on-AdBlockers]] that blocks the third party content, while allowing her to safely surf her favorite websites. Thus she is safe and more in control of her online experience [[W3C-Ethical-Web-Principles]].
 
 ## Framework Use Cases ## {#usecases-framework}
 
@@ -2674,7 +2674,7 @@ Thanks to W3C Privacy Interest Group for privacy and security review and feedbac
     ],
     "date": "January 2019"
   },
-  "Privacy study on Ad-blockers": {
+  "Privacy-study-on-AdBlockers": {
     "href": "https://www.researchgate.net/publication/318330749_Ad-blocking_A_Study_on_Performance_Privacy_and_Counter-measures",
     "title": "Ad-blocking: A Study on Performance, Privacy and Counter-measures",
     "authors": [
@@ -2684,7 +2684,7 @@ Thanks to W3C Privacy Interest Group for privacy and security review and feedbac
     ],
     "date": "June 2017"
   },
-  "W3C Ethical Web Principles": {
+  "W3C-Ethical-Web-Principles": {
     "href": "https://www.w3.org/2001/tag/doc/ethical-web-principles/#render",
     "title": "People should be able to render web content as they want"
   },

--- a/index.bs
+++ b/index.bs
@@ -325,6 +325,10 @@ applications such as [[FaceForensics++]] analyze the videos and protect a user a
 the fake videos or images. When she watches a fake video on the web, the 
 detection application alerts her of the fraud video in real-time.
 
+### Ethical Content Filtering ### {#usecase-ethical-content-filtering}
+
+A user is cautious about her online privacy and wants to be protected from the online trackers, malware and any third-parties present on the web pages that she visits. She activates her content-filter [[Privacy study on Ad-blockers]] that blocks the third party content, while allowing her to safely surf her favorite websites. Thus she is safe and more in control of her online experience [[W3C Ethical Web Principles]].
+
 ## Framework Use Cases ## {#usecases-framework}
 
 This section collects framework-level use cases for a dedicated low-level API


### PR DESCRIPTION
As discussed in the issue: #236, we have been working on **machine learning-based content filtering**; and notice that there is a gap when it comes to web standards for supporting content blocking and filtering. This hinders in implementing solutions that upholds the W3C ethical principle that "People should be able to render web content as they want".

With this PR, I submit the use case on "Ethical Content Filtering" for addition to the WebNN specs.

Thanks,
Humera
https://de.linkedin.com/in/humeranoor
https://eyeo.com/


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/humeranoor/webnn/pull/253.html" title="Last updated on Feb 16, 2022, 2:01 PM UTC (5819ba7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/253/19a09ab...humeranoor:5819ba7.html" title="Last updated on Feb 16, 2022, 2:01 PM UTC (5819ba7)">Diff</a>