### PR TITLE
Fix #393 for input()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1245,7 +1245,7 @@ Create a named {{MLOperand}} based on a descriptor, that can be used as an input
         1. If |descriptor|.{{MLOperandDescriptor/dimensions}} [=map/exists=]:
             1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return `false`, throw a "{{DataError}}" {{DOMException}} and stop.
             1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. Let |operand| be the result of invoking the <a>create MLOperand</a> steps with [=this=], `"input"` and |descriptor|.
+    1. Let |operand| be the result of invoking the <a>create MLOperand</a> steps with [=this=] and |descriptor|.
         1. If that throws, re-throw the exception and stop.
     1. Set |operand|.{{MLOperand/[[name]]}} to |name|.
     1. Make a request to the underlying platform to register |operand| as an input and store a reference to the corresponding [=implementation-defined=] platform object in |operand|.{{MLOperand/[[operand]]}}.


### PR DESCRIPTION
Remove extra parameter from 'create MLOperand' invocation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zolkis/webnn/pull/394.html" title="Last updated on Jun 2, 2023, 1:35 PM UTC (1f4dd64)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/394/c22a3ac...zolkis:1f4dd64.html" title="Last updated on Jun 2, 2023, 1:35 PM UTC (1f4dd64)">Diff</a>