### PR TITLE
Optimized compute method of effective filter size for conv2d and convTranspose2d.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1156,7 +1156,7 @@ partial interface MLGraphBuilder {
 
     **Returns:** an {{MLOperand}}. The output 4-D tensor that contains the convolution result. The output shape is interpreted according to the *options.inputLayout* value. More specifically, the spatial dimensions or the sizes of the last two dimensions of the output tensor for the *nchw* input layout can be calculated as follow:
 
-    *output size = 1 + (input size - filter size - (filter size - 1) ** *(dilation - 1) + beginning padding + ending padding) / stride*
+    *output size = 1 + (input size - (filter size - 1) ** *dilation - 1 + beginning padding + ending padding) / stride*
 
     <div class="note">
     A *depthwise* conv2d operation is a variant of grouped convolution, used in models like the MobileNet, where the *options.groups* = input_channels = output_channels and the shape of filter tensor is [options.groups, 1, height, width]
@@ -1233,7 +1233,7 @@ partial interface MLGraphBuilder {
 
     **Returns:** an {{MLOperand}}. The output 4-D tensor that contains the transposed convolution result. The output shape is interpreted according to the *options.inputLayout* value. More specifically, unless the *options.outputSizes* values are explicitly specified, the *options.outputPadding* may be needed to compute the spatial dimension values of the output tensor as follow:
 
-    *output size = (input size - 1) ** *stride + filter size + (filter size - 1) ** *(dilation - 1) - beginning padding - ending padding + output padding*
+    *output size = (input size - 1) ** *stride + (filter size - 1) ** *dilation + 1 - beginning padding - ending padding + output padding*
 </div>
 
 ### Element-wise binary operations ### {#api-mlgraphbuilder-binary}


### PR DESCRIPTION
Current WebNN Spec uses below method to compute `effective filter size` for **conv2d** and **convTranspose2d**.

```
effective filter size = filter size + (filter size - 1) * (dilation - 1)
```
This pr is to align with the common compute method for `effective filter size` which's from review comment on https://github.com/webmachinelearning/webnn-baseline/pull/31#discussion_r1069104021 by @fdwr. Thanks @fdwr!

@huningxin @wchao1115 @anssiko PTAL, thanks. 