### PR TITLE
Use static padding values for `pad` operation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2353,55 +2353,61 @@ dictionary MLPadOptions {
 };
 
 partial interface MLGraphBuilder {
-  MLOperand pad(MLOperand input, MLOperand padding, optional MLPadOptions options = {});
+  MLOperand pad(MLOperand input,
+                sequence<unsigned long> beginningPadding,
+                sequence<unsigned long> endPadding,
+                optional MLPadOptions options = {});
 };
 </script>
 <div algorithm=pad>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input tensor.
-        - *padding*: an {{MLOperand}}. The 2-D Tensor of integer values indicating the number of padding values to add at the beginning and end of each input dimensions. The tensor has shape [*n*, 2] where *n* is the rank of the input tensor. For each dimension *D* of *input*, *padding[D, 0]* indicates how many values to add before the content in that dimension, and *padding[D, 1]* indicates how many values to add after the content in that dimension.
+        - *beginningPadding*: a sequence of {{unsigned long}}. The sequence of unsigned integer values indicating the number of padding values to add at the beginning of each input dimension, of length *N* where *N* is the rank of the input tensor. For each dimension *d* of *input*, *beginningPadding[d]* indicates how many values to add before the content in that dimension.
+        - *endPadding*: a sequence of {{unsigned long}}. The sequence of unsigned integer values indicating the number of padding values to add at the end of each input dimension, of length *N* where *N* is the rank of the input tensor. For each dimension *d* of *input*, *endPadding[d]* indicates how many values to add after the content in that dimension.
         - *options*: an optional {{MLPadOptions}}. The optional parameters of the operation.
             - *mode*: an {{MLPaddingMode}}. The different ways to pad the tensor. When not set, it's assumed to be "constant".
             - *value*: a {{float}}. The pad value when the *options.mode* is set to *"constant"*. When not set, it's assumed to be 0.
 
-    **Returns:** an {{MLOperand}}. The padded output tensor.
+    **Returns:** an {{MLOperand}}. The padded output tensor. Each dimension of the output tensor can be calculated as follow:
+
+    *output size = beginning padding + input size + ending padding*
+
     <div class="example">
     <pre highlight="js">
     // input: [[1,2,3], [4,5,6]]
     const input = builder.constant(
       { type: 'float32', dimensions: [2,3] }, new Float32Array([1,2,3,4,5,6]));
 
-    // padding: [[1,1], [2,2]]
-    const padding = builder.constant(
-      { type: 'float32', dimensions: [2,2] }, new Float32Array([1,1,2,2]));
+    const beginningPadding = [1,1];
+    const endPadding = [2,2];
 
     // "constant" padded:
     //    [[0,0,0,0,0,0,0],
     //     [0,0,1,2,3,0,0],
     //     [0,0,4,5,6,0,0],
     //     [0,0,0,0,0,0,0]]
-    builder.pad(input, padding);
+    builder.pad(input, beginningPadding, endPadding);
 
     // "edge" padded:
     //    [[1,1,1,2,3,3,3],
     //     [1,1,1,2,3,3,3],
     //     [4,4,4,5,6,6,6],
     //     [4,4,4,5,6,6,6]]
-    builder.pad(input, padding, { mode: "edge" });
+    builder.pad(input, beginningPadding, endPadding, { mode: "edge" });
 
     // "reflection" padded:
     //    [[6,5,4,5,6,5,4],
     //     [3,2,1,2,3,2,1],
     //     [6,5,4,5,6,5,4],
     //     [3,2,1,2,3,2,1]]
-    builder.pad(input, padding, { mode: "reflection" });
+    builder.pad(input, beginningPadding, endPadding, { mode: "reflection" });
 
     // "symmetric" padded:
     //    [[2,1,1,2,3,3,2],
     //     [2,1,1,2,3,3,2],
     //     [5,4,4,5,6,6,5],
     //     [5,4,4,5,6,6,5]]
-    builder.pad(input, padding, { mode: "symmetric" });
+    builder.pad(input, beginningPadding, endPadding, { mode: "symmetric" });
     </pre>
     </div>
 </div>

--- a/index.bs
+++ b/index.bs
@@ -2355,7 +2355,7 @@ dictionary MLPadOptions {
 partial interface MLGraphBuilder {
   MLOperand pad(MLOperand input,
                 sequence<unsigned long> beginningPadding,
-                sequence<unsigned long> endPadding,
+                sequence<unsigned long> endingPadding,
                 optional MLPadOptions options = {});
 };
 </script>
@@ -2363,7 +2363,7 @@ partial interface MLGraphBuilder {
     **Arguments:**
         - *input*: an {{MLOperand}}. The input tensor.
         - *beginningPadding*: a sequence of {{unsigned long}}. The sequence of unsigned integer values indicating the number of padding values to add at the beginning of each input dimension, of length *N* where *N* is the rank of the input tensor. For each dimension *d* of *input*, *beginningPadding[d]* indicates how many values to add before the content in that dimension.
-        - *endPadding*: a sequence of {{unsigned long}}. The sequence of unsigned integer values indicating the number of padding values to add at the end of each input dimension, of length *N* where *N* is the rank of the input tensor. For each dimension *d* of *input*, *endPadding[d]* indicates how many values to add after the content in that dimension.
+        - *endingPadding*: a sequence of {{unsigned long}}. The sequence of unsigned integer values indicating the number of padding values to add at the ending of each input dimension, of length *N* where *N* is the rank of the input tensor. For each dimension *d* of *input*, *endingPadding[d]* indicates how many values to add after the content in that dimension.
         - *options*: an optional {{MLPadOptions}}. The optional parameters of the operation.
             - *mode*: an {{MLPaddingMode}}. The different ways to pad the tensor. When not set, it's assumed to be "constant".
             - *value*: a {{float}}. The pad value when the *options.mode* is set to *"constant"*. When not set, it's assumed to be 0.
@@ -2379,35 +2379,35 @@ partial interface MLGraphBuilder {
       { type: 'float32', dimensions: [2,3] }, new Float32Array([1,2,3,4,5,6]));
 
     const beginningPadding = [1,1];
-    const endPadding = [2,2];
+    const endingPadding = [2,2];
 
     // "constant" padded:
     //    [[0,0,0,0,0,0,0],
     //     [0,0,1,2,3,0,0],
     //     [0,0,4,5,6,0,0],
     //     [0,0,0,0,0,0,0]]
-    builder.pad(input, beginningPadding, endPadding);
+    builder.pad(input, beginningPadding, endingPadding);
 
     // "edge" padded:
     //    [[1,1,1,2,3,3,3],
     //     [1,1,1,2,3,3,3],
     //     [4,4,4,5,6,6,6],
     //     [4,4,4,5,6,6,6]]
-    builder.pad(input, beginningPadding, endPadding, { mode: "edge" });
+    builder.pad(input, beginningPadding, endingPadding, { mode: "edge" });
 
     // "reflection" padded:
     //    [[6,5,4,5,6,5,4],
     //     [3,2,1,2,3,2,1],
     //     [6,5,4,5,6,5,4],
     //     [3,2,1,2,3,2,1]]
-    builder.pad(input, beginningPadding, endPadding, { mode: "reflection" });
+    builder.pad(input, beginningPadding, endingPadding, { mode: "reflection" });
 
     // "symmetric" padded:
     //    [[2,1,1,2,3,3,2],
     //     [2,1,1,2,3,3,2],
     //     [5,4,4,5,6,6,5],
     //     [5,4,4,5,6,6,5]]
-    builder.pad(input, beginningPadding, endPadding, { mode: "symmetric" });
+    builder.pad(input, beginningPadding, endingPadding, { mode: "symmetric" });
     </pre>
     </div>
 </div>


### PR DESCRIPTION
fix #354

@wchao1115 @wacky6 @anssiko @pyu10055 @RafaelCintron , PTAL. Thanks!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/355.html" title="Last updated on Mar 1, 2023, 2:00 AM UTC (91547d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/355/14c6670...huningxin:91547d4.html" title="Last updated on Mar 1, 2023, 2:00 AM UTC (91547d4)">Diff</a>