### PR TITLE
Fix #308: refer to MLContext validation steps from MLGraphBuilder

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1019,10 +1019,8 @@ Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGr
 The [=new=] {{MLGraphBuilder}} constructor steps are:
 1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, throw a "{{SecurityError}}" {{DOMException}} and abort these steps.
 1. Let |context| be the first argument.
-1. If |context| is not a valid {{MLContext}}, throw a "{{TypeError}}" and abort these steps.
+1.  If the <a>validate MLContext</a> steps given |context| return `false`, throw a "{{TypeError}}" and abort these steps.
 1. Set {{MLGraphBuilder/[[context]]}} to |context|.
-
-Issue(webmachinelearning/webnn#308): Add an algorithm to validate {{MLContext}}.
 
 ### The batchNormalization() method ### {#api-mlgraphbuilder-batchnorm}
 Normalize the tensor values of input features across the batch dimension using [[Batch-Normalization]]. For each input feature, the mean and variance values of that feature supplied in this calculation as parameters are previously computed across the batch dimension of the input during the model training phase of this operation.
@@ -1478,8 +1476,8 @@ dictionary MLGruOptions {
 };
 
 partial interface MLGraphBuilder {
-  sequence<MLOperand> gru(MLOperand input, MLOperand weight, MLOperand recurrentWeight, 
-                          unsigned long steps, unsigned long hiddenSize, 
+  sequence<MLOperand> gru(MLOperand input, MLOperand weight, MLOperand recurrentWeight,
+                          unsigned long steps, unsigned long hiddenSize,
                           optional MLGruOptions options = {});
 };
 </script>
@@ -1577,7 +1575,7 @@ dictionary MLGruCellOptions {
 
 partial interface MLGraphBuilder {
   MLOperand gruCell(MLOperand input, MLOperand weight, MLOperand recurrentWeight,
-                    MLOperand hiddenState, unsigned long hiddenSize, 
+                    MLOperand hiddenState, unsigned long hiddenSize,
                     optional MLGruCellOptions options = {});
 };
 </script>
@@ -1598,7 +1596,7 @@ partial interface MLGraphBuilder {
     **Returns:** an {{MLOperand}}. The 2-D tensor of shape [batch_size, hidden_size], the cell output hidden state of a single time step of the recurrent network.
 
     <div class="note">
-    The behavior of this operation can be generically emulated via other operations as shown below, when the weight layout is the default *"zrn"* layout, and the activation functions of the update/reset gate and new gate are of the operator types *sigmoid* and *tanh* respectively.    
+    The behavior of this operation can be generically emulated via other operations as shown below, when the weight layout is the default *"zrn"* layout, and the activation functions of the update/reset gate and new gate are of the operator types *sigmoid* and *tanh* respectively.
     <pre highlight="js">
     const one = builder.constant(1);
     const zero = builder.constant(0);
@@ -1924,8 +1922,8 @@ dictionary MLLstmOptions {
 };
 
 partial interface MLGraphBuilder {
-  sequence<MLOperand> lstm(MLOperand input, MLOperand weight, MLOperand recurrentWeight, 
-                           unsigned long steps, unsigned long hiddenSize, 
+  sequence<MLOperand> lstm(MLOperand input, MLOperand weight, MLOperand recurrentWeight,
+                           unsigned long steps, unsigned long hiddenSize,
                            optional MLLstmOptions options = {});
 };
 </script>
@@ -2041,7 +2039,7 @@ dictionary MLLstmCellOptions {
 
 partial interface MLGraphBuilder {
   sequence<MLOperand> lstmCell(MLOperand input, MLOperand weight, MLOperand recurrentWeight,
-                               MLOperand hiddenState, MLOperand cellState, unsigned long hiddenSize, 
+                               MLOperand hiddenState, MLOperand cellState, unsigned long hiddenSize,
                                optional MLLstmCellOptions options = {});
 };
 </script>
@@ -2063,7 +2061,7 @@ partial interface MLGraphBuilder {
     **Returns:** a sequence of {{MLOperand}}. The first element of the sequence is the output hidden state of the current time step of the recurrent network. The following element is the output cell state. Both elements are 2-D tensors of shape [batch_size, hidden_size].
 
     <div class="note">
-    The behavior of this operation can be generically emulated via other operations as shown below, when the weight layout is the default *"iofg"* layout, and the activation functions of the input/forget/output gate and the cell gate/the cell state's filter for the output hidden state are of the operator types *sigmoid* and *tanh* respectively.    
+    The behavior of this operation can be generically emulated via other operations as shown below, when the weight layout is the default *"iofg"* layout, and the activation functions of the input/forget/output gate and the cell gate/the cell state's filter for the output hidden state are of the operator types *sigmoid* and *tanh* respectively.
     <pre highlight="js">
     const zero = builder.constant(0);
 
@@ -2309,8 +2307,8 @@ partial interface MLGraphBuilder {
             is interpreted according to the value of *options.layout*.
         - *options*: an optional {{MLPool2dOptions}}. The optional parameters of the operation.
             - *windowDimensions*: a sequence of {{unsigned long}} of length 2. The dimensions of the sliding window,
-                [window_height, window_width]. If not present, the window dimensions are assumed to be the height  
-                and width dimensions of the input shape. 
+                [window_height, window_width]. If not present, the window dimensions are assumed to be the height
+                and width dimensions of the input shape.
             - *padding*: a sequence of {{unsigned long}} of length 4. The additional rows and columns added to the beginning and ending of each spatial dimension of *input*, [beginning_height, ending_height, beginning_width, ending_width]. If not present, the values are assumed to be [0,0,0,0].
             - *strides*: a sequence of {{unsigned long}} of length 2. The stride of the
                 sliding window for each spatial dimension of *input*,
@@ -2545,7 +2543,7 @@ partial interface MLGraphBuilder {
     **Arguments:**
         - *x*: an {{MLOperand}}. The input 2-D tensor.
 
-    **Returns:** 
+    **Returns:**
         - an {{MLOperand}}. The output 2-D tensor that contains the softmax results, of the same shape as the input tensor.
         - an {{MLActivation}}. The activation function representing the softmax operation.
 

--- a/index.bs
+++ b/index.bs
@@ -1019,7 +1019,8 @@ Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGr
 The [=new=] {{MLGraphBuilder}} constructor steps are:
 1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, throw a "{{SecurityError}}" {{DOMException}} and abort these steps.
 1. Let |context| be the first argument.
-1.  If the <a>validate MLContext</a> steps given |context| return `false`, throw a "{{TypeError}}" and abort these steps.
+1. If the <a>validate MLContext</a> steps given |context| return `false`, throw a "{{TypeError}}" and abort these steps.
+
 1. Set {{MLGraphBuilder/[[context]]}} to |context|.
 
 ### The batchNormalization() method ### {#api-mlgraphbuilder-batchnorm}


### PR DESCRIPTION
Fix #308: refer to MLContext validation steps from MLGraphBuilder constructor

Minor change, adds reference to missing algorithm.

@anssiko PTAL


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zolkis/webnn/pull/332.html" title="Last updated on Jan 24, 2023, 9:56 AM UTC (6cefee4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/332/019a1f6...zolkis:6cefee4.html" title="Last updated on Jan 24, 2023, 9:56 AM UTC (6cefee4)">Diff</a>