### PR TITLE
Simplify MLContext creation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -516,19 +516,19 @@ a graph execution method that provides the maximum flexibility to callers that a
 application. It does this by placing the workload required to initialize and compute the results of the
 operations in the graph onto a {{GPUCommandBuffer}}. The callers are responsible for the eventual submission
 of this workload on the {{GPUQueue}} through the WebGPU queue submission mechanism. Once the submitted workload
-is completely executed, the result is avaialble in the bound output buffers.
+is completely executed, the result is available in the bound output buffers.
 
 ## Context and Device Association ## {#programming-model-context-device-association}
 
 An {{MLContext}} interface represents a state of neural network execution. An important function of this state is manage resources used in the compilation 
-and execution of the neural network graph. An implementation in a user agent may implement this state in term of CPU resources when an {{MLContext}} is created 
+and execution of the neural network graph. An implementation in a user agent may implement this state in terms of CPU resources when an {{MLContext}} is created 
 without an explicit association with a hardware device (aka. a *"default context"*). However, when an {{MLContext}} is created from a specific {{GPUDevice}} that 
 is also used by the application of WebGPU (aka. a *"GPU context"*), any GPU resource created from the same {{GPUDevice}} such as the {{GPUBuffer}} or {{GPUTexture}} 
 is considered a native resource that can also be used as a graph constant, input, or output operand.
 
 In a situation when a GPU context executes a graph with a constant or an input or output allocated in the system memory as in an {{ArrayBufferView}}, the content 
 is automatically uploaded from the system memory to the GPU memory, and downloaded back to the system memory of an {{ArrayBufferView}} output buffer at the end of 
-the graph execution. This automatic data upload and download cycles will only occur whenever the executing GPU context determines that the data be copied out of or back 
+the graph execution. This automatic data upload and download cycles will only occur whenever the executing GPU context determines that the data must be copied out of or back 
 into the system memory as part of the execution. Additionally, the eventual result of the execution must also be in a known layout format. While the internal execution 
 technique may be optimized for native memory access pattern in an intermediate result within the graph, the output of the last operation of the graph must convert 
 the content back to a known layout format at the end of the graph in order to maintain interoperability as expected by the caller.

--- a/index.bs
+++ b/index.bs
@@ -520,15 +520,16 @@ is completely executed, the result is available in the bound output buffers.
 
 ## Context and Device Association ## {#programming-model-context-device-association}
 
-An {{MLContext}} interface represents a state of neural network execution. An important function of this state is manage resources used in the compilation 
-and execution of the neural network graph. An implementation in a user agent may implement this state in terms of CPU resources when an {{MLContext}} is created 
-without an explicit association with a hardware device (aka. a *"default context"*). However, when an {{MLContext}} is created from a specific {{GPUDevice}} that 
-is also used by the application of WebGPU (aka. a *"GPU context"*), any GPU resource created from the same {{GPUDevice}} such as the {{GPUBuffer}} or {{GPUTexture}} 
-is considered a native resource that can also be used as a graph constant, input, or output operand.
+An {{MLContext}} interface represents a state of a neural network execution. An important function of this state is to manage resources used in the compilation 
+and execution of the neural network graph. An implementation in a user agent may implement this state in terms of CPU resources and execution when an {{MLContext}} 
+is created without an explicit association with a hardware device (aka. a *"default context"*). However, when an {{MLContext}} is created from a WebGPU {{GPUDevice}} 
+(aka. a *"GPU context"*), the implementation uses the specified GPU device as a resource domain for the subsequent compilation and execution of the graph. 
+Any GPU resource such as the {{GPUBuffer}} or {{GPUTexture}} created from the same {{GPUDevice}} is therefore considered a resource of native resource type that 
+can be used to store a graph constant, input, or output operand.
 
 In a situation when a GPU context executes a graph with a constant or an input or output allocated in the system memory as in an {{ArrayBufferView}}, the content 
 is automatically uploaded from the system memory to the GPU memory, and downloaded back to the system memory of an {{ArrayBufferView}} output buffer at the end of 
-the graph execution. This automatic data upload and download cycles will only occur whenever the executing GPU context determines that the data must be copied out of or back 
+the graph execution. These automatic data upload and download cycles will only occur whenever the executing GPU context determines that the data must be copied out of or back 
 into the system memory as part of the execution. Additionally, the eventual result of the execution must also be in a known layout format. While the internal execution 
 technique may be optimized for native memory access pattern in an intermediate result within the graph, the output of the last operation of the graph must convert 
 the content back to a known layout format at the end of the graph in order to maintain interoperability as expected by the caller.

--- a/index.bs
+++ b/index.bs
@@ -663,7 +663,7 @@ To <dfn lt="validate MLContext">validate {{MLContext}}</dfn>, given |context|, r
 1. Return `true`;
 
 ### Synchronous Execution ### {#api-mlcontext-sync-execution}
-Synchronously carries out the computational workload of a compiled graph {{MLGraph}} on the calling thread, which must be a worker thread, to produce results as defined by the operations in the graph. This method of execution requires an {{MLContext}} created with {{MLContextOptions}}. Otherwise, it throws an "{{OperationError}}" {{DOMException}}.
+Synchronously carries out the computational workload of a compiled graph {{MLGraph}} on the calling thread, which must be a worker thread, to produce results as defined by the operations in the graph.
 
 <script type=idl>
 partial interface MLContext {
@@ -754,7 +754,7 @@ console.log(&#96;values: ${bufferE}&#96;);
 </div>
 
 ### Asynchronous Execution ### {#api-mlcontext-async-execution}
-Asynchronously carries out the computational workload of a compiled graph {{MLGraph}} on a separate timeline, either on a CPU worker thread or on a GPU timeline submitting a GPU workload on the command queue. The asynchronous nature of this call avoids blocking the calling thread while the computation for result is ongoing. This method of execution requires an {{MLContext}} created with {{MLContextOptions}}. Otherwise, it throws an "{{OperationError}}" {{DOMException}}.
+Asynchronously carries out the computational workload of a compiled graph {{MLGraph}} on a separate timeline, either on a CPU worker thread or on a GPU timeline submitting a GPU workload on the command queue. The asynchronous nature of this call avoids blocking the calling thread while the computation for result is ongoing.
 
 <script type=idl>
 partial interface MLContext {

--- a/index.bs
+++ b/index.bs
@@ -401,7 +401,7 @@ As a future-proofing measure, the API design allows certain operations that can 
 
 Issue: Investigate side channel attack feasibility considering the current state where CPU is shared between processes running renderers.
 
-In order to not allow an attacker to target a specific implementation that may contain a flaw, the [[#programming-model-device-selection]] mechanism is a hint only, and the concrete device selection is left to the implementation - a user agent could for instance choose never to run a model on a device with known vulnerabilities. As a further mitigation, no device enumeration mechanism is defined.
+In order to not allow an attacker to target a specific implementation that may contain a flaw, the [[#programming-model-context-device-association]] mechanism is a hint only, and the concrete device selection is left to the implementation - a user agent could for instance choose never to run a model on a device with known vulnerabilities. As a further mitigation, no device enumeration mechanism is defined.
 
 Issue: Hinting partially mitigates the concern. Investigate additional mitigations.
 
@@ -442,7 +442,7 @@ Unlike WebGPU, this API does not intrinsically support custom shader authoring; 
 
 The WebGPU API identifies <a href="https://gpuweb.github.io/gpuweb/#privacy-machine-artifacts">machine-specific artifacts</a> as a privacy consideration. Given the WebNN API defines means to record an ML workload onto a WebGPU-compatible {{GPUCommandBuffer}}, compute unit scheduling may under certain circumstances introduce a fingerprint. However, similarly to WebGPU, such fingerprints are identical across most or all of the devices of each vendor, mitigating the concern. Furthermore, software implementations can be used to further eliminate such artifacts.
 
-The WebNN API defines two developer-settable preferences to help inform [[#programming-model-device-selection]] and allow the implementation to better select the most appropriate underlying execution device for the workload. [=Device type=] normatively indicates the kind of device and is either "cpu" or "gpu". If this type cannot be satisfied, an "{{OperationError}}" {{DOMException}} is thrown, thus this type can in some cases add two bits of entropy to the fingerprint. [=Power preference=] indicates preference as related to the power consumption and is considered a hint only and as such does not increase entropy of the fingerprint.
+The WebNN API defines developer-settable preferences to help inform [[#programming-model-context-device-association]] and allow the implementation to better select the most appropriate underlying execution device for the workload. [=Power preference=] indicates preference as related to the power consumption and is considered a hint only and as such does not increase entropy of the fingerprint.
 
 If a future version of this specification introduces support for new a  [=device type=] that can only support a subset of {{MLOperandType}}s, that may introduce a new fingerprint.
 
@@ -491,26 +491,27 @@ that shares the same buffer as the input tensor. (In the case of reshape or sque
 the entire data is shared, while in the case of slice, a part of the input data is shared.)
 The implementation may use views, as above, for intermediate values.
 
-Before the execution, the computation graph that is used to compute one or more specified outputs needs to be compiled and optimized. The key purpose of the compilation step is to enable optimizations that span two or more operations, such as operation or loop fusion.
+Before the execution, the computation graph that is used to compute one or more specified outputs needs to be compiled and optimized. 
+The key purpose of the compilation step is to enable optimizations that span two or more operations, such as operation or loop fusion.
 
-There are multiple ways by which the graph may be compiled. The {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} method compiles the graph in the background without blocking the calling thread, and returns a {{Promise}} that resolves to an {{MLGraph}}. The {{MLGraphBuilder}}.{{MLGraphBuilder/buildSync()}} method compiles the graph immediately on the calling thread, which must be a worker thread running on CPU or GPU device, and returns an {{MLGraph}}. Both compilation methods produce an {{MLGraph}} that represents a compiled graph for optimal execution.
+There are multiple ways by which the graph may be compiled. The {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} method compiles the graph 
+in the background without blocking the calling thread, and returns a {{Promise}} that resolves to an {{MLGraph}}. The 
+{{MLGraphBuilder}}.{{MLGraphBuilder/buildSync()}} method compiles the graph immediately on the calling thread, which must be a worker 
+thread and returns an {{MLGraph}}. Both compilation methods produce an {{MLGraph}} that represents a compiled graph for optimal execution.
 
 Once the {{MLGraph}} is constructed, there are multiple ways by which the graph may be executed. The
 {{MLContext}}.{{MLContext/computeSync()}} method represents a way the execution of the graph is carried out immediately
-on the calling thread, which must also be a worker thread, either on a CPU or GPU device. The execution
-produces the results of the computation from all the inputs bound to the graph.
+on the calling thread, which must also be a worker thread. The execution produces the results of the computation from all the inputs bound to the graph.
 
-The {{MLContext}}.{{MLContext/compute()}} method represents a way the execution of the graph is performed asynchronously
-either on a parallel timeline in a separate worker thread for the CPU execution or on a GPU timeline in a GPU
-command queue. This method returns immediately without blocking the calling thread while the actual execution is
-offloaded to a different timeline. This type of execution is appropriate when the responsiveness of the calling
-thread is critical to good user experience. The computation results will be placed at the bound outputs at the
-time the operation is successfully completed on the offloaded timeline at which time the calling thread is
-signaled. This type of execution supports both the CPU and GPU device.
+The {{MLContext}}.{{MLContext/compute()}} method represents a way the execution of the graph is performed asynchronously either on a parallel 
+timeline in a CPU worker thread or on a GPU timeline executing a GPU command queue. This method returns immediately without blocking the calling 
+thread while the actual execution is offloaded to a different timeline. This type of execution is appropriate when the responsiveness of the calling 
+thread is critical to good user experience. The computation results will be placed at the bound outputs at the time the operation is successfully 
+completed on the offloaded timeline at which time the calling thread is signaled.
 
 In both the {{MLContext}}.{{MLContext/compute()}} and {{MLContext}}.{{MLContext/computeSync()}} execution methods, the caller supplies
-the input values using {{MLNamedArrayBufferViews}}, binding the input {{MLOperand}}s to their values. The caller
-then supplies pre-allocated buffers for output {{MLOperand}}s using {{MLNamedArrayBufferViews}}.
+the input values using {{MLNamedArrayBufferViews}}, binding the input {{MLOperand}}s to their values. The caller then supplies pre-allocated 
+buffers for output {{MLOperand}}s using {{MLNamedArrayBufferViews}}.
 
 The {{MLCommandEncoder}} interface created by the {{MLContext}}.{{MLContext/createCommandEncoder()}} method supports
 a graph execution method that provides the maximum flexibility to callers that also utilize WebGPU in their
@@ -519,21 +520,28 @@ operations in the graph onto a {{GPUCommandBuffer}}. The callers are responsible
 of this workload on the {{GPUQueue}} through the WebGPU queue submission mechanism. Once the submitted workload
 is completely executed, the result is avaialble in the bound output buffers.
 
-## Device Selection ## {#programming-model-device-selection}
+## Context and Device Association ## {#programming-model-context-device-association}
 
-An {{MLContext}} interface represents a global state of neural network execution. One of the important context states is the underlying execution device that manages the resources and facilitates the compilation and the eventual execution of the neural network graph. In addition to the default method of creation with {{MLContextOptions}}, an {{MLContext}} could also be created from a specific {{GPUDevice}} that is already in use by the application, in which case the corresponding {{GPUBuffer}} resources used as graph constants, as well as the {{GPUTexture}} as graph inputs must also be created from the same device. In a multi-adapter configuration, the device used for {{MLContext}} must be created from the same adapter as the device used to allocate the resources referenced in the graph.
+An {{MLContext}} interface represents a state of neural network execution. An important function of this state is manage resources used in the compilation 
+and execution of the neural network graph. An implementation in a user agent may implement this state in term of CPU resources when an {{MLContext}} is created 
+without an explicit association with a hardware device (aka. a *"default context"*). However, when an {{MLContext}} is created from a specific {{GPUDevice}} that 
+is also used by the application of WebGPU (aka. a *"GPU context"*), any GPU resource created from the same {{GPUDevice}} such as the {{GPUBuffer}} or {{GPUTexture}} 
+is considered a native resource that can also be used as a graph constant, input, or output operand.
 
-In a situation when a GPU context executes a graph with a constant or an input in the system memory as an {{ArrayBufferView}}, the input content is automatically uploaded from the system memory to the GPU memory, and downloaded back to the system memory of an {{ArrayBufferView}} output buffer at the end of the graph execution. This data upload and download cycles will only occur whenever the execution device requires the data to be copied out of and back into the system memory, such as in the case of the GPU. It doesn't occur when the device is a CPU device. Additionally, the result of the graph execution is in a known layout format. While the execution may be optimized for a native memory access pattern in an intermediate result within the graph, the output of the last operation of the graph must convert the content back to a known layout format at the end of the graph in order to maintain the expected behavior from the caller's perspective.
+In a situation when a GPU context executes a graph with a constant or an input or output allocated in the system memory as in an {{ArrayBufferView}}, the content 
+is automatically uploaded from the system memory to the GPU memory, and downloaded back to the system memory of an {{ArrayBufferView}} output buffer at the end of 
+the graph execution. This automatic data upload and download cycles will only occur whenever the executing GPU context determines that the data be copied out of or back 
+into the system memory as part of the execution. Additionally, the eventual result of the execution must also be in a known layout format. While the internal execution 
+technique may be optimized for native memory access pattern in an intermediate result within the graph, the output of the last operation of the graph must convert 
+the content back to a known layout format at the end of the graph in order to maintain interoperability as expected by the caller.
 
-When an {{MLContext}} is created with {{MLContextOptions}}, the user agent selects and creates the underlying execution device by taking into account the application's [=power preference=] and [=device type=] specified in the {{MLPowerPreference}} and {{MLDeviceType}} options.
-
-The following table summarizes the types of resource supported by the context created through different method of creation:
+The following table summarizes the types of resource supported by the context created through different methods of creation:
 
 <div class="note">
 <table>
-  <tr><th>Creation method<th>ArrayBufferView<th>GPUBuffer<th>GPUTexture
-  <tr><td>MLContextOptions<td>Yes<td>No<td>No
-  <tr><td>GPUDevice<td>Yes<td>Yes<td>Yes
+  <tr><th>Context Type<th>ArrayBufferView<th>GPUBuffer<th>GPUTexture
+  <tr><td>Default Context<td>Yes<td>No<td>No
+  <tr><td>GPU Context<td>Yes<td>Yes<td>Yes
 </table>
 </div>
 
@@ -555,29 +563,26 @@ WorkerNavigator includes NavigatorML;
 
 ## The ML interface ## {#api-ml}
 <script type=idl>
-enum MLDeviceType {
-  "cpu",
-  "gpu"
-};
-
 enum MLPowerPreference {
   "default",
-  "high-performance",
   "low-power"
 };
 
 dictionary MLContextOptions {
-  MLDeviceType deviceType = "cpu";
   MLPowerPreference powerPreference = "default";
 };
 
 [SecureContext, Exposed=(Window, DedicatedWorker)]
 interface ML {
+  // Default context
   Promise<MLContext> createContext(optional MLContextOptions options = {});
-  Promise<MLContext> createContext(GPUDevice gpuDevice);
 
   [Exposed=(DedicatedWorker)]
   MLContext createContextSync(optional MLContextOptions options = {});
+
+  // GPU context
+  Promise<MLContext> createContext(GPUDevice gpuDevice);
+
   [Exposed=(DedicatedWorker)]
   MLContext createContextSync(GPUDevice gpuDevice);
 };
@@ -599,11 +604,9 @@ The {{ML/createContext()}} method steps are:
     1. Let |context| be a new {{MLContext}} object.
     1. If |options| is a {{GPUDevice}} object,
         1. Set |context|.{{[[contextType]]}} to "[=webgpu-context|webgpu=]".
-        1. Set |context|.{{[[deviceType]]}} to "[=device-type-gpu|gpu=]".
         1. Set |context|.{{[[powerPreference]]}} to "[=power-preference-default|default=]".
     1. Otherwise,
         1. Set |context|.{{[[contextType]]}} to "[=default-context|default=]".
-        1. If |options|["{{deviceType}}"] [=map/exists=], then set |context|.{{[[deviceType]]}} to |options|["{{deviceType}}"]. Otherwise, set |context|.{{[[deviceType]]}} to "[=device-type-cpu|cpu=]".
         1. If |options|["{{powerPreference}}"] [=map/exists=], then set |context|.{{[[powerPreference]]}} to |options|["{{powerPreference}}"]. Otherwise, set |context|.{{[[powerPreference]]}} to "[=power-preference-default|default=]".
 1. If the <a>validate MLContext</a> steps given |context| return `false`, [=reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}} and abort these steps.
 1. [=Resolve=] |promise| with |context|.
@@ -617,30 +620,20 @@ The {{ML/createContextSync()}} method steps are:
 1. Return |context|.
 
 ## The MLContext interface ## {#api-mlcontext}
-The {{MLContext}} interface represents a global state of neural network compute workload and execution processes. Each {{MLContext}} object has associated [=context type=], [=device type=] and [=power preference=].
+The {{MLContext}} interface represents a global state of neural network compute workload and execution processes. Each {{MLContext}} object has associated [=context type=] and [=power preference=].
 
 The <dfn>context type</dfn> is the type of the execution context that manages the resources and facilitates the compilation and execution of the neural network graph:
 <dl>
 <dt>"<code><dfn data-lt="default-context">default</dfn></code>"</dt>
 <dd>Context created per user preference options.</dd>
 <dt>"<code><dfn data-lt="webgpu-context">webgpu</dfn></code>"</dt>
-<dd>Context created from WebGPU device.</dd>
-</dl>
-
-The <dfn>device type</dfn> indicates the kind of device used for the context. It is one of the following:
-<dl>
-<dt>"<code><dfn data-lt="device-type-cpu">cpu</dfn></code>"</dt>
-<dd>Provides the broadest compatibility and usability across all client devices with varying degrees of performance.</dd>
-<dt>"<code><dfn data-lt="device-type-gpu">gpu</dfn></code>"</dt>
-<dd>Provides the broadest range of achievable performance across graphics hardware platforms from consumer devices to professional workstations.</dd>
+<dd>Context created from a WebGPU device.</dd>
 </dl>
 
 The <dfn>power preference</dfn> indicates preference as related to power consumption. It is one of the following:
 <dl>
 <dt>"<code><dfn data-lt="power-preference-default">default</dfn></code>"</dt>
 <dd>Let the user agent select the most suitable behavior.</dd>
-<dt>"<code><dfn data-lt="power-preference-high-performance">high-performance</dfn></code>"</dt>
-<dd>Prioritizes execution speed over power consumption.</dd>
 <dt>"<code><dfn data-lt="power-preference-low-power">low-power</dfn></code>"</dt>
 <dd>Prioritizes power consumption over other considerations such as execution speed.</dd>
 </dl>
@@ -658,24 +651,16 @@ interface MLContext {};
     : <dfn>\[[contextType]]</dfn> of type [=context type=]
     ::
         The {{MLContext}}'s [=context type=].
-    : <dfn>\[[deviceType]]</dfn> of type [=device type=]
-    ::
-        The {{MLContext}}'s [=device type=].
     : <dfn>\[[powerPreference]]</dfn> of type [=power preference=]
     ::
         The {{MLContext}}'s [=power preference=].
 </dl>
 
-<div class="note">
-When the {{[[contextType]]}} is set to [=default-context|default=] with the {{MLContextOptions}}.{{deviceType}} set to [=device-type-gpu|gpu=], the user agent is responsible for creating an internal GPU device that operates within the context and is capable of ML workload submission on behalf of the calling application. In this setting however, only {{ArrayBufferView}} inputs and outputs are allowed in and out of the graph execution since the application has no way to know what type of internal GPU device is being created on their behalf. In this case, the user agent is responsible for automatic uploads and downloads of the inputs and outputs to and from the GPU memory using this said internal device.
-</div>
-
 ### The {{MLContext}} validation algorithm ### {#api-mlcontext-validate}
 To <dfn lt="validate MLContext">validate {{MLContext}}</dfn>, given |context|, run these steps:
 1. If |context|.{{[[contextType]]}} is not "[=webgpu-context|webgpu=]" or "[=default-context|default=], return `false`.
-1. If |context|.{{[[deviceType]]}} is not "[=device-type-cpu|cpu=]" or "[=device-type-gpu|gpu=]", return `false`.
-1. If |context|.{{[[powerPreference]]}} is not "[=power-preference-default|default=]" or "[=power-preference-high-performance|high-performance=]" or "[=power-preference-low-power|low-power=]", return `false`.
-1. If the user agent cannot support |context|.{{[[contextType]]}}, |context|.{{[[deviceType]]}} and |context|.{{[[powerPreference]]}}, return `false`.
+1. If |context|.{{[[powerPreference]]}} is not "[=power-preference-default|default=]" or "[=power-preference-low-power|low-power=]", return `false`.
+1. If the user agent cannot support |context|.{{[[contextType]]}} and |context|.{{[[powerPreference]]}}, return `false`.
 1. Return `true`;
 
 ### Synchronous Execution ### {#api-mlcontext-sync-execution}
@@ -770,7 +755,7 @@ console.log(&#96;values: ${bufferE}&#96;);
 </div>
 
 ### Asynchronous Execution ### {#api-mlcontext-async-execution}
-Asynchronously carries out the computational workload of a compiled graph {{MLGraph}} on a separate timeline, either on a worker thread for the CPU execution, or on a GPU timeline for the submission of GPU workload on the command queue. The asynchronous nature of this call avoids blocking the calling thread while the computation for result is ongoing. This method of execution requires an {{MLContext}} created with {{MLContextOptions}}. Otherwise, it throws an "{{OperationError}}" {{DOMException}}.
+Asynchronously carries out the computational workload of a compiled graph {{MLGraph}} on a separate timeline, either on a CPU worker thread or on a GPU timeline submitting a GPU workload on the command queue. The asynchronous nature of this call avoids blocking the calling thread while the computation for result is ongoing. This method of execution requires an {{MLContext}} created with {{MLContextOptions}}. Otherwise, it throws an "{{OperationError}}" {{DOMException}}.
 
 <script type=idl>
 partial interface MLContext {

--- a/index.bs
+++ b/index.bs
@@ -444,8 +444,6 @@ The WebGPU API identifies <a href="https://gpuweb.github.io/gpuweb/#privacy-mach
 
 The WebNN API defines developer-settable preferences to help inform [[#programming-model-context-device-association]] and allow the implementation to better select the most appropriate underlying execution device for the workload. [=Power preference=] indicates preference as related to the power consumption and is considered a hint only and as such does not increase entropy of the fingerprint.
 
-If a future version of this specification introduces support for new a  [=device type=] that can only support a subset of {{MLOperandType}}s, that may introduce a new fingerprint.
-
 In general, implementers of this API are expected to apply <a href="https://gpuweb.github.io/gpuweb/#privacy-considerations">WebGPU Privacy Considerations</a> to their implementations where applicable.
 
 


### PR DESCRIPTION
Given the explicit support for the WebGPU `gpuDevice` as a dedicated ML context type in addition to the default type, and the recent removal of the support for the WebGLContext device type, the `MLContext` creation can be further simplified by removing the internal GPU device type that is not explicitly specified as a `gpuDevice` parameter to the ML context creation method i.e. a GPU context can now be created only from a WebGPU device. 

The second change is the removal of the `high-performance` power preference. This option was originally defined to facilitate the creation of a GPU context that is focused on high performance, low latency execution of a discrete GPU (presumably as a tiebreaker in a configuration where both an integrated GPU and a dedicated discrete GPU are present). Following the rationale behind the first change to only support a GPU context thru a WebGPU device, this option is no longer necessary since the specified `gpuDevice` must be created from an adapter that must first be explicitly selected by the user of WebGPU i.e. it is now up to the user to choose which GPU adapter (e.g. integrated vs. discrete) that they want to use as a GPU device backing the `MLContext` object.

Lastly, please note that with this change, the *default context* is now an implementation choice. As long as the implementation takes reasonable consideration to the user-specified power preference option, it can implement the default context type any way they want to as long as they aren't a GPU implementation. For instance, the implementation can be entirely CPU-based or as a hybrid CPU-NPU implementation, as long as it fully supports `ArrayBufferView` as in the API contract, it's all good from the spec point of view. I've taken to remove explicit mentions of CPU as a normative requirement in the relevant wordings to make it sound more like an informative consideration.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/pull/322.html" title="Last updated on Jan 13, 2023, 11:11 PM UTC (fde3783)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/322/d87f5d2...fde3783.html" title="Last updated on Jan 13, 2023, 11:11 PM UTC (fde3783)">Diff</a>