### PR TITLE
Fix #311: use [=map/exist=] instead of exist

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -693,12 +693,12 @@ partial interface MLContext {
     1. If any of the following requirements are unmet, then throw a {{DataError}} {{DOMException}} and stop.
         <div class=validusage>
             1. For each |key| -> |value| of |inputs|:
-                1. |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|] must exist.
+                1. |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|] must [=map/exist=].
                 1. Let |inputDesc| be |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|].
                 1. The type of {{ArrayBufferView}} |value| must match |inputDesc|.{{MLOperandDescriptor/type}} according to [this table](#appendices-mloperandtype-arraybufferview-compatibility).
                 1. |value|.\[[ByteLength]] must equal to [=byte length=] of |inputDesc|.
             1. For each |key| -> |value| of |outputs|:
-                1. |graph|.{{MLGraph/[[outputDescriptors]]}}[|key|] must exist.
+                1. |graph|.{{MLGraph/[[outputDescriptors]]}}[|key|] must [=map/exist=].
                 1. Let |outputDesc| be |graph|.{{MLGraph/[[outputDescriptors]]}}[|key|].
                 1. The type of {{ArrayBufferView}} |value| must match |outputDesc|.{{MLOperandDescriptor/type}} according to [this table](#appendices-mloperandtype-arraybufferview-compatibility).
                 1. |value|.\[[ByteLength]] must equal to [=byte length=] of |outputDesc|.
@@ -783,12 +783,12 @@ partial interface MLContext {
     1. If any of the following requirements are unmet, then throw a {{DataError}} {{DOMException}} and stop.
         <div class=validusage>
             1. For each |key| -> |value| of |inputs|:
-                1. |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|] must exist.
+                1. |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|] must [=map/exist=].
                 1. Let |inputDesc| be |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|].
                 1. The type of {{ArrayBufferView}} |value| must match |inputDesc|.{{MLOperandDescriptor/type}} according to [this table](#appendices-mloperandtype-arraybufferview-compatibility).
                 1. |value|.\[[ByteLength]] must equal to [=byte length=] of |inputDesc|.
             1. For each |key| -> |value| of |outputs|:
-                1. |graph|.{{MLGraph/[[outputDescriptors]]}}[|key|] must exist.
+                1. |graph|.{{MLGraph/[[outputDescriptors]]}}[|key|] must [=map/exist=].
                 1. Let |outputDesc| be |graph|.{{MLGraph/[[outputDescriptors]]}}[|key|].
                 1. The type of {{ArrayBufferView}} |value| must match |outputDesc|.{{MLOperandDescriptor/type}} according to [this table](#appendices-mloperandtype-arraybufferview-compatibility).
                 1. |value|.\[[ByteLength]] must equal to [=byte length=] of |outputDesc|.
@@ -2468,12 +2468,12 @@ partial interface MLCommandEncoder {
       1. If any of the following requirements are unmet, then throw a {{DataError}} {{DOMException}} and stop.
           <div class=validusage>
             1. For each |key| -> |value| of |inputs|:
-                1. |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|] must exist.
+                1. |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|] must [=map/exist=].
                 1. Let |inputDesc| be |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|].
                 1. If |value| is a {{GPUBuffer}}, then:
                     1. |value|.{{GPUBuffer/size}} must equal to [=byte length=] of |inputDesc|.
             1. For each |key| -> |value| of |outputs|:
-                1. |graph|.{{MLGraph/[[outputDescriptors]]}}[|key|] must exist.
+                1. |graph|.{{MLGraph/[[outputDescriptors]]}}[|key|] must [=map/exist=].
                 1. Let |outputDesc| be |graph|.{{MLGraph/[[outputDescriptors]]}}[|key|].
                 1. If |value| is a {{GPUBuffer}}, then:
                     1. |value|.{{GPUBuffer/size}} must equal to [=byte length=] of |outputDesc|.


### PR DESCRIPTION
A trivial editorial change, just add correct referencing to "exist" clauses.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zolkis/webnn/pull/313.html" title="Last updated on Dec 12, 2022, 7:09 PM UTC (f4a7f13)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/313/8ac6b40...zolkis:f4a7f13.html" title="Last updated on Dec 12, 2022, 7:09 PM UTC (f4a7f13)">Diff</a>