### PR TITLE
Fix #439: add missing conv2d() and convTranspose2d() validation steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2064,6 +2064,8 @@ partial interface MLGraphBuilder {
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLConv2dOptions/padding}} is `undefined`, set it to `[0, 0, 0, 0]`.
     1. If |options|.{{MLConv2dOptions/strides}} is `undefined`, set it to `[1, 1]`.
+    1. Else if |options|.{{MLConv2dOptions/strides}}.size() is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConv2dOptions/dilations}} is `undefined`, set it to `[1, 1]`.
     1. If |options|.{{MLConv2dOptions/autoPad}} is `undefined`, set it to `"explicit"`.
     1. If |options|.{{MLConv2dOptions/groups}} is `undefined`, set it to `1`.
@@ -2230,6 +2232,8 @@ partial interface MLGraphBuilder {
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLConvTranspose2dOptions/padding}} is `undefined`, set it to `[0, 0, 0, 0]`.
     1. If |options|.{{MLConvTranspose2dOptions/strides}} is `undefined`, set it to `[1, 1]`.
+    1. Else if |options|.{{MLConv2dOptions/strides}}.size() is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/dilations}} is `undefined`, set it to `[1, 1]`.
     1. If |options|.{{MLConvTranspose2dOptions/outputPadding}} is `undefined`, set it to `[0, 0]`.
     1. If |options|.{{MLConvTranspose2dOptions/autoPad}} is `undefined`, set it to `"explicit"`.


### PR DESCRIPTION
Fix #439 , and also fix the transpose op.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zolkis/webnn/pull/441.html" title="Last updated on Jul 12, 2023, 4:35 PM UTC (b7eaee9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/441/567396b...zolkis:b7eaee9.html" title="Last updated on Jul 12, 2023, 4:35 PM UTC (b7eaee9)">Diff</a>