### PR TITLE
Fix Makefile for offline mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,6 @@ ifdef online
 	fi; \
 	curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F force=1 > index.html
 else
-	bikeshed --die-on=everything spec index.bs
+#	bikeshed -f spec index.bs
+	bikeshed --die-on=fatal spec index.bs
 endif


### PR DESCRIPTION
Currently the bikeshed offline mode fails, since it's using the "die on everything" policy (see [bikeshed options](https://tabatkins.github.io/bikeshed/#cli-options)).
The bikeshed online mode uses forced mode, i.e. "die on nothing".
This small change uses "die on fatal" policy in offline mode, and keeps "die on nothing" for online mode.
The offline "die on nothing", i.e. forced mode is left in a comment.

Signed-off-by: Zoltan Kis <zoltan.kis@intel.com>