### PR TITLE
Define graph execution methods used in different threading models.

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -41,13 +41,15 @@ const B = builder.input('B', operandType);
 const C = builder.add(builder.mul(A, constant), B);
 // 2. Compile it into an executable.
 const graph = builder.build({'C': C});
+// 3. Create an execution method
+const execution = new MLExecution(context);
 // 3. Bind inputs to the graph and execute for the result.
 const bufferA = new Float32Array(4).fill(1.0);
 const bufferB = new Float32Array(4).fill(0.8);
 const bufferC = new Float32Array(4);
 const inputs = {'A': bufferA, 'B': bufferB};
 const outputs = {'C': bufferC};
-graph.compute(inputs, outputs);
+execution.compute(graph, inputs, outputs);
 // The computed result of [[1, 1], [1, 1]] is in the buffer associated with
 // the output operand.
 console.log('Output value: ' + bufferC);
@@ -99,6 +101,7 @@ There are many important [application use cases](https://webmachinelearning.gith
 export class NSNet2 {
   constructor() {
     this.graph = null;
+    this.execution = null;
     this.frameSize = 161;
     this.hiddenSize = 400;
   }
@@ -140,6 +143,8 @@ export class NSNet2 {
     const relu167 = builder.relu(builder.add(builder.matmul(relu163, weight216), biasFcOut2));
     const output = builder.sigmoid(builder.add(builder.matmul(relu167, weight217), biasFcOut4));
     this.graph = builder.build({'output': output, 'gru94': gru94, 'gru157': gru157});
+    // Create graph execution method
+    this.execution = new MLExecution(context);
   }
 
   compute(inputBuffer, initialState92Buffer, initialState155Buffer, outputBuffer, gru94Buffer, gru157Buffer) {
@@ -153,7 +158,7 @@ export class NSNet2 {
       'gru94': gru94Buffer,
       'gru157': gru157Buffer
     };
-    return this.graph.compute(inputs, outputs);
+    return this.execution.compute(graph, inputs, outputs);
   }
 }
 ```

--- a/index.bs
+++ b/index.bs
@@ -623,7 +623,7 @@ interface MLContext {};
 
 ## MLOperandDescriptor ## {#api-mloperanddescriptor}
 <script type=idl>
-enum MLGPUInputOperandLayout {
+enum MLInputOperandLayout {
   "nchw",
   "nhwc"
 };
@@ -852,7 +852,7 @@ dictionary MLConv2dOptions {
   sequence<long> dilations;
   MLAutoPad autoPad = "explicit";
   long groups = 1;
-  MLGPUInputOperandLayout inputLayout = "nchw";
+  MLInputOperandLayout inputLayout = "nchw";
   MLConv2dFilterOperandLayout filterLayout = "oihw";
   MLOperand bias;
   MLOperator activation;
@@ -874,7 +874,7 @@ partial interface MLGraphBuilder {
             - *dilations*: a sequence of {{long}} of length 2. The dilation factor for each spatial dimension of *input*, [dilation_height, dilation_width]. If not present, the values are assumed to be [1,1].
             - *autoPad*: an {{MLAutoPad}}. The automatic input padding options. By default, this argument is set to *"explicit"*, which means that the values in the *options.padding* array should be used for input padding. When the option is set other than *"explicit"*, the values in the *options.padding* array are ignored. With the *"same-upper"* option, the padding values are automatically computed such that the additional ending padding of the spatial input dimensions would allow all of the input values in the corresponding dimension to be filtered. The *"same-lower"* option is similar but padding is applied to the beginning padding of the spatial input dimensions instead of the ending one.
             - *groups*: a {{long}} scalar. The number of groups that input channels and output channels are divided into, default to 1.
-            - *inputLayout*: an {{MLGPUInputOperandLayout}}. The default value is *"nchw"*. This option specifies the layout format of the input and output tensor as follow:
+            - *inputLayout*: an {{MLInputOperandLayout}}. The default value is *"nchw"*. This option specifies the layout format of the input and output tensor as follow:
 
                 "nchw":
                     - input tensor: [batches, input_channels, height, width]
@@ -929,7 +929,7 @@ dictionary MLConvTranspose2dOptions {
   sequence<long> outputSizes;
   MLAutoPad autoPad = "explicit";
   long groups = 1;
-  MLGPUInputOperandLayout inputLayout = "nchw";
+  MLInputOperandLayout inputLayout = "nchw";
   MLConvTranspose2dFilterOperandLayout filterLayout = "iohw";
   MLOperand bias;
   MLOperator activation;
@@ -954,7 +954,7 @@ partial interface MLGraphBuilder {
             - *outputSizes*: a sequence of {{long}} of length 2. The sizes of the last two dimensions of the output tensor. When the output sizes are explicitly specified, the output padding values in *options.outputPadding* are ignored. If not specified, the output sizes are automatically computed.
             - *autoPad*: an {{MLAutoPad}}. The automatic input padding options. By default, this argument is set to *"explicit"*, which means that the values in the *options.padding* array should be used for input padding. When the option is set other than *"explicit"*, the values in the *options.padding* array are ignored. With the *"same-upper"* option, the padding values are automatically computed such that the additional ending padding of the spatial input dimensions would allow all of the input values in the corresponding dimension to be filtered. The *"same-lower"* option is similar but padding is applied to the beginning padding of the spatial input dimensions instead of the ending one.
             - *groups*: a {{long}} scalar. The number of groups that input channels and output channels are divided into, default to 1.
-            - *inputLayout*: an {{MLGPUInputOperandLayout}}. The default value is *"nchw"*. This option specifies the layout format of the input and output tensor as follow:
+            - *inputLayout*: an {{MLInputOperandLayout}}. The default value is *"nchw"*. This option specifies the layout format of the input and output tensor as follow:
 
                 "nchw":
                     - input tensor: [batches, input_channels, height, width]
@@ -1461,7 +1461,7 @@ dictionary MLInstanceNormalizationOptions {
   MLOperand scale;
   MLOperand bias;
   float epsilon = 1e-5;
-  MLGPUInputOperandLayout layout = "nchw";
+  MLInputOperandLayout layout = "nchw";
 };
 
 partial interface MLGraphBuilder {
@@ -1476,7 +1476,7 @@ partial interface MLGraphBuilder {
               - *scale*: an {{MLOperand}}. The 1-D tensor of the scaling values whose length is equal to the size of the feature dimension of the input e.g. for the input tensor with *nchw* layout, the feature dimension is 1.
               - *bias*: an {{MLOperand}}. The 1-D tensor of the bias values whose length is equal to the size of the feature dimension of the input e.g. for the input tensor with *nchw* layout, the feature dimension is 1.
               - *epsilon*: a {{float}} scalar. A small value to prevent computational error due to divide-by-zero. The default value is 0.00001 when not specified.
-              - *layout*: an {{MLGPUInputOperandLayout}}. This option specifies the layout format of the input. The default value is *"nchw"*.
+              - *layout*: an {{MLInputOperandLayout}}. This option specifies the layout format of the input. The default value is *"nchw"*.
         
     **Returns:** an {{MLOperand}}. The instance-normalized 4-D tensor of the same shape as the input tensor.
 
@@ -1702,7 +1702,7 @@ dictionary MLPool2dOptions {
   sequence<long> strides;
   sequence<long> dilations;
   MLAutoPad autoPad = "explicit";
-  MLGPUInputOperandLayout layout = "nchw";
+  MLInputOperandLayout layout = "nchw";
   MLRoundingType roundingType = "floor";
   sequence<long> outputSizes;
 };
@@ -1729,7 +1729,7 @@ partial interface MLGraphBuilder {
                 for each spatial dimension of *input*, [dilation_height, dilation_width].
                 If not present, the values are assumed to be [1,1].
             - *autoPad*: an {{MLAutoPad}}. The automatic input padding options. By default, this argument is set to *"explicit"*, which means that the values in the *options.padding* array should be used for input padding. When the option is set other than *"explicit"*, the values in the *options.padding* array are ignored. With the *"same-upper"* option, the padding values are automatically computed such that the additional ending padding of the spatial input dimensions would allow all of the input values in the corresponding dimension to be filtered. The *"same-lower"* option is similar but padding is applied to the beginning padding of the spatial input dimensions instead of the ending one.
-            - *layout*: an {{MLGPUInputOperandLayout}}. The default value is *"nchw"*. This option specifies the
+            - *layout*: an {{MLInputOperandLayout}}. The default value is *"nchw"*. This option specifies the
                 layout format of the input and output tensor as follow:
 
                 "nchw":

--- a/index.bs
+++ b/index.bs
@@ -30,6 +30,9 @@ urlPrefix: https://gpuweb.github.io/gpuweb/; spec: WEBGPU
         text: GPUDevice; url: gpu-device
         text: GPUBuffer; url: buffer-interface
         text: GPUTexture; url: texture-interface
+        text: GPUQueue; url: queues
+        text: GPUCommandBuffer; url: command-buffers
+        text: GPUCommandBufferDescriptor; url: dictdef-gpucommandbufferdescriptor
 </pre>
 <pre class="biblio">
 {
@@ -410,8 +413,7 @@ computer vision, natural language processing, and robotics.
 The WebNN API is a specification for constructing, compiling, and executing computational
 graphs of neural networks.
 
-The {{MLGraph}} interface represents a compiled computational graph (that is, a model) and exposes
-a compute method to perform inference.
+The {{MLGraph}} interface represents a compiled computational graph that is immutable (that is, a model).
 
 The {{MLGraphBuilder}} interface serves as a builder (factory) to create a {{MLGraph}}.
 An {{MLOperand}} is a representation of data that flows within the computational graph,
@@ -432,10 +434,29 @@ the computation graph used to compute one or more specified outputs. The key
 purpose of the compilation step is to enable optimizations that span two or
 more operations, such as operation or loop fusion.
 
-The {{MLGraph/compute()}} method of the {{MLGraph}} interface is used to execute the
-compiled computation graph (to perform inference). The caller supplies the input
-values using {{MLNamedInputs}}, binding the input {{MLOperand}}s to their values.
-The caller supplies pre-allocated buffers for output {{MLOperand}}s using {{MLNamedOutputs}}.
+Once the {{MLGraph}} is constructed, there are multiple ways by which the graph may be executed.
+The {{MLExecution}} interface represents a way the execution of the graph is carried out immediately on the
+calling thread, which must also be a worker thread. The execution is carried out by the {{MLExecution/compute()}},
+method which produces the results of the computation from all the inputs bound to graph on the bound outputs.
+This type of execution is limited to only when the computational device bound to the ML context is a CPU.
+
+The {{MLAwaitedExecution}} interface represents a way the execution of the graph is performed asynchronously
+on a separate worker thread. The call to the {{MLAwaitedExecution/compute()}} method returns instantly without 
+blocking the calling thread. This execution method is appropriate when the responsiveness of the calling thread
+is critical to good user experience. The computation results will be placed at the bound outputs at the time
+the operation is completed on a worker thread at which time the calling thread is signaled. This type of 
+execution supports both the CPU and GPU execution of the graph, including when the ML context is created from 
+the {{WebGLRenderingContext}}.
+
+The {{MLCommandEncoder}} interface supports an execution method that provides the maximum flexibility to 
+callers that also utilize WebGPU in their application. It does this by placing the workload required to
+initialize and compute the results of the operations in the graph onto a {{GPUCommandBuffer}}. The callers
+are responsible for the eventual submission of this workload on the {{GPUQueue}}. The submitted workload 
+once completely executed on the GPU would signal the queue with the results filled in the bound output buffers.
+
+In each of these various execution methods, the caller supplies the input values using {{MLNamedInputs}}
+or equivalent type, binding the input {{MLOperand}}s to their values. The caller supplies pre-allocated
+buffers for output {{MLOperand}}s using {{MLNamedOutputs}} or equivalent type.
 
 The runtime values (of {{MLOperand}}s) are tensors, which are essentially multidimensional
 arrays. The representation of the tensors is implementation dependent, but it typically
@@ -602,7 +623,7 @@ interface MLContext {};
 
 ## MLOperandDescriptor ## {#api-mloperanddescriptor}
 <script type=idl>
-enum MLInputOperandLayout {
+enum MLGPUInputOperandLayout {
   "nchw",
   "nhwc"
 };
@@ -831,7 +852,7 @@ dictionary MLConv2dOptions {
   sequence<long> dilations;
   MLAutoPad autoPad = "explicit";
   long groups = 1;
-  MLInputOperandLayout inputLayout = "nchw";
+  MLGPUInputOperandLayout inputLayout = "nchw";
   MLConv2dFilterOperandLayout filterLayout = "oihw";
   MLOperand bias;
   MLOperator activation;
@@ -853,7 +874,7 @@ partial interface MLGraphBuilder {
             - *dilations*: a sequence of {{long}} of length 2. The dilation factor for each spatial dimension of *input*, [dilation_height, dilation_width]. If not present, the values are assumed to be [1,1].
             - *autoPad*: an {{MLAutoPad}}. The automatic input padding options. By default, this argument is set to *"explicit"*, which means that the values in the *options.padding* array should be used for input padding. When the option is set other than *"explicit"*, the values in the *options.padding* array are ignored. With the *"same-upper"* option, the padding values are automatically computed such that the additional ending padding of the spatial input dimensions would allow all of the input values in the corresponding dimension to be filtered. The *"same-lower"* option is similar but padding is applied to the beginning padding of the spatial input dimensions instead of the ending one.
             - *groups*: a {{long}} scalar. The number of groups that input channels and output channels are divided into, default to 1.
-            - *inputLayout*: an {{MLInputOperandLayout}}. The default value is *"nchw"*. This option specifies the layout format of the input and output tensor as follow:
+            - *inputLayout*: an {{MLGPUInputOperandLayout}}. The default value is *"nchw"*. This option specifies the layout format of the input and output tensor as follow:
 
                 "nchw":
                     - input tensor: [batches, input_channels, height, width]
@@ -908,7 +929,7 @@ dictionary MLConvTranspose2dOptions {
   sequence<long> outputSizes;
   MLAutoPad autoPad = "explicit";
   long groups = 1;
-  MLInputOperandLayout inputLayout = "nchw";
+  MLGPUInputOperandLayout inputLayout = "nchw";
   MLConvTranspose2dFilterOperandLayout filterLayout = "iohw";
   MLOperand bias;
   MLOperator activation;
@@ -933,7 +954,7 @@ partial interface MLGraphBuilder {
             - *outputSizes*: a sequence of {{long}} of length 2. The sizes of the last two dimensions of the output tensor. When the output sizes are explicitly specified, the output padding values in *options.outputPadding* are ignored. If not specified, the output sizes are automatically computed.
             - *autoPad*: an {{MLAutoPad}}. The automatic input padding options. By default, this argument is set to *"explicit"*, which means that the values in the *options.padding* array should be used for input padding. When the option is set other than *"explicit"*, the values in the *options.padding* array are ignored. With the *"same-upper"* option, the padding values are automatically computed such that the additional ending padding of the spatial input dimensions would allow all of the input values in the corresponding dimension to be filtered. The *"same-lower"* option is similar but padding is applied to the beginning padding of the spatial input dimensions instead of the ending one.
             - *groups*: a {{long}} scalar. The number of groups that input channels and output channels are divided into, default to 1.
-            - *inputLayout*: an {{MLInputOperandLayout}}. The default value is *"nchw"*. This option specifies the layout format of the input and output tensor as follow:
+            - *inputLayout*: an {{MLGPUInputOperandLayout}}. The default value is *"nchw"*. This option specifies the layout format of the input and output tensor as follow:
 
                 "nchw":
                     - input tensor: [batches, input_channels, height, width]
@@ -1440,7 +1461,7 @@ dictionary MLInstanceNormalizationOptions {
   MLOperand scale;
   MLOperand bias;
   float epsilon = 1e-5;
-  MLInputOperandLayout layout = "nchw";
+  MLGPUInputOperandLayout layout = "nchw";
 };
 
 partial interface MLGraphBuilder {
@@ -1455,7 +1476,7 @@ partial interface MLGraphBuilder {
               - *scale*: an {{MLOperand}}. The 1-D tensor of the scaling values whose length is equal to the size of the feature dimension of the input e.g. for the input tensor with *nchw* layout, the feature dimension is 1.
               - *bias*: an {{MLOperand}}. The 1-D tensor of the bias values whose length is equal to the size of the feature dimension of the input e.g. for the input tensor with *nchw* layout, the feature dimension is 1.
               - *epsilon*: a {{float}} scalar. A small value to prevent computational error due to divide-by-zero. The default value is 0.00001 when not specified.
-              - *layout*: an {{MLInputOperandLayout}}. This option specifies the layout format of the input. The default value is *"nchw"*.
+              - *layout*: an {{MLGPUInputOperandLayout}}. This option specifies the layout format of the input. The default value is *"nchw"*.
         
     **Returns:** an {{MLOperand}}. The instance-normalized 4-D tensor of the same shape as the input tensor.
 
@@ -1681,7 +1702,7 @@ dictionary MLPool2dOptions {
   sequence<long> strides;
   sequence<long> dilations;
   MLAutoPad autoPad = "explicit";
-  MLInputOperandLayout layout = "nchw";
+  MLGPUInputOperandLayout layout = "nchw";
   MLRoundingType roundingType = "floor";
   sequence<long> outputSizes;
 };
@@ -1708,7 +1729,7 @@ partial interface MLGraphBuilder {
                 for each spatial dimension of *input*, [dilation_height, dilation_width].
                 If not present, the values are assumed to be [1,1].
             - *autoPad*: an {{MLAutoPad}}. The automatic input padding options. By default, this argument is set to *"explicit"*, which means that the values in the *options.padding* array should be used for input padding. When the option is set other than *"explicit"*, the values in the *options.padding* array are ignored. With the *"same-upper"* option, the padding values are automatically computed such that the additional ending padding of the spatial input dimensions would allow all of the input values in the corresponding dimension to be filtered. The *"same-lower"* option is similar but padding is applied to the beginning padding of the spatial input dimensions instead of the ending one.
-            - *layout*: an {{MLInputOperandLayout}}. The default value is *"nchw"*. This option specifies the
+            - *layout*: an {{MLGPUInputOperandLayout}}. The default value is *"nchw"*. This option specifies the
                 layout format of the input and output tensor as follow:
 
                 "nchw":
@@ -2130,20 +2151,8 @@ partial interface MLGraphBuilder {
 The {{MLGraph}} interface represents a compiled computational graph. A compiled graph once constructed is immutable and cannot be subsequently changed.
 
 <script type=idl>
-typedef (MLBufferView or WebGLTexture or GPUTexture) MLResource;
-
-dictionary MLInput {
-  required MLResource resource;
-  required sequence<long> dimensions;
-};
-
-typedef record<DOMString, (MLResource or MLInput)> MLNamedInputs;
-typedef record<DOMString, MLResource> MLNamedOutputs;
-
 [SecureContext, Exposed=(Window, DedicatedWorker)]
-interface MLGraph {
-  undefined compute(MLNamedInputs inputs, MLNamedOutputs outputs);
-};
+interface MLGraph {};
 </script>
 
 {{MLGraph}} has the following internal slots:
@@ -2166,18 +2175,51 @@ interface MLGraph {
         The underlying implementation provided by the User Agent.
 </dl>
 
-<dl dfn-type=method dfn-for=MLGraph>
-    : <dfn>compute(inputs, outputs)</dfn>
-    ::
-        Compute the {{MLGraph}} given {{MLNamedInputs}} and {{MLNamedOutputs}}. Return once the compute has completed and the results in {{MLNamedOutputs}} are ready to be consumed.
+## MLExecution ## {#api-mlexecution}
+The {{MLExecution}} interface represents a method of execution that synchronously carries out the computational workload of a compiled graph {{MLGraph}} on the calling thread, which must be a worker thread, to produce results as defined by the operations in the graph. This method of execution requires an {{MLContext}} created with {{MLContextOptions}} with the {{MLDevicePreference}} option set to either "cpu" or "default" resolved to a CPU context.
 
-        <div algorithm=MLGraph.compute>
-            **Called on:** {{MLGraph}} |this|.
+<script type=idl>
+dictionary MLArrayInput {
+  required ArrayBufferView resource;
+  required sequence<long> dimensions;
+};
+
+typedef record<DOMString, (ArrayBufferView or MLArrayInput)> MLNamedArrayInputs;
+typedef record<DOMString, ArrayBufferView> MLNamedArrayOutputs;
+
+[SecureContext, Exposed=(DedicatedWorker)]
+interface MLExecution {
+  constructor(MLContext context);
+
+  undefined compute(MLGraph graph, MLNamedArrayInputs inputs, MLNamedArrayOutputs outputs);
+};
+</script>
+
+{{MLExecution}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="MLExecution">
+    : <dfn>\[[context]]</dfn> of type {{MLContext}}
+    ::
+        The context of type {{MLContext}} associated with this {{MLExecution}}.
+
+    : <dfn>\[[implementation]]</dfn>
+    ::
+        The underlying implementation provided by the User Agent.
+</dl>
+
+<dl dfn-type=method dfn-for=MLExecution>
+    : <dfn>compute(graph, inputs, outputs)</dfn>
+    ::
+        Compute the {{MLGraph}} given {{MLNamedArrayInputs}} and {{MLNamedArrayOutputs}}. Return once the computation is completed and the results in {{MLNamedArrayOutputs}} are ready to be consumed.
+
+        <div algorithm=MLExecution.compute>
+            **Called on:** {{MLExecution}} |this|.
 
             **Arguments:**
-            <pre class=argumentdef for="MLGraph/compute(inputs, outputs)">
-                |inputs|: an {{MLNamedInputs}}. The resources and optional dimensions of inputs for the compute.
-                |outputs|: an {{MLNamedOutputs}}. The pre-allocated resources of required outputs for the compute.
+            <pre class=argumentdef for="MLExecution/compute(graph, inputs, outputs)">
+                |graph|: an {{MLGraph}}. The compiled graph to be executed.
+                |inputs|: an {{MLNamedArrayInputs}}. The resources and optional dimensions of inputs.
+                |outputs|: an {{MLNamedArrayOutputs}}. The pre-allocated resources of required outputs.
             </pre>
 
             **Returns:** {{undefined}}.
@@ -2185,8 +2227,120 @@ interface MLGraph {
             1. If any of the following requirements are unmet, then throw a {{DataError}} {{DOMException}} and stop.
                 <div class=validusage>
                     1. For each |key| -> |value| of |inputs|:
-                        1. |this|.{{MLGraph/[[inputDescriptors]]}}[|key|] must exist.
-                        1. Let |inputDesc| be |this|.{{MLGraph/[[inputDescriptors]]}}[|key|].
+                        1. |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|] must exist.
+                        1. Let |inputDesc| be |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|].
+                        1. Let |inputSize| be 1.
+                        1. If |value| is an {{MLArrayInput}}, then:
+                            1. The length of |value|.{{MLArrayInput/dimensions}} must be the same as the length of |inputDesc|.{{MLOperandDescriptor/dimensions}}.
+                            1. Let |i| be 0.
+                            1. While true:
+                                1. Let |dimension| be |value|.{{MLArrayInput/dimensions}}[|i|].
+                                1. |dimension| must be greater than 0.
+                                1. If |inputDesc|.{{MLOperandDescriptor/dimensions}}[|i|] is greater than 0, then |dimension| must be equal to |inputDesc|.{{MLOperandDescriptor/dimensions}}[|i|].
+                                1. Set |inputSize| to the product of |inputSize| and |dimension|.
+                                1. Increment |i| by 1.
+                                1. If |i| if equal to the length of |value|.{{MLArrayInput/dimensions}}, then break.
+                        1. Else:
+                            1. For each |dimension| of |inputDesc|.{{MLOperandDescriptor/dimensions}}:
+                                1. The value of |dimension| must be greater than 0.
+                                1. Set |inputSize| to the product of |inputSize| and |dimension|.
+                        1. If |value| is an {{MLArrayInput}}, then let |resource| be |value|.{{MLArrayInput/resource}}.
+                        1. If |value| is an {{ArrayBufferView}}, then let |resource| be |value|.
+                        1. If |resource| is an {{ArrayBufferView}}, then:
+                            1. The kind of |resource| must be compatible with |inputDesc|.{{MLOperandDescriptor/type}} according to [this table](#appendices-mloperandtype-arraybufferview-compatibility).
+                            1. The length of |resource| must be the same as |inputSize|.
+
+                    1. For each |key| -> |value| of |outputs|:
+                        1. |graph|.{{MLGraph/[[outputNames]]}}[|key|] must exist.
+                </div>
+            <!-- Compute -->
+            1. For each |key| -> |value| of |inputs|:
+                1. Let |inputDesc| be |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|].
+                1. Let |inputTensor| be a new tensor for |graph|.{{MLGraph/[[implementation]]}} of data type that is compatible with |inputDesc|.{{MLOperandDescriptor/type}}.
+                1. If |value| is an {{MLArrayInput}}, then:
+                    1. Set the dimensions of |inputTensor| to |value|.{{MLArrayInput/dimensions}}.
+                1. Else:
+                    1. Set the dimensions of |inputTensor| to |inputDesc|.{{MLOperandDescriptor/dimensions}}.
+                1. If |value| is an {{MLArrayInput}}, then:
+                    1. Set the values of |inputTensor| to the values of |value|.{{MLArrayInput/resource}}.
+                1. If |value| is an {{ArrayBufferView}}, then:
+                    1. Set the values of |inputTensor| to the values of |value|.
+                1. Set the input of |graph|.{{MLGraph/[[implementation]]}} that is associated with |key| to |inputTensor|.
+            1. For each |key| -> |value| of |outputs|:
+                1. Issue a compute request for output of |graph|.{{MLGraph/[[implementation]]}} that is associated with |key|.
+                1. Wait for the compute request to be completed.
+                1. If there is an error returned by |graph|.{{MLGraph/[[implementation]]}}, then:
+                    1. Throw an {{OperationError}} {{DOMException}} and stop.
+                1. Else:
+                    1. Let |outputTensor| be the output tensor returned by |graph|.{{MLGraph/[[implementation]]}}.
+                    1. If the kind of |value| is not compatible with the value type of |outputTensor|, then throw a {{DataError}} {{DOMException}} and stop.
+                    1. Let |outputSize| be 1.
+                    1. For each |dimension| of dimensions of |outputTensor|:
+                        1. Set |outputSize| to the product of |outputSize| and |dimension|.
+                    1. If |outputSize| is greater than the length of |value|, then:
+                        1. Throw a {{DataError}} {{DOMException}} and stop.
+                    1. Else:
+                        1. Set the values of |value| to the values of |outputTensor|.
+            1. Return {{undefined}}.
+        </div>
+</dl>
+
+## MLAwaitedExecution ## {#api-mlawaitedexecution}
+The {{MLAwaitedExecution}} interface represents a method of execution that asynchronously carries out the computational workload of a compiled graph {{MLGraph}} on a worker thread to avoid blocking the calling thread while producing results as defined by the operations in the graph. This method of execution requires an {{MLContext}} created with {{MLContextOptions}} or {{WebGLRenderingContext}}.
+
+<script type=idl>
+typedef (MLBufferView or WebGLTexture or GPUTexture) MLResource;
+
+dictionary MLInput {
+  required MLResource resource;
+  required sequence<long> dimensions;
+};
+
+typedef record<DOMString, (MLResource or MLInput)> MLNamedInputs;
+typedef record<DOMString, MLResource> MLNamedOutputs;
+
+[SecureContext, Exposed=(Window, DedicatedWorker)]
+interface MLAwaitedExecution {
+  constructor(MLContext context);
+
+  Promise<MLNamedOutputs> compute(MLGraph graph, MLNamedInputs inputs, MLNamedOutputs outputs);
+};
+</script>
+
+{{MLAwaitedExecution}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="MLAwaitedExecution">
+    : <dfn>\[[context]]</dfn> of type {{MLContext}}
+    ::
+        The context of type {{MLContext}} associated with this {{MLAwaitedExecution}}.
+
+    : <dfn>\[[implementation]]</dfn>
+    ::
+        The underlying implementation provided by the User Agent.
+</dl>
+
+<dl dfn-type=method dfn-for=MLAwaitedExecution>
+    : <dfn>compute(graph, inputs, outputs)</dfn>
+    ::
+        Compute the {{MLGraph}} given {{MLNamedInputs}} and {{MLNamedOutputs}}. Return immediately without blocking the calling thread. The Promise<{{MLNamedOutputs}}> return value will be signaled when the computation is completed on the worker thread and that the results in {{MLNamedOutputs}} are ready to be consumed.
+
+        <div algorithm=MLAwaitedExecution.compute>
+            **Called on:** {{MLAwaitedExecution}} |this|.
+
+            **Arguments:**
+            <pre class=argumentdef for="MLAwaitedExecution/compute(graph, inputs, outputs)">
+                |graph|: an {{MLGraph}}. The compiled graph to be executed.
+                |inputs|: an {{MLNamedInputs}}. The resources and optional dimensions of inputs.
+                |outputs|: an {{MLNamedOutputs}}. The pre-allocated resources of required outputs.
+            </pre>
+
+            **Returns:** Promise<{{MLNamedOutputs}}>.
+
+            1. If any of the following requirements are unmet, then throw a {{DataError}} {{DOMException}} and stop.
+                <div class=validusage>
+                    1. For each |key| -> |value| of |inputs|:
+                        1. |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|] must exist.
+                        1. Let |inputDesc| be |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|].
                         1. Let |inputSize| be 1.
                         1. If |value| is an {{MLInput}}, then:
                             1. The length of |value|.{{MLInput/dimensions}} must be the same as the length of |inputDesc|.{{MLOperandDescriptor/dimensions}}.
@@ -2209,12 +2363,12 @@ interface MLGraph {
                             1. The length of |resource| must be the same as |inputSize|.
 
                     1. For each |key| -> |value| of |outputs|:
-                        1. |this|.{{MLGraph/[[outputNames]]}}[|key|] must exist.
+                        1. |graph|.{{MLGraph/[[outputNames]]}}[|key|] must exist.
                 </div>
             <!-- Compute -->
             1. For each |key| -> |value| of |inputs|:
-                1. Let |inputDesc| be |this|.{{MLGraph/[[inputDescriptors]]}}[|key|].
-                1. Let |inputTensor| be a new tensor for |this|.{{MLGraph/[[implementation]]}} of data type that is compatible with |inputDesc|.{{MLOperandDescriptor/type}}.
+                1. Let |inputDesc| be |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|].
+                1. Let |inputTensor| be a new tensor for |graph|.{{MLGraph/[[implementation]]}} of data type that is compatible with |inputDesc|.{{MLOperandDescriptor/type}}.
                 1. If |value| is an {{MLInput}}, then:
                     1. Set the dimensions of |inputTensor| to |value|.{{MLInput/dimensions}}.
                 1. Else:
@@ -2223,14 +2377,143 @@ interface MLGraph {
                     1. Set the values of |inputTensor| to the values of |value|.{{MLInput/resource}}.
                 1. If |value| is an {{MLResource}}, then:
                     1. Set the values of |inputTensor| to the values of |value|.
-                1. Set the input of |this|.{{MLGraph/[[implementation]]}} that is associated with |key| to |inputTensor|.
+                1. Set the input of |graph|.{{MLGraph/[[implementation]]}} that is associated with |key| to |inputTensor|.
             1. For each |key| -> |value| of |outputs|:
-                1. Issue a compute request for output of |this|.{{MLGraph/[[implementation]]}} that is associated with |key|.
+                1. Issue a compute request for output of |graph|.{{MLGraph/[[implementation]]}} that is associated with |key|.
                 1. Wait for the compute request to be completed.
-                1. If there is an error returned by |this|.{{MLGraph/[[implementation]]}}, then:
+                1. If there is an error returned by |graph|.{{MLGraph/[[implementation]]}}, then:
                     1. Throw an {{OperationError}} {{DOMException}} and stop.
                 1. Else:
-                    1. Let |outputTensor| be the output tensor returned by |this|.{{MLGraph/[[implementation]]}}.
+                    1. Let |outputTensor| be the output tensor returned by |graph|.{{MLGraph/[[implementation]]}}.
+                    1. If the kind of |value| is not compatible with the value type of |outputTensor|, then throw a {{DataError}} {{DOMException}} and stop.
+                    1. Let |outputSize| be 1.
+                    1. For each |dimension| of dimensions of |outputTensor|:
+                        1. Set |outputSize| to the product of |outputSize| and |dimension|.
+                    1. If |outputSize| is greater than the length of |value|, then:
+                        1. Throw a {{DataError}} {{DOMException}} and stop.
+                    1. Else:
+                        1. Set the values of |value| to the values of |outputTensor|.
+            1. Return Promise<{{MLNamedOutputs}}>.
+        </div>
+</dl>
+
+## MLCommandEncoder ## {#api-mlcommandencoder}
+The {{MLCommandEncoder}} interface represents a method of execution that synchronously records the computational workload of a compiled graph {{MLGraph}} to a GPU command buffer {{GPUCommandBuffer}} on the calling thread. Since the workload is not immediately executed, just recorded, this method allows more flexibility for the caller to determine how and when the recorded commands will be submitted for execution on the GPU relative to other GPU workload on the same queue. This method of execution requires an {{MLContext}} created with {{GPUDevice}}.
+
+<script type=idl>
+typedef (GPUBuffer or GPUTexture) MLGPUResource;
+
+dictionary MLGPUInput {
+  required MLGPUResource resource;
+  required sequence<long> dimensions;
+};
+
+typedef record<DOMString, (MLGPUResource or MLGPUInput)> MLNamedGPUInputs;
+typedef record<DOMString, MLGPUResource> MLNamedGPUOutputs;
+
+[SecureContext, Exposed=(Window, DedicatedWorker)]
+interface MLCommandEncoder {
+  constructor(MLContext context);
+
+  undefined initializeGraph(MLGraph graph, MLNamedGPUInputs inputs);
+
+  undefined dispatch(MLGraph graph, MLNamedGPUInputs inputs, MLNamedGPUOutputs outputs);
+
+  GPUCommandBuffer finish(optional GPUCommandBufferDescriptor descriptor = {});
+};
+</script>
+
+{{MLCommandEncoder}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="MLCommandEncoder">
+    : <dfn>\[[context]]</dfn> of type {{MLContext}}
+    ::
+        The context of type {{MLContext}} associated with this {{MLCommandEncoder}}.
+
+    : <dfn>\[[implementation]]</dfn>
+    ::
+        The underlying implementation provided by the User Agent.
+</dl>
+
+<dl dfn-type=method dfn-for=MLCommandEncoder>
+    : <dfn>initializeGraph(graph, inputs)</dfn>
+    ::
+        Record the initialization of the graph {{MLGraph}} on the GPU command buffer {{GPUCommandBuffer}} with constant inputs {{MLNamedGPUInputs}} such as weight inputs. This is a necessary step for optimal performance as it allows the underlying platform an opportunity to prepare and optimize constant input data for the following execution of computational wordloads on the queue. It should only be done once per graph.
+
+        <div algorithm=MLCommandEncoder.initializeGraph>
+            **Called on:** {{MLCommandEncoder}} |this|.
+
+            **Arguments:**
+            <pre class=argumentdef for="MLCommandEncoder/initializeGraph(graph, inputs)">
+                |graph|: an {{MLGraph}}. The compiled graph to be executed.
+                |inputs|: an {{MLNamedGPUInputs}}. The resources and optional dimensions of constant inputs.
+            </pre>
+
+            **Returns:** {{undefined}}.
+        </div>
+
+    : <dfn>dispatch(graph, inputs, outputs)</dfn>
+    ::
+        Record the computational workload of the {{MLGraph}} on the GPU command buffer {{GPUCommandBuffer}} with {{MLNamedGPUInputs}} and {{MLNamedGPUOutputs}}. Return once the recording is completed.
+
+        <div algorithm=MLCommandEncoder.dispatch>
+            **Called on:** {{MLCommandEncoder}} |this|.
+
+            **Arguments:**
+            <pre class=argumentdef for="MLCommandEncoder/dispatch(graph, inputs, outputs)">
+                |graph|: an {{MLGraph}}. The compiled graph to be executed.
+                |inputs|: an {{MLNamedGPUInputs}}. The resources and optional dimensions of inputs.
+                |outputs|: an {{MLNamedGPUOutputs}}. The pre-allocated resources of required outputs.
+            </pre>
+
+            **Returns:** {{undefined}}.
+
+            1. If any of the following requirements are unmet, then throw a {{DataError}} {{DOMException}} and stop.
+                <div class=validusage>
+                    1. For each |key| -> |value| of |inputs|:
+                        1. |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|] must exist.
+                        1. Let |inputDesc| be |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|].
+                        1. Let |inputSize| be 1.
+                        1. If |value| is an {{MLGPUInput}}, then:
+                            1. The length of |value|.{{MLGPUInput/dimensions}} must be the same as the length of |inputDesc|.{{MLOperandDescriptor/dimensions}}.
+                            1. Let |i| be 0.
+                            1. While true:
+                                1. Let |dimension| be |value|.{{MLGPUInput/dimensions}}[|i|].
+                                1. |dimension| must be greater than 0.
+                                1. If |inputDesc|.{{MLOperandDescriptor/dimensions}}[|i|] is greater than 0, then |dimension| must be equal to |inputDesc|.{{MLOperandDescriptor/dimensions}}[|i|].
+                                1. Set |inputSize| to the product of |inputSize| and |dimension|.
+                                1. Increment |i| by 1.
+                                1. If |i| if equal to the length of |value|.{{MLGPUInput/dimensions}}, then break.
+                        1. Else:
+                            1. For each |dimension| of |inputDesc|.{{MLOperandDescriptor/dimensions}}:
+                                1. The value of |dimension| must be greater than 0.
+                                1. Set |inputSize| to the product of |inputSize| and |dimension|.
+                        1. If |value| is an {{MLGPUInput}}, then let |resource| be |value|.{{MLGPUInput/resource}}.
+                        1. If |value| is an {{MLGPUResource}}, then let |resource| be |value|.
+
+                    1. For each |key| -> |value| of |outputs|:
+                        1. |graph|.{{MLGraph/[[outputNames]]}}[|key|] must exist.
+                </div>
+            <!-- Dispatch -->
+            1. For each |key| -> |value| of |inputs|:
+                1. Let |inputDesc| be |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|].
+                1. Let |inputTensor| be a new tensor for |graph|.{{MLGraph/[[implementation]]}} of data type that is compatible with |inputDesc|.{{MLOperandDescriptor/type}}.
+                1. If |value| is an {{MLGPUInput}}, then:
+                    1. Set the dimensions of |inputTensor| to |value|.{{MLGPUInput/dimensions}}.
+                1. Else:
+                    1. Set the dimensions of |inputTensor| to |inputDesc|.{{MLOperandDescriptor/dimensions}}.
+                1. If |value| is an {{MLGPUInput}}, then:
+                    1. Set the values of |inputTensor| to the values of |value|.{{MLGPUInput/resource}}.
+                1. If |value| is an {{MLGPUResource}}, then:
+                    1. Set the values of |inputTensor| to the values of |value|.
+                1. Set the input of |graph|.{{MLGraph/[[implementation]]}} that is associated with |key| to |inputTensor|.
+            1. For each |key| -> |value| of |outputs|:
+                1. Issue a compute request for output of |graph|.{{MLGraph/[[implementation]]}} that is associated with |key|.
+                1. Wait for the compute request to be completed.
+                1. If there is an error returned by |graph|.{{MLGraph/[[implementation]]}}, then:
+                    1. Throw an {{OperationError}} {{DOMException}} and stop.
+                1. Else:
+                    1. Let |outputTensor| be the output tensor returned by |graph|.{{MLGraph/[[implementation]]}}.
                     1. If the kind of |value| is not compatible with the value type of |outputTensor|, then throw a {{DataError}} {{DOMException}} and stop.
                     1. Let |outputSize| be 1.
                     1. For each |dimension| of dimensions of |outputTensor|:
@@ -2240,8 +2523,21 @@ interface MLGraph {
                     1. Else:
                         1. Set the values of |value| to the values of |outputTensor|.
             1. Return {{undefined}}.
+        </div>
 
-            Issue: Describe the algorithm steps for |this|.{{MLGraph/[[context]]}} created from {{WebGLRenderingContext}} and {{GPUDevice}}.
+    : <dfn>finish(descriptor)</dfn>
+    ::
+        Complete the recording of the command sequence and return a corresponding {{GPUCommandBuffer}}.
+
+        <div algorithm=MLCommandEncoder.finish>
+            **Called on:** {{MLCommandEncoder}} |this|.
+
+            **Arguments:**
+            <pre class=argumentdef for="MLCommandEncoder/finish(descriptor)">
+                |descriptor|: an {{GPUCommandBufferDescriptor}}. Descriptor of the command buffer.
+            </pre>
+
+            **Returns:** {{GPUCommandBuffer}}.
         </div>
 </dl>
 
@@ -2266,6 +2562,9 @@ const b = builder.input('b', descB);
 const c = builder.matmul(a, b);
 const graph = builder.build({'c': c});
 
+// Create a graph execution method
+const execution = new MLExecution(context);
+
 function allocateAndCompute(shapeA, shapeB, shapeC) {
   const bufferA = new Float32Array(sizeOfShape(shapeA)).fill(0.5);
   const bufferB = new Float32Array(sizeOfShape(shapeB)).fill(0.5);
@@ -2277,7 +2576,7 @@ function allocateAndCompute(shapeA, shapeB, shapeC) {
     'b': {resource: bufferB, dimensions: shapeB},
   };
   const outputs = {'c': bufferC};
-  graph.compute(inputs, outputs);
+  execution.compute(graph, inputs, outputs);
   console.log(&#96;values: ${bufferC}&#96;);
 }
 
@@ -2306,17 +2605,20 @@ const d = builder.matmul(a, b);
 const e = builder.add(d, c);
 const graph = builder.build({'d': d, 'e': e});
 
+// Create a graph execution method
+const execution = new MLExecution(context);
+
 const bufferA = new Float32Array(sizeOfShape(descA.dimensions)).fill(0.5);
 const inputs = {'a': bufferA};
 
 // Compute d.
 const bufferD = new Float32Array(sizeOfShape([3, 3]));
-graph.compute(inputs, {'d': bufferD});
+execution.compute(graph, inputs, {'d': bufferD});
 console.log(&#96;values: ${bufferD}&#96;);
 
 // Compute e.
 const bufferE = new Float32Array(sizeOfShape([3, 3]));
-graph.compute(inputs, {'e': bufferE});
+execution.compute(graph, inputs, {'e': bufferE});
 console.log(&#96;values: ${bufferE}&#96;);
 </pre>
 </div>
@@ -2386,6 +2688,14 @@ const graph = builder.build({'output': output});
 </div>
 
 <div class="example">
+Create the graph execution method that carries out immediately on the calling thread.
+<pre highlight="js">
+// Create the graph execution method
+const execution = new MLExecution(context);
+</pre>
+</div>
+
+<div class="example">
 The following code executes the compiled graph.
 <pre highlight="js">
 // Setup the input buffers with value 1.
@@ -2399,7 +2709,7 @@ const inputs = {
   'input2': inputBuffer2,
 };
 const outputs = {'output': outputBuffer};
-graph.compute(inputs, outputs);
+execution.compute(graph, inputs, outputs);
 
 console.log('Output value: ' + outputBuffer);
 // Output value: 2.25,2.25,2.25,2.25,2.25,2.25,2.25,2.25


### PR DESCRIPTION
Based on the discussion in issue #230, we define three methods of execution for the compiled graph as follow:

*Immediate Execution* through the `MLExecution` interface:
> The [MLExecution](https://api.csswg.org/bikeshed/#mlexecution) interface represents a method of execution that synchronously carries out the computational workload of a compiled graph [MLGraph](https://api.csswg.org/bikeshed/#mlgraph) on the calling thread, which must be a worker thread, to produce results as defined by the operations in the graph. This method of execution requires an [MLContext](https://api.csswg.org/bikeshed/#mlcontext) created with [MLContextOptions](https://api.csswg.org/bikeshed/#dictdef-mlcontextoptions) with the [MLDevicePreference](https://api.csswg.org/bikeshed/#enumdef-mldevicepreference) option set to either "cpu" or "default" resolved to a CPU context.

*Async Execution* through the `MLAwaitedExecution` interface:
> The [MLAwaitedExecution](https://api.csswg.org/bikeshed/#mlawaitedexecution) interface represents a method of execution that asynchronously carries out the computational workload of a compiled graph [MLGraph](https://api.csswg.org/bikeshed/#mlgraph) on a worker thread to avoid blocking the calling thread while producing results as defined by the operations in the graph. This method of execution requires an [MLContext](https://api.csswg.org/bikeshed/#mlcontext) created with [MLContextOptions](https://api.csswg.org/bikeshed/#dictdef-mlcontextoptions) or [WebGLRenderingContext](https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14).

*Queued Execution* through the `MLCommandEncoder` interface:
> The [MLCommandEncoder](https://api.csswg.org/bikeshed/#mlcommandencoder) interface represents a method of execution that synchronously records the computational workload of a compiled graph [MLGraph](https://api.csswg.org/bikeshed/#mlgraph) to a GPU command buffer [GPUCommandBuffer](https://gpuweb.github.io/gpuweb/#command-buffers) on the calling thread. Since the workload is not immediately executed, just recorded, this method allows more flexibility for the caller to determine how and when the recorded commands will be submitted for execution on the GPU relative to other GPU workload on the same queue. This method of execution requires an [MLContext](https://api.csswg.org/bikeshed/#mlcontext) created with [GPUDevice](https://gpuweb.github.io/gpuweb/#gpu-device).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/pull/255.html" title="Last updated on Mar 10, 2022, 9:37 AM UTC (078ff38)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/255/2ea57d1...078ff38.html" title="Last updated on Mar 10, 2022, 9:37 AM UTC (078ff38)">Diff</a>