### PR TITLE
Use unsigned long type for sizes option of resample2d

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2073,7 +2073,7 @@ enum MLInterpolationMode {
 dictionary MLResample2dOptions {
   MLInterpolationMode mode = "nearest-neighbor";
   sequence<float> scales;
-  sequence<long> sizes;
+  sequence<unsigned long> sizes;
   sequence<long> axes;
 };
 
@@ -2088,7 +2088,7 @@ partial interface MLGraphBuilder {
             - *mode*: an {{MLInterpolationMode}}. The interpolation algorithm used to fill the output tensor values.
                 If not set, it is assumed to be the *Nearest Neighbor* interpolation.
             - *scales*: a sequence of {{float}} of length 2. Each value represents the scaling factor used to scale in each spatial dimensions of input, [scale_height, scale_width]. If not set, the values are assumed to be [1.0, 1.0].
-            - *sizes*: a sequence of {{long}} of length 2. The target sizes for each spatial dimensions of input, [size_height, size_width]. When the target sizes are specified, the *options.scales* argument is ignored as the scaling factor values are derived from the target sizes of each spatial dimension of input.
+            - *sizes*: a sequence of {{unsigned long}} of length 2. The target sizes for each spatial dimensions of input, [size_height, size_width]. When the target sizes are specified, the *options.scales* argument is ignored as the scaling factor values are derived from the target sizes of each spatial dimension of input.
             - *axes*: a sequence of {{long}} of length 2. The two consecutive dimensions of the input tensor to which the interpolation algorithm applies. The valid values in the sequence are [0, 1], [1, 2] or [2, 3]. When not specified, the sequence is assumed to be [2, 3].
 
     **Returns:** an {{MLOperand}}. The output 4-D tensor.


### PR DESCRIPTION
The sizes option of resample2d specifies the target sizes for each spatial dimensions of input operand. Its type should be consistent with the type of operand dimensions which is unsigned long.

fix #300

@wchao1115 @anssiko @wacky6, PTAL.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/306.html" title="Last updated on Dec 5, 2022, 2:42 AM UTC (a91d79b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/306/64e2648...huningxin:a91d79b.html" title="Last updated on Dec 5, 2022, 2:42 AM UTC (a91d79b)">Diff</a>