### PR TITLE
Add float16 to MLOperandType and ArrayBufferView compatibility table

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -61,6 +61,9 @@ urlPrefix: https://webidl.spec.whatwg.org/; spec: WEBIDL
     type: dfn
         text: underlying buffer; url: buffersource-underlying-buffer
         text: buffer byte length; url: buffersource-byte-length
+urlPrefix: https://tc39.es/proposal-float16array/; spec: float16array
+    type: interface
+        text: Float16Array; url: sec-float16array
 </pre>
 <pre class="biblio">
 {
@@ -3154,7 +3157,7 @@ console.log('Output value: ' + result.outputs.output);
         <td>{{Float32Array}}
     <tr>
         <td>{{MLOperandType/float16}}
-        <td><p class="issue">TC39 <a href="https://tc39.es/proposal-float16array/">`Float16Array`</a> is work in progress. Implementations can emulate this type by passing raw bits via {{Uint16Array}}. <a href="https://github.com/webmachinelearning/webnn/issues/373">[Issue webnn#373]</a></p>
+        <td>{{Float16Array}}
     <tr>
         <td>{{MLOperandType/int32}}
         <td>{{Int32Array}}
@@ -3168,6 +3171,8 @@ console.log('Output value: ' + result.outputs.output);
         <td>{{MLOperandType/uint8}}
         <td>{{Uint8Array}}
 </table>
+
+<p class="note">{{Float16Array}} is at <a href="https://tc39.es/process-document/">ECMA Stage 3</a> signalling its design is finished. Implementers wanting to enable this type ahead native implementations can emulate the type by passing raw bits via {{Uint16Array}}. <a href="https://github.com/webmachinelearning/webnn/issues/373">[Issue webnn#373]</a></p>
 
 <h2 id="acknowledgements">Acknowledgements</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -3172,7 +3172,7 @@ console.log('Output value: ' + result.outputs.output);
         <td>{{Uint8Array}}
 </table>
 
-<p class="note">{{Float16Array}} is at <a href="https://tc39.es/process-document/">ECMA Stage 3</a> signalling its design is finished. Implementers wanting to enable this type ahead native implementations can emulate the type by passing raw bits via {{Uint16Array}}. <a href="https://github.com/webmachinelearning/webnn/issues/373">[Issue webnn#373]</a></p>
+<p class="note">{{Float16Array}} is at <a href="https://tc39.es/process-document/">ECMA Stage 3</a> signaling its design is finished. Implementers wanting to enable this type ahead native implementations can emulate the type by passing raw bits via {{Uint16Array}}. <a href="https://github.com/webmachinelearning/webnn/issues/373">[Issue webnn#373]</a></p>
 
 <h2 id="acknowledgements">Acknowledgements</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -3153,6 +3153,9 @@ console.log('Output value: ' + result.outputs.output);
         <td>{{MLOperandType/float32}}
         <td>{{Float32Array}}
     <tr>
+        <td>{{MLOperandType/float16}}
+        <td><p class="issue">TC39 <a href="https://tc39.es/proposal-float16array/">`Float16Array`</a> is work in progress. <a href="https://github.com/webmachinelearning/webnn/issues/373">[Issue webnn#373]</a></p>
+    <tr>
         <td>{{MLOperandType/int32}}
         <td>{{Int32Array}}
     <tr>
@@ -3165,8 +3168,6 @@ console.log('Output value: ' + result.outputs.output);
         <td>{{MLOperandType/uint8}}
         <td>{{Uint8Array}}
 </table>
-
-Issue(webmachinelearning/webnn#127): clarify the usage of {{ArrayBufferView}} for {{MLOperandType/float16}}.
 
 <h2 id="acknowledgements">Acknowledgements</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -3154,7 +3154,7 @@ console.log('Output value: ' + result.outputs.output);
         <td>{{Float32Array}}
     <tr>
         <td>{{MLOperandType/float16}}
-        <td><p class="issue">TC39 <a href="https://tc39.es/proposal-float16array/">`Float16Array`</a> is work in progress. <a href="https://github.com/webmachinelearning/webnn/issues/373">[Issue webnn#373]</a></p>
+        <td><p class="issue">TC39 <a href="https://tc39.es/proposal-float16array/">`Float16Array`</a> is work in progress. Implementations can emulate this type by passing raw bits via {{Uint16Array}}. <a href="https://github.com/webmachinelearning/webnn/issues/373">[Issue webnn#373]</a></p>
     <tr>
         <td>{{MLOperandType/int32}}
         <td>{{Int32Array}}

--- a/index.bs
+++ b/index.bs
@@ -3194,6 +3194,9 @@ Thanks to Alex Gough and the Chrome Security team for security review and questi
 Thanks to Michal Karzynski for sharing practical guidelines and learnings from ONNX.
 
 Thanks to Kaustubha Govind and Chrome privacy reviewers for feedback and privacy considerations.
+
+Thanks to Jiewei Qian for Chromium implementation review and feedback.
+
 <pre class="biblio">
 {
   "Models": {


### PR DESCRIPTION
This is an update to the compatibility table to note the latest status of float16 per discussion in https://github.com/webmachinelearning/webnn/issues/373.

- Note TC39 Float16Array proposal is WIP
- Update issue links

(Bikeshed syntax not supported inside tables, thus plain HTML.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/pull/386.html" title="Last updated on Jun 6, 2023, 9:08 AM UTC (af8e9c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/386/9774d49...af8e9c6.html" title="Last updated on Jun 6, 2023, 9:08 AM UTC (af8e9c6)">Diff</a>