### PR TITLE
Add missing algorithms, add stylistic improvements, update with spec conventions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1005,7 +1005,7 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |operand|.{{MLOperand/[[builder]]}} is {{MLGraphBuilder}}.
-    1. If |builder| is not `undefined` and is not equal to |operand|.{{MLOperand/[[builder]]}}, return `false`.
+    1. If |builder| [=map/exists=]] and is not equal to |operand|.{{MLOperand/[[builder]]}}, return `false`.
     1. Let |desc| be |operand|.{{MLOperand/[[descriptor]]}}.
     1. If |desc| is not an [=object=] that [=implements=] {{MLOperandDescriptor}}, return `false`.
     1. If |desc|.{{MLOperandDescriptor/dimensions}} [=map/exists=] and invoking <a>check dimensions</a> given |desc|.{{MLOperandDescriptor/dimensions}} and |desc|.{{MLOperandDescriptor/type}} returns `false`, then return `false`.
@@ -1056,7 +1056,7 @@ The {{MLActivation}} objects (including the ones passed as input to methods) are
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |builder| is {{MLGraphBuilder}}.
-    1. If |name| is `undefined` or `null`,  throw a "{{TypeError}}" and abort these steps.
+    1. If |name| is empty, then throw a "{{TypeError}}" and abort these steps.
     1. Let |activation| be a new [=object=].
     1. Set |activation|.{{MLActivation/[[builder]]}} to |builder|.
     1. Set |activation|.{{MLActivation/[[name]]}} to |name|.
@@ -2131,21 +2131,17 @@ partial interface MLGraphBuilder {
     1. If |input_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |filter_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options| is `undefined`, let |options| be an empty [=object=].
-    1. If |options|.{{MLConv2dOptions/padding}} is `undefined`, set it to `[0, 0, 0, 0]`.
+    1. If |options|.{{MLConv2dOptions/padding}} does not [=map/exist=], set it to `[0, 0, 0, 0]`.
     1. Else if |options|.{{MLConv2dOptions/padding}}.length is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLConv2dOptions/strides}} is `undefined`, set it to `[1, 1]`.
+    1. If |options|.{{MLConv2dOptions/strides}} does not [=map/exist=], set it to `[1, 1]`.
     1. Else if |options|.{{MLConv2dOptions/strides}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
     1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options|.{{MLConv2dOptions/dilations}} is `undefined`, set it to `[1, 1]`.
+    1. If |options|.{{MLConv2dOptions/dilations}} does not [=map/exist=], set it to `[1, 1]`.
     1. Else if |options|.{{MLConv2dOptions/dilations}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options|.{{MLConv2dOptions/autoPad}} is `undefined`, set it to `"explicit"`.
-    1. If |options|.{{MLConv2dOptions/groups}} is `undefined`, set it to `1`.
-    1. Else if |options|.{{MLConv2dOptions/groups}} is 0, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLConv2dOptions/autoPad}} does not [=map/exist=], set it to `"explicit"`.
+    1. If |options|.{{MLConv2dOptions/groups}} is 0, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |input_size| / |options|.{{MLConv2dOptions/groups}} is not equal to |filter_size|, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. Else if |input_size| % |options|.{{MLConv2dOptions/groups}} is not 0, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLConv2dOptions/inputLayout}} is `undefined`, set it to `"nchw"`.
-    1. If |options|.{{MLConv2dOptions/filterLayout}} is `undefined`, set it to `"oihw"`.
     1. If |options|.{{MLConv2dOptions/bias}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConv2dOptions/bias}} is {{MLOperand}}.
     1. If the length of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}} and stop.
@@ -2310,25 +2306,20 @@ partial interface MLGraphBuilder {
     1. If |input_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |filter_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options| is `undefined`, let |options| be an empty [=object=].
-    1. If |options|.{{MLConvTranspose2dOptions/padding}} is `undefined`, set it to `[0, 0, 0, 0]`.
+    1. If |options|.{{MLConvTranspose2dOptions/padding}} does not [=map/exist=], set it to `[0, 0, 0, 0]`.
     1. Else if |options|.{{MLConvTranspose2dOptions/padding}}.length is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLConvTranspose2dOptions/strides}} is `undefined`, set it to `[1, 1]`.
+    1. If |options|.{{MLConvTranspose2dOptions/strides}} does not [=map/exist=], set it to `[1, 1]`.
     1. Else if |options|.{{MLConvTranspose2dOptions/strides}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
     1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options|.{{MLConvTranspose2dOptions/dilations}} is `undefined`, set it to `[1, 1]`.
+    1. If |options|.{{MLConvTranspose2dOptions/dilations}} does not [=map/exist=], set it to `[1, 1]`.
     1. Else if |options|.{{MLConvTranspose2dOptions/dilations}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options|.{{MLConvTranspose2dOptions/outputPadding}} is `undefined`, set it to `[0, 0]`.
+    1. If |options|.{{MLConvTranspose2dOptions/outputPadding}} does not [=map/exist=], set it to `[0, 0]`.
     1. Else if |options|.{{MLConvTranspose2dOptions/outputPadding}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/outputSizes}} [=map/exists=]:
         1. If |options|.{{MLConvTranspose2dOptions/outputSizes}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
         1. If the elements of |options|.{{MLConvTranspose2dOptions/outputSizes}} are not smaller than the elements at the same dimension (index) for |options|.{{MLConvTranspose2dOptions/strides}}, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLConvTranspose2dOptions/autoPad}} is `undefined`, set it to `"explicit"`.
-    1. If |options|.{{MLConvTranspose2dOptions/groups}} is `undefined`, set it to `1`.
     1. If |input_size| / |options|.{{MLConvTranspose2dOptions/groups}} is not equal to |filter_size|, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. Else if |input_size| % |options|.{{MLConvTranspose2dOptions/groups}} is not 0, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLConvTranspose2dOptions/inputLayout}} is `undefined`, set it to `"nchw"`.
-    1. If |options|.{{MLConvTranspose2dOptions/filterLayout}} is `undefined`, set it to `"iohw"`.
     1. If |options|.{{MLConvTranspose2dOptions/bias}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConvTranspose2dOptions/bias}} is {{MLOperand}}.
     1. If the length of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}} and stop.
@@ -2724,13 +2715,6 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=gemm class=algorithm-steps>
     1. [=Assert=]: the type of |a| and |b| is {{MLOperand}}.
-    1. If |options| is `undefined`, let |options| be an empty [=object=].
-    1. If |options|.{{MLGemmOptions/alpha}} is `undefined`, set it to `1.0`.
-    1. If |options|.{{MLGemmOptions/beta}} is `undefined`, set it to `1.0`.
-    1. If |options|.{{MLGemmOptions/aTranspose}} is `undefined`, set it to `false`.
-    1. If |options|.{{MLGemmOptions/aTranspose}} is not `false`, set it to `true`.
-    1. If |options|.{{MLGemmOptions/bTranspose}} is `undefined`, set it to `false`.
-    1. If |options|.{{MLGemmOptions/bTranspose}} is not `false`, set it to `true`.
     1. Let |shapeA| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeA| the size of |shapeA|.
     1. Let |shapeB| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeB| the size of |shapeB|.
     1. If |sizeA| is not `2` or |sizeB| is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
@@ -2864,7 +2848,6 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
     1. If the rank of |input| or |weight| is not `3`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If the rank of |weight| or |recurrentWeight| is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLGruOptions/bias}} [=map/exists=].
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
@@ -2874,11 +2857,7 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLGruOptions/initialHiddenState}} [=map/exists=].
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `3`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLGruOptions/resetAfter}} is `undefined`, set it to `true`.
-    1. If |options|.{{MLGruOptions/returnSequence}} is `undefined`, set it to `false`.
-    1. If |options|.{{MLGruOptions/direction}} is `undefined`, set it to `"forward"`.
     1. If |options|.{{MLGruOptions/direction}} is not one of {{MLRecurrentNetworkDirection}}, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options|.{{MLGruOptions/layout}} is `undefined`, set it to `"zrn"`.
     1. If |options|.{{MLGruOptions/layout}} is not one of {{MLGruWeightLayout}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of {{MLActivation}} objects with size `2`, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |steps| is not a [=number=] or it is `0`, then [=exception/throw=] a {{TypeError}} and stop.
@@ -3019,15 +2998,12 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
     1. If the rank of |input| or |weight| is not `3`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If the rank of |weight| or |recurrentWeight| is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLGruOptions/bias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `1`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLGruOptions/recurrentBias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `1`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLGruOptions/resetAfter}} is `undefined`, set it to `true`.
-    1. If |options|.{{MLGruOptions/layout}} is `undefined`, set it to `"zrn"`.
     1. If |options|.{{MLGruOptions/layout}} is not one of {{MLGruWeightLayout}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of {{MLActivation}} objects with size `2`, then [=exception/throw=] a {{TypeError}} and stop.
     1. Let |desc| a new {{MLOperandDescriptor}}.
@@ -3366,13 +3342,10 @@ The {{MLInstanceNormalizationOptions}} members are:
   <div algorithm=instancenorm class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If the rank of |input| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. [=Assert=]:  the type of |options|.{{MLInstanceNormalizationOptions/scale}} is {{MLOperand}}.
     1. If the rank of |options|.{{MLInstanceNormalizationOptions/scale}} is not equal to the size of the channel dimension of |input|, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. [=Assert=]: the type of |options|.{{MLInstanceNormalizationOptions/bias}} is  {{MLOperand}}.
     1. If the rank of |options|.{{MLInstanceNormalizationOptions/bias}} is not equal to the size of the channel dimension of |input|, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLInstanceNormalizationOptions/epsilon}} is `undefined`, let it be `0.00001`.
-    1. If |options|.{{MLInstanceNormalizationOptions/layout}} is `undefined`, let it be `"nchw"`.
     1. Otherwise if |options|.{{MLInstanceNormalizationOptions/layout}} is not one of {{MLInputOperandLayout}}, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
@@ -3685,8 +3658,6 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/lstm(input, weight, recurrentWeight, steps, hiddenSize, options)}} steps are:
   </summary>
   <div algorithm=lstm class=algorithm-steps>
-    1. If |options| is `undefined`, let |options| be an empty [=object=].
-    1. If |options|.{{MLLstmOptions/direction}} is `undefined`, set it to `"forward"`.
     1. If |options|.{{MLLstmOptions/direction}} is not one of {{MLRecurrentNetworkDirection}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. Let |num_directions| be `1` if |options|.{{MLLstmOptions/direction}} is `"forward"`, or otherwise let it be `2`.
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
@@ -3722,8 +3693,6 @@ partial interface MLGraphBuilder {
         1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to |batch_size|, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[2] is not |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLLstmOptions/returnSequence}} is `undefined`, set it to `false`.
-    1. If |options|.{{MLLstmOptions/layout}} is `undefined`, set it to `"iofg"`.
     1. If |options|.{{MLLstmOptions/layout}} is not one of {{MLLstmWeightLayout}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLLstmOptions/activations}} [=map/exists=]:
         1. If it is not an array of size `3`, then [=exception/throw=] a {{TypeError}} and stop.
@@ -3892,7 +3861,6 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |input|, |weight|, |recurrentWeight|, |hiddenState| and |cellState| is {{MLOperand}}.
     1. If the rank of |input|, |weight|, |recurrentWeight|, |hiddenState| or |cellState| is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. Let |batch_size| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0].
-    1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLLstmCellOptions/bias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `1`, then throw a "{{DataError}}" {{DOMException}} and stop.
@@ -3905,7 +3873,6 @@ partial interface MLGraphBuilder {
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `1`, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmCellOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not 3 * |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLLstmCellOptions/layout}} is `undefined`, set it to `"iofg"`.
     1. If |options|.{{MLLstmCellOptions/layout}} is not one of {{MLLstmWeightLayout}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLLstmCellOptions/activations}} [=map/exists=]:
         1. If it is not an array of size `3`, then [=exception/throw=] a {{TypeError}} and stop.
@@ -4180,10 +4147,7 @@ partial interface MLGraphBuilder {
   <div algorithm=pad class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |beginningPadding| or |endingPadding| is not a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options| is `undefined`, let |options| be an empty [=object=].
-    1. If |options|.{{MLPadOptions/mode}} is `undefined`, set it to `"constant"`.
-        1. Otherwise, if |options|.{{MLPadOptions/mode}} is not one of {{MLPaddingMode}}, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options|.{{MLPadOptions/value}} is `undefined`, set it to `0`.
+    1. If |options|.{{MLPadOptions/mode}} is not one of {{MLPaddingMode}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of invoking the <a>calculate padding output sizes</a> given |input|, |beginningPadding| and |endingPadding|.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
@@ -4364,19 +4328,15 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: |op| is one of "averagePool2d", "l2Pool2d", "maxPool2d".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If the length of of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options| is `undefined`, let |options| be a new {{MLPool2dOptions}} object.
-    1. If |options|.{{MLPool2dOptions/outputSizes}} [=map/exists=], or if |options|.{{MLPool2dOptions/padding}} is `undefined`, set |options|.{{MLPool2dOptions/padding}} to `[0, 0, 0, 0]`.
+    1. If |options|.{{MLPool2dOptions/outputSizes}} [=map/exists=], or if |options|.{{MLPool2dOptions/padding}} does not [=map/exist=], set |options|.{{MLPool2dOptions/padding}} to `[0, 0, 0, 0]`.
     1. If the length of of |padding|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLPool2dOptions/strides}} is `undefined`, set |options|.{{MLPool2dOptions/strides}} to `[1, 1]`.
+    1. If |options|.{{MLPool2dOptions/strides}} does not [=map/exist=], set |options|.{{MLPool2dOptions/strides}} to `[1, 1]`.
     1. If the length of of |options|.{{MLPool2dOptions/strides}} is not 2, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If any value in |options|.{{MLPool2dOptions/strides}} is not greater than 0, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLPool2dOptions/dilations}} is `undefined`, set |options|.{{MLPool2dOptions/dilations}} to `[1, 1]`.
+    1. If |options|.{{MLPool2dOptions/dilations}} does not [=map/exist=], set |options|.{{MLPool2dOptions/dilations}} to `[1, 1]`.
     1. If the length of of |options|.{{MLPool2dOptions/dilations}} is not 2, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If any value in |options|.{{MLPool2dOptions/dilations}} is not greater than 0, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLPool2dOptions/autoPad}} is `undefined`, set |options|.{{MLPool2dOptions/autoPad}} to `"explicit"`.
     1. If |options|.{{MLPool2dOptions/autoPad}} is not `"explicit"`, set |options|.{{MLPool2dOptions/padding}} to `[0, 0, 0, 0]`.
-    1. If |options|.{{MLPool2dOptions/layout}} is `undefined`, set |options|.{{MLPool2dOptions/layout}} to `"nchw"`.
-    1. If |options|.{{MLPool2dOptions/roundingType}} is `undefined`, set |options|.{{MLPool2dOptions/roundingType}} to `"floor"`.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Make a request to the underlying platform to:
@@ -4528,7 +4488,6 @@ partial interface MLGraphBuilder {
   <div algorithm=reduce class=algorithm-steps>
     1. [=Assert=]: |op| is one of "reduceL1", "reduceL2", "reduceLogSum", "reduceLogSumExp", "reduceMax", "reduceMean", "reduceMin", "reduceProduct", "reduceSum", "reduceSumSquare".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If |options| is `undefined`, let |options| be a new {{MLReduceOptions}} object with |options|.{{MLReduceOptions/keepDimensions}} set to `false` and |options|.{{MLReduceOptions/axes}} set to `null`.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -5217,8 +5176,6 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=split class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If |options| is `undefined`, let |options| be an empty [=object=].
-    1. If |options|.{{MLSplitOptions/axis}} is `undefined`, let |options|.{{MLSplitOptions/axis}} be `0`.
     1. If |splits| is not {{unsigned long}} or a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
@@ -5293,7 +5250,6 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=squeeze class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLSqueezeOptions/axes}} [=map/exists=], then:
         1. Let |dimensions| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. For |index| between 0 and the size of |options|.{{MLSqueezeOptions/axes}}:
@@ -5421,8 +5377,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=transpose class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If |options| is `undefined`, let |options| be an empty [=object=].
-    1. If |options|.{{MLTransposeOptions/permutation}} is `undefined`, let |options|.{{MLTransposeOptions/permutation}} be the reversed sequence of all indices for |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+    1. If |options|.{{MLTransposeOptions/permutation}} does not [=map/exist=], let |options|.{{MLTransposeOptions/permutation}} be the reversed sequence of all indices for |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Otherwise if |options|.{{MLTransposeOptions/permutation}} [=map/exists=]:
         1. If |options|.{{MLTransposeOptions/permutation}} is not a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}} and stop.
         1. If the rank of |options|.{{MLTransposeOptions/permutation}} is not the same as the rank of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a {{TypeError}} and stop.

--- a/index.bs
+++ b/index.bs
@@ -2455,7 +2455,7 @@ partial interface MLGraphBuilder {
 
 <details open>
   <summary>
-    To <dfn for="MLGraphBuilder" lt="broadcast-shapes">broadcast shapes</dfn> given |shape1| and |shape2|, run the following steps:
+    To <dfn for="MLGraphBuilder">broadcast-shapes</dfn> given |shape1| and |shape2|, run the following steps:
   </summary>
   <div algorithm=broadcast-shape class=algorithm-steps>
     1. [=Assert=]: The type of |shape1| and |shape2| is `sequence of unsigned long`.
@@ -2554,7 +2554,6 @@ partial interface MLGraphBuilder {
   <div algorithm=unary class=algorithm-steps>
     1. [=Assert=]: |op| is one of "abs", "ceil", "cos", "exp", "floor", "log", "neg", "sin", "tan".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. Let |descriptor| be a new {{MLOperandDescriptor}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
@@ -2759,7 +2758,7 @@ partial interface MLGraphBuilder {
   <div algorithm=gemm class=algorithm-steps>
     1. [=Assert=]: the type of |a| and |b| is {{MLOperand}}.
     1. Let |shapeA| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeA| the [=list/size=] of |shapeA|.
-    1. Let |shapeB| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeB| the [=list/size=] of |shapeB|.
+    1. Let |shapeB| be |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeB| the [=list/size=] of |shapeB|.
     1. If |sizeA| is not `2` or |sizeB| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGemmOptions/aTranspose}} is `true`, then let |shapeA| be the reverse array of |shapeA|.
     1. If |options|.{{MLGemmOptions/bTranspose}} is `true`, then let |shapeB| be the reverse array of |shapeB|.
@@ -3663,7 +3662,7 @@ partial interface MLGraphBuilder {
 
     : <dfn>peepholeWeight</dfn>
     ::
-        An {{MLOperand}}. Specifies the 2-D weight tensor for peepholes of shape [num_directions, 4 * hidden_size]. The pack ordering of the weight vectors is for the `input (i)`, `output (o)`, and `forget (f)` gate, respectively.
+        An {{MLOperand}}. Specifies the 2-D weight tensor for peepholes of shape [num_directions, 3 * hidden_size]. The pack ordering of the weight vectors is for the `input (i)`, `output (o)`, and `forget (f)` gate, respectively.
 
     : <dfn>initialHiddenState</dfn>
     ::
@@ -3748,13 +3747,15 @@ partial interface MLGraphBuilder {
         1. [=Assert=]: the type of its elements is {{MLActivation}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |desc| a new {{MLOperandDescriptor}}.
-        1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |nume_directions|, |batch_size|, |hiddenSize| ].
+        1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |num_directions|, |batch_size|, |hiddenSize| ].
         1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
         1. Let |output0| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Let |output1| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
-        1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |steps|, |nume_directions|, |batch_size|, |hiddenSize| ].
-        1. Let |output2| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
-        1. Let |output| be the array [ |output0|, |output1|, |output2 ].
+        1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |steps|, |num_directions|, |batch_size|, |hiddenSize| ].
+        1. If |options|.{{MLLstmOptions/returnSequence}} is set to true:
+            1. Let |output2| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
+            1. Let |output| be the array [ |output0|, |output1|, |output2| ].
+        1. Otherwise, Let |output| be the array [ |output0|, |output1| ].
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the LSTM operation, given |weight|, |recurrentWeight|, |steps|, |hiddenSize| and |options|.
             1. Store a reference of |opImpl| in |output0|.{{MLOperand/[[operator]]}}, |output1|.{{MLOperand/[[operator]]}} and |output2|.{{MLOperand/[[operator]]}}.
@@ -4823,7 +4824,7 @@ partial interface MLGraphBuilder {
         1. If the [=list/size=] of |newShape| is `0`, set |outputShape| to `«  1  »` (reshaping to scalar).
         1. If |newShape| contains more than one `null` value, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If any value in |newShape| is `0`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. Let |inputElementCount| be the product of all elements in |inputs|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+        1. Let |inputElementCount| be the product of all elements in |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. If |newShape| contains a `null` value, set that value to |inputElementCount| divided by the product of all other values in |newShape|.
             1. If that value is too large for {{unsigned long}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If product of all values in |newShape| is not equal to |inputElementCount|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -5162,7 +5163,7 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the softsign operation, given |options|.
+            1. Let |opImpl| be an [=implementation-defined=] platform operator for the softsign operation.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
             1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Store a reference to |outputImpl| in |output|.{{MLOperand/[[operand]]}}.

--- a/index.bs
+++ b/index.bs
@@ -803,7 +803,7 @@ Its <a>default allowlist</a> is <code>'self'</code>.
     1. Let |promise| be [=a new promise=].
     1. Return |promise| and run the following steps [=in parallel=].
     1. Let |context| be the result of [=creating a context=] given |options|.
-    1. If <a>validating MLContext</a> given |context| returns `false`, [=reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}}.
+    1. If <a>validating MLContext</a> given |context| returns false, [=reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}}.
     1. [=Resolve=] |promise| with |context|.
 </div>
 </details>
@@ -817,7 +817,7 @@ Its <a>default allowlist</a> is <code>'self'</code>.
     1. Let |promise| be [=a new promise=].
     1. Return |promise| and run the following steps [=in parallel=].
     1. Let |context| be the result of [=creating a context=] given |gpuDevice|.
-    1. If <a>validating MLContext</a> given |context| returns `false`, [=reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}}.
+    1. If <a>validating MLContext</a> given |context| returns false, [=reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}}.
     1. [=Resolve=] |promise| with |context|.
 </div>
 </details>
@@ -831,7 +831,7 @@ Its <a>default allowlist</a> is <code>'self'</code>.
   <div class=algorithm-steps>
     1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, then [=exception/throw=] a "{{SecurityError}}" {{DOMException}}.
     1. Let |context| be the result [=creating a context=] |options|.
-    1. If <a>validating MLContext</a> given |context| return `false`, then [=exception/throw=] a "{{NotSupportedError}}" {{DOMException}}.
+    1. If <a>validating MLContext</a> given |context| return false, then [=exception/throw=] a "{{NotSupportedError}}" {{DOMException}}.
     1. Return |context|.
   </div>
 </details>
@@ -843,7 +843,7 @@ Its <a>default allowlist</a> is <code>'self'</code>.
   <div class=algorithm-steps>
     1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, then [=exception/throw=] a "{{SecurityError}}" {{DOMException}}.
     1. Let |context| be the result [=creating a context=] with |gpuDevice|.
-    1. If <a>validating MLContext</a> given |context| return `false`, then [=exception/throw=] a "{{NotSupportedError}}" {{DOMException}}.
+    1. If <a>validating MLContext</a> given |context| return false, then [=exception/throw=] a "{{NotSupportedError}}" {{DOMException}}.
     1. Return |context|.
   </div>
 </details>
@@ -996,10 +996,10 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
     To <dfn>check dimensions</dfn> given |dimensions| and |type|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. If the [=list/size=] of |dimensions| is 0, return `false`.
-    1. If the [=list/size=] of |dimensions| is too large to be supported by the implementation, return `false`.
-    1. If any element of |dimensions| is not a positive number, or it is too large to be supported by the implementation given |type|, return `false`.
-    1. Return `true`.
+    1. If the [=list/size=] of |dimensions| is 0, return false.
+    1. If the [=list/size=] of |dimensions| is too large to be supported by the implementation, return false.
+    1. If any element of |dimensions| is not a positive number, or it is too large to be supported by the implementation given |type|, return false.
+    1. Return true.
   </div>
 </details>
 
@@ -1009,10 +1009,10 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |operand|.{{MLOperand/[[builder]]}} is {{MLGraphBuilder}}.
-    1. If |builder| is not equal to |operand|.{{MLOperand/[[builder]]}}, return `false`.
+    1. If |builder| is not equal to |operand|.{{MLOperand/[[builder]]}}, return false.
     1. Let |desc| be |operand|.{{MLOperand/[[descriptor]]}}.
-    1. If |desc|.{{MLOperandDescriptor/dimensions}} [=map/exists=] and invoking <a>check dimensions</a> given |desc|.{{MLOperandDescriptor/dimensions}} and |desc|.{{MLOperandDescriptor/type}} returns `false`, then return `false`.
-    1. Return `true`.
+    1. If |desc|.{{MLOperandDescriptor/dimensions}} [=map/exists=] and invoking <a>check dimensions</a> given |desc|.{{MLOperandDescriptor/dimensions}} and |desc|.{{MLOperandDescriptor/type}} returns false, then return false.
+    1. Return true.
   </div>
 </details>
 
@@ -1136,11 +1136,11 @@ When the {{[[contextType]]}} is set to [=default-context|default=] with the {{ML
     To <dfn>validate MLContext</dfn>, given |context|, run these steps:
   </summary>
   <div class=algorithm-steps>
-    1. If |context|.{{[[contextType]]}} is not "[=webgpu-context|webgpu=]" or "[=default-context|default=]", return `false`.
-    1. If |context|.{{[[deviceType]]}} is not "[=device-type-cpu|cpu=]" or "[=device-type-gpu|gpu=]", return `false`.
-    1. If |context|.{{[[powerPreference]]}} is not "[=power-preference-default|default=]" or "[=power-preference-high-performance|high-performance=]" or "[=power-preference-low-power|low-power=]", return `false`.
-    1. If the user agent cannot support |context|.{{[[contextType]]}}, |context|.{{[[deviceType]]}} and |context|.{{[[powerPreference]]}}, return `false`.
-    1. Return `true`;
+    1. If |context|.{{[[contextType]]}} is not "[=webgpu-context|webgpu=]" or "[=default-context|default=]", return false.
+    1. If |context|.{{[[deviceType]]}} is not "[=device-type-cpu|cpu=]" or "[=device-type-gpu|gpu=]", return false.
+    1. If |context|.{{[[powerPreference]]}} is not "[=power-preference-default|default=]" or "[=power-preference-high-performance|high-performance=]" or "[=power-preference-low-power|low-power=]", return false.
+    1. If the user agent cannot support |context|.{{[[contextType]]}}, |context|.{{[[deviceType]]}} and |context|.{{[[powerPreference]]}}, return false.
+    1. Return true;
   </div>
 </details>
 
@@ -1170,8 +1170,8 @@ partial interface MLContext {
   </summary>
   <div class=algorithm-steps>
     1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=]", [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-    1. If <a>validating graph resources</a> given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns `false`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If <a>validating graph resources</a> given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns `false`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If <a>validating graph resources</a> given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If <a>validating graph resources</a> given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Invoke <a>execute graph</a> given |graph|, |inputs| and |outputs|.
     1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return {{undefined}}.
@@ -1185,10 +1185,10 @@ partial interface MLContext {
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |resources| is {{MLNamedArrayBufferViews}}.
     1. [=map/For each=] [=record=] <|key|, |value|> of |resources|:
-        1. If |descriptors|[|key|] does not [=map/exist=], return `false`.
+        1. If |descriptors|[|key|] does not [=map/exist=], return false.
         1. [=Assert=]: the type of |value| is {{ArrayBufferView}}.
-        1. If <a>validating buffer with descriptor</a> given |value| and |descriptors|[|key|] returns `false`, then return `false`.
-    1. Return `true`.
+        1. If <a>validating buffer with descriptor</a> given |value| and |descriptors|[|key|] returns false, then return false.
+    1. Return true.
   </div>
 </details>
 
@@ -1197,9 +1197,9 @@ partial interface MLContext {
     To <dfn>validate buffer with descriptor</dfn> given |bufferView| and |descriptor|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. If |bufferView| is not an {{MLBufferView}}, return `false`.
-    1. If |bufferView|'s [=element type=] does not match to |descriptor|.{{MLOperandDescriptor/type}}  according to [this table](#appendices-mloperandtype-arraybufferview-compatibility), return `false`.
-    1. If |bufferView|.\[[ByteLength]] is not equal to the [=byte length=] of |descriptor|, return `false`.
+    1. If |bufferView| is not an {{MLBufferView}}, return false.
+    1. If |bufferView|'s [=element type=] does not match to |descriptor|.{{MLOperandDescriptor/type}}  according to [this table](#appendices-mloperandtype-arraybufferview-compatibility), return false.
+    1. If |bufferView|.\[[ByteLength]] is not equal to the [=byte length=] of |descriptor|, return false.
   </div>
 </details>
 
@@ -1323,8 +1323,8 @@ partial interface MLContext {
     1. Let |promise| be [=a new promise=].
     1. Return |promise| and run the following steps [=in parallel=]:
         1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=]", [=reject=] |promise| with an "{{OperationError}}" {{DOMException}}.
-        1. If <a>validating graph resources</a> given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns `false`, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}}.
-        1. If <a>validating graph resources</a> given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns `false`, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}}.
+        1. If <a>validating graph resources</a> given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns false, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}}.
+        1. If <a>validating graph resources</a> given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns false, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}}.
         1. Let |transferredInputs| be the result of [=MLNamedArrayBufferViews/transfer|transferring=] {{MLNamedArrayBufferViews}} |inputs|.
         1. Let |transferredOutputs| be the result of [=MLNamedArrayBufferViews/transfer|transferring=] {{MLNamedArrayBufferViews}} |outputs|.
         1. Invoke <a>execute graph</a> given |graph|, |transferredInputs| and |transferredOutputs|.
@@ -1586,7 +1586,7 @@ Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGr
   </summary>
   <div class=algorithm-steps>
     1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, then [=exception/throw=] a "{{SecurityError}}" {{DOMException}}.
-    1. If <a>validating MLContext</a> given |context| returns `false`, then [=exception/throw=] a "{{TypeError}}" and abort these steps.
+    1. If <a>validating MLContext</a> given |context| returns false, then [=exception/throw=] a "{{TypeError}}" and abort these steps.
     1. Set {{MLGraphBuilder/[[context]]}} to |context|.
   </div>
 </details>
@@ -1613,7 +1613,7 @@ Create a named {{MLOperand}} based on a descriptor, that can be used as an input
     1. [=Assert=]: the type of |descriptor| is {{MLOperandDescriptor}}.
     1. [=Assert=]: If |descriptor|.{{MLOperandDescriptor/dimensions}} does not [=map/exist=], then |descriptor| defines a scalar input.
     1. If |descriptor|.{{MLOperandDescriptor/dimensions}} [=map/exists=]:
-        1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return `false`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
@@ -1670,7 +1670,7 @@ Build a composed graph up to a given output operand into a computational graph, 
             1. Store a reference to |graphImpl| in |graph|.{{MLGraph/[[implementation]]}}.
         1. Make a request to the underlying platform to initialize the graph:
             1. [=map/For each=] |operand| in |outputs|:
-                1. If <a>validating MLOperand</a> given |operand| and [=this=] returns `false`, then [=exception/throw=] a {{TypeError}}.
+                1. If <a>validating MLOperand</a> given |operand| and [=this=] returns false, then [=exception/throw=] a {{TypeError}}.
                 1. If |operand| was created as an input by the underlying platform:
                     1. If |operand|.{{MLOperand/[[name]]}}] is not unique for |graphImpl|, then [=exception/throw=] a {{TypeError}}.
                     1. Add |operand|.{{MLOperand/[[descriptor]]}} to |graph|.{{MLGraph/[[inputDescriptors]]}}[|operand|.{{MLOperand/[[name]]}}].
@@ -1703,8 +1703,8 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
     </div>
     1. [=Assert=]: the type of |descriptor| is {{MLOperandDescriptor}}.
     1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return `false`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If <a>validating buffer with descriptor</a> given |bufferView| and |descriptor| returns `false`, then [=exception/throw=] a {{TypeError}}.
+    1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If <a>validating buffer with descriptor</a> given |bufferView| and |descriptor| returns false, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
         1. Let |bytes| be the result of invoking the [=get a copy of the bytes held by the buffer source=] steps given |bufferView|.
@@ -1890,8 +1890,8 @@ partial interface MLGraphBuilder {
     To <dfn>check clamp options</dfn> given |options|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. If |options|.{{MLClampOptions/minValue}} is greater than |options|.{{MLClampOptions/maxValue}}, then return `false`.
-    1. Return `true`.
+    1. If |options|.{{MLClampOptions/minValue}} is greater than |options|.{{MLClampOptions/maxValue}}, then return false.
+    1. Return true.
   </div>
 </details>
 
@@ -1913,7 +1913,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |operand| is {{MLOperand}}.
-    1. If running the <a>check clamp options</a> steps given |options| returns `false`, then [=exception/throw=] a {{TypeError}}.
+    1. If running the <a>check clamp options</a> steps given |options| returns false, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |operand|.
         1. Make a request to the underlying platform to:
@@ -1943,7 +1943,7 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>clamp(|options|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. If running the <a>check clamp options</a> steps given |options| returns `false`, then [=exception/throw=] a {{TypeError}}.
+    1. If running the <a>check clamp options</a> steps given |options| returns false, then [=exception/throw=] a {{TypeError}}.
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=],  `"clamp"` and |options|.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
@@ -1985,9 +1985,9 @@ partial interface MLGraphBuilder {
     1. If any of the following steps fail, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Let |desc| be |inputs|[0].{{MLOperand/[[descriptor]]}}.
         1. If |axis| is greater than or equal to the [=rank=] of |desc|, fail.
-        1. Let |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] be `0`.
+        1. Let |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] be 0.
         1. [=map/For each=] |index| in [=the range=] 0 to the [=rank=] of |inputs|, exclusive:
-            1. If <a>validating MLOperand</a> given |inputs|[|index|] and [=this=] returns `false`, then fail.
+            1. If <a>validating MLOperand</a> given |inputs|[|index|] and [=this=] returns false, then fail.
             1. [=map/For each=] |dim| in [=the range=] 0 to the [=rank=] of |inputs|[|index|].{{MLOperandDescriptor/dimensions}}, exclusive:
                 <div class="note">
                     If the shape of each corresponding dimension and type of the operands, except for those of the dimension given by |axis|, is not the same, fail.
@@ -2137,16 +2137,16 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |input| and |filter| is {{MLOperand}}.
     1. Let |inputSize| be the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Let |filterSize| be the [=list/size=] of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-    1. If |inputSize| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |filterSize| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |inputSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |filterSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/padding}} does not [=map/exist=], set it to `« 0, 0, 0, 0 »`.
     1. Else if the [=list/size=] of |options|.{{MLConv2dOptions/padding}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConv2dOptions/strides}} does not [=map/exist=], set it to `« 1, 1 »`.
-    1. Else if the [=list/size=] of |options|.{{MLConv2dOptions/strides}} is not `2`, then [=exception/throw=] a {{TypeError}}.
+    1. Else if the [=list/size=] of |options|.{{MLConv2dOptions/strides}} is not 2, then [=exception/throw=] a {{TypeError}}.
     1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/dilations}} does not [=map/exist=], set it to `« 1, 1 »`.
-    1. Else if the [=list/size=] of |options|.{{MLConv2dOptions/dilations}} is not `2`, then [=exception/throw=] a {{TypeError}}.
+    1. Else if the [=list/size=] of |options|.{{MLConv2dOptions/dilations}} is not 2, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/autoPad}} does not [=map/exist=], set it to `"explicit"`.
     1. If |options|.{{MLConv2dOptions/groups}} is 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |inputSize| / |options|.{{MLConv2dOptions/groups}} is not equal to |filterSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -2313,20 +2313,20 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |input| and |filter| is {{MLOperand}}.
     1. Let |inputSize| be the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Let |filterSize| be the [=list/size=] of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-    1. If |inputSize| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |filterSize| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |inputSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |filterSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/padding}} does not [=map/exist=], set it to `« 0, 0, 0, 0 »`.
     1. Else if the [=list/size=] of |options|.{{MLConvTranspose2dOptions/padding}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConvTranspose2dOptions/strides}} does not [=map/exist=], set it to `« 1, 1 »`.
-    1. Else if the [=list/size=] of |options|.{{MLConvTranspose2dOptions/strides}} is not `2`, then [=exception/throw=] a {{TypeError}}.
+    1. Else if the [=list/size=] of |options|.{{MLConvTranspose2dOptions/strides}} is not 2, then [=exception/throw=] a {{TypeError}}.
     1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/dilations}} does not [=map/exist=], set it to `« 1, 1 »`.
-    1. Else if the [=list/size=] of |options|.{{MLConvTranspose2dOptions/dilations}} is not `2`, then [=exception/throw=] a {{TypeError}}.
+    1. Else if the [=list/size=] of |options|.{{MLConvTranspose2dOptions/dilations}} is not 2, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/outputPadding}} does not [=map/exist=], set it to `« 0, 0 »`.
-    1. Else if the [=list/size=] of |options|.{{MLConvTranspose2dOptions/outputPadding}} is not `2`, then [=exception/throw=] a {{TypeError}}.
+    1. Else if the [=list/size=] of |options|.{{MLConvTranspose2dOptions/outputPadding}} is not 2, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/outputSizes}} [=map/exists=]:
-        1. If the [=list/size=] of |options|.{{MLConvTranspose2dOptions/outputSizes}} is not `2`, then [=exception/throw=] a {{TypeError}}.
+        1. If the [=list/size=] of |options|.{{MLConvTranspose2dOptions/outputSizes}} is not 2, then [=exception/throw=] a {{TypeError}}.
         1. If the elements of |options|.{{MLConvTranspose2dOptions/outputSizes}} are not smaller than the elements at the same dimension (index) for |options|.{{MLConvTranspose2dOptions/strides}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |inputSize| / |options|.{{MLConvTranspose2dOptions/groups}} is not equal to |filterSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Else if |inputSize| % |options|.{{MLConvTranspose2dOptions/groups}} is not 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -2726,7 +2726,7 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLGemmOptions>
     : <dfn>c</dfn>
     ::
-        An {{MLOperand}}. Specifies the third input tensor. It is either a scalar, or of the shape that is unidirectionally broadcastable to the shape [M, N] according to [[!numpy-broadcasting-rule]]. When it is not specified, the computation is done as if *c* is a scalar `0.0`.
+        An {{MLOperand}}. Specifies the third input tensor. It is either a scalar, or of the shape that is unidirectionally broadcastable to the shape [M, N] according to [[!numpy-broadcasting-rule]]. When it is not specified, the computation is done as if *c* is a scalar 0.0.
 
     : <dfn>alpha</dfn>
     ::
@@ -2763,9 +2763,9 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |a| and |b| is {{MLOperand}}.
     1. Let |shapeA| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeA| the [=list/size=] of |shapeA|.
     1. Let |shapeB| be |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeB| the [=list/size=] of |shapeB|.
-    1. If |sizeA| is not `2` or |sizeB| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |options|.{{MLGemmOptions/aTranspose}} is `true`, then let |shapeA| be the reverse array of |shapeA|.
-    1. If |options|.{{MLGemmOptions/bTranspose}} is `true`, then let |shapeB| be the reverse array of |shapeB|.
+    1. If |sizeA| is not 2 or |sizeB| is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |options|.{{MLGemmOptions/aTranspose}} is true, then let |shapeA| be the reverse array of |shapeA|.
+    1. If |options|.{{MLGemmOptions/bTranspose}} is true, then let |shapeB| be the reverse array of |shapeB|.
     1. If |shapeA|[1] is not equal to |shapeB|[0], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGemmOptions/c}} [=map/exists=] and is not unidirectionally broadcastable to the shape [|shapeA|[0], |shapeB|[1]] according to the [[!numpy-broadcasting-rule]], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         <div class="note">
@@ -2854,16 +2854,16 @@ partial interface MLGraphBuilder {
 
     : <dfn>resetAfter</dfn>
     ::
-        A {{boolean}} indicating whether to apply the reset gate after or before matrix multiplication. The default value is `true`.
+        A {{boolean}} indicating whether to apply the reset gate after or before matrix multiplication. The default value is true.
 
     : <dfn>returnSequence</dfn>
     ::
         A {{boolean}} indicating whether to also return the entire sequence with every output from each time step in it in addition to the output of the last time step.
-        The default value is `false`.
+        The default value is false.
 
     : <dfn>direction</dfn>
     ::
-        An {{MLRecurrentNetworkDirection}}. Specifies the processing direction of the input sequence. When set to `"both"`, the size of the first dimension of the weight and the bias tensor shapes must be `2`, and the input is processed in both directions.
+        An {{MLRecurrentNetworkDirection}}. Specifies the processing direction of the input sequence. When set to `"both"`, the size of the first dimension of the weight and the bias tensor shapes must be 2, and the input is processed in both directions.
 
     : <dfn>layout</dfn>
     ::
@@ -2883,7 +2883,7 @@ partial interface MLGraphBuilder {
         - *hiddenSize*: an {{unsigned long}} scalar. The value of the third dimension of the cell output tensor shape. It indicates the number of features in the hidden state.
         - *options*: an optional {{MLGruOptions}}. The optional parameters of the operation.
 
-    **Returns:** a sequence of {{MLOperand}}. The first element of the sequence is a 3-D tensor of shape [numDirections, batchSize, hiddenSize], the cell output from the last time step of the network. Additionally, if |options|.{{MLGruOptions/returnSequence}} is set to `true`, the second element is the 4-D output tensor of shape [steps, numDirections, batchSize, hiddenSize] containing every cell outputs from each time step in the temporal sequence.
+    **Returns:** a sequence of {{MLOperand}}. The first element of the sequence is a 3-D tensor of shape [numDirections, batchSize, hiddenSize], the cell output from the last time step of the network. Additionally, if |options|.{{MLGruOptions/returnSequence}} is set to true, the second element is the 4-D output tensor of shape [steps, numDirections, batchSize, hiddenSize] containing every cell outputs from each time step in the temporal sequence.
 </div>
 
 <details open algorithm>
@@ -2893,16 +2893,16 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
-    1. If the [=rank=] of |input| or |weight| or |recurrentWeight| is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |input| or |weight| or |recurrentWeight| is not 3, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/bias}} [=map/exists=].
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If |options|.{{MLGruOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to `3 * hiddenSize`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLGruOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to 3 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/recurrentBias}} [=map/exists=].
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If |options|.{{MLGruOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to `3 * hiddenSize`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLGruOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to 3 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/initialHiddenState}} [=map/exists=].
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If its rank is not 3, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and its [=list/size=] is not 2, then [=exception/throw=] a {{TypeError}}.
     1. If |steps| is not equal to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0], then [=exception/throw=] a {{TypeError}}.
     1. Let |output| be an empty sequence of {{MLOperand}} objects.
@@ -3011,7 +3011,7 @@ partial interface MLGraphBuilder {
 
     : <dfn>resetAfter</dfn>
     ::
-        A {{boolean}} indicating whether to apply the reset gate after or before matrix multiplication. The default value is `true`.
+        A {{boolean}} indicating whether to apply the reset gate after or before matrix multiplication. The default value is true.
 
     : <dfn>layout</dfn>
     ::
@@ -3041,9 +3041,9 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
-    1. If the [=rank=] of |input| or |weight| or |recurrentWeight| or |hiddenState| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |input| or |weight| or |recurrentWeight| or |hiddenState| is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |weight|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not equal to 3 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |recurrentWeight|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not equal to `3 * hiddenSize`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |recurrentWeight|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not equal to 3 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/bias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not equal to 3 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -3207,11 +3207,11 @@ partial interface MLGraphBuilder {
     : <dfn>alpha</dfn>
     ::
          A {{float}} scalar multiplier.
-         The default value is `0.2`.
+         The default value is 0.2.
     : <dfn>beta</dfn>
     ::
          A {{float}} scalar addition.
-         The default value is `0.5`.
+         The default value is 0.5.
 </dl>
 
 #### The {{MLGraphBuilder/hardSigmoid(input, options)}} method #### {#api-mlgraphbuilder-hardsigmoid-input-options}
@@ -3396,7 +3396,7 @@ The {{MLInstanceNormalizationOptions}} members are:
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If the [=rank=] of |input| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |input| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=Assert=]:  the type of |options|.{{MLInstanceNormalizationOptions/scale}} is {{MLOperand}}.
     1. If the [=rank=] of |options|.{{MLInstanceNormalizationOptions/scale}} is not equal to the [=list/size=] of the channel dimension of |input|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=Assert=]: the type of |options|.{{MLInstanceNormalizationOptions/bias}} is  {{MLOperand}}.
@@ -3486,7 +3486,7 @@ partial interface MLGraphBuilder {
     : <dfn>alpha</dfn>
     ::
          A {{float}} scalar multiplier.
-         The default value is `0.01`.
+         The default value is 0.01.
 </dl>
 
 #### The {{MLGraphBuilder/leakyRelu(input, options)}} method #### {#api-mlgraphbuilder-leaky-relu-input-options}
@@ -3575,11 +3575,11 @@ partial interface MLGraphBuilder {
     : <dfn>alpha</dfn>
     ::
          A {{float}} scalar multiplier.
-         The default value is `1`.
+         The default value is 1.
     : <dfn>beta</dfn>
     ::
          A {{float}} scalar addition.
-         The default value is `0`.
+         The default value is 0.
 </dl>
 
 #### The {{MLGraphBuilder/linear(input, options)}} method #### {#api-mlgraphbuilder-linear-input-options}
@@ -3688,7 +3688,7 @@ partial interface MLGraphBuilder {
 
     : <dfn>direction</dfn>
     ::
-        An {{MLRecurrentNetworkDirection}}. Specifies the processing direction of the input sequence. When set to `"both"`, the size of the first dimension of the weight and the bias tensor shapes must be `2`, and the input is processed in both directions.
+        An {{MLRecurrentNetworkDirection}}. Specifies the processing direction of the input sequence. When set to `"both"`, the size of the first dimension of the weight and the bias tensor shapes must be 2, and the input is processed in both directions.
 
     : <dfn>layout</dfn>
     ::
@@ -3717,7 +3717,7 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>lstm(|input|, |weight|, |recurrentWeight|, |steps|, |hiddenSize|, |options|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. Let |numDirections| be `1` if |options|.{{MLLstmOptions/direction}} is `"forward"`, or otherwise let it be `2`.
+    1. Let |numDirections| be 1 if |options|.{{MLLstmOptions/direction}} is `"forward"`, or otherwise let it be 2.
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
         <div class="note">
             The shape of |input|, |weight| or |recurrentWeight| could be also checked here.
@@ -3726,28 +3726,28 @@ partial interface MLGraphBuilder {
     1. Let |batchSize| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1].
     1. If |options|.{{MLLstmOptions/bias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If its rank is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |numDirections|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not 4 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmOptions/recurrentBias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If its rank is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |numDirections|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not 4 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmOptions/peepholeWeight}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If its rank is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |numDirections|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not 4 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmOptions/initialHiddenState}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If its rank is not 3, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/initialHiddenState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |numDirections|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/initialHiddenState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to |batchSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/initialHiddenState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[2] is not |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmOptions/initialCellState}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If its rank is not 3, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |numDirections|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to |batchSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[2] is not |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -3919,19 +3919,19 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |weight|, |recurrentWeight|, |hiddenState| and |cellState| is {{MLOperand}}.
-    1. If the [=rank=] of |input|, |weight|, |recurrentWeight|, |hiddenState| or |cellState| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |input|, |weight|, |recurrentWeight|, |hiddenState| or |cellState| is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |batchSize| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0].
     1. If |options|.{{MLLstmCellOptions/bias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `1`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If its rank is not 1, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmCellOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not 4 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmCellOptions/recurrentBias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `1`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If its rank is not 1, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmCellOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not 4 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmCellOptions/peepholeWeight}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `1`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If its rank is not 1, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmCellOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not 3 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmCellOptions/activations}} [=map/exists=]:
         1. If its [=list/size=] is not 3, then [=exception/throw=] a {{TypeError}}.
@@ -4104,10 +4104,10 @@ partial interface MLGraphBuilder {
   <div class=algorithm-steps>
     1. Let |shapeA| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeA| the [=list/size=] of |shapeA|.
     1. Let |shapeB| be |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeB| the [=list/size=] of |shapeB|.
-    1. If |sizeA| and |sizeB| is `1`, return `«  1  »`.
-    1. If |sizeA| is `1` and |sizeB| is not, then insert `1` in the front of |shapeA| to become [ 1 | |shapeA| ] and let |sizeA| be `2`.
+    1. If |sizeA| and |sizeB| is 1, return `«  1  »`.
+    1. If |sizeA| is 1 and |sizeB| is not, then insert 1 in the front of |shapeA| to become [ 1 | |shapeA| ] and let |sizeA| be 2.
     1. If |shapeA|[0] is not equal to |shapeB|[|sizeB| - 2], then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-    1. If |sizeB| is `1` and |sizeA| is not, then insert `1` in the front of |shapeB| to become [ 1 | |shapeB| ] and let |sizeB| be `2`.
+    1. If |sizeB| is 1 and |sizeA| is not, then insert 1 in the front of |shapeB| to become [ 1 | |shapeB| ] and let |sizeB| be 2.
     1. If |shapeA|[|sizeA| - 1] is not equal to |shapeB|[0], then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
     1. If |shapeA| is not equal to |shapeB|, then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
     1. Let |shape| be an array whose size |size| is the maximum of |sizeA| and |sizeB|.
@@ -4176,7 +4176,7 @@ partial interface MLGraphBuilder {
     ::
         A {{float}}.
         Specifies the padding value when {{MLPadOptions/mode}} is set to `"constant"`.
-        The default value is `0`.
+        The default value is 0.
 </dl>
 
 <div>
@@ -4400,7 +4400,7 @@ partial interface MLGraphBuilder {
     1. If the [=list/size=] of |options|.{{MLPool2dOptions/strides}} is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any value in |options|.{{MLPool2dOptions/strides}} is not greater than 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLPool2dOptions/outputSizes}} [=map/exists=]:
-        1. If the [=list/size=] of |options|.{{MLPool2dOptions/outputSizes}} is not `2`, then [=exception/throw=] a {{TypeError}}.
+        1. If the [=list/size=] of |options|.{{MLPool2dOptions/outputSizes}} is not 2, then [=exception/throw=] a {{TypeError}}.
         1. If the elements of |options|.{{MLPool2dOptions/outputSizes}} are not smaller than the elements at the same dimension (index) for |options|.{{MLPool2dOptions/strides}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLPool2dOptions/dilations}} does not [=map/exist=], set |options|.{{MLPool2dOptions/dilations}} to `« 1, 1 »`.
     1. If the [=list/size=] of |options|.{{MLPool2dOptions/dilations}} is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -4780,11 +4780,11 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. If |options|.{{MLResample2dOptions/scales}} does not [=map/exist=], set it to to `« 1.0, 1.0 »`.
-    1. Otherwise, if any of its values is not greater than `0`, return `false`.
-    1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], and if its size is not `2`, or if any of its values is not greater than `0`, return `false`.
+    1. Otherwise, if any of its values is not greater than 0, return false.
+    1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], and if its size is not 2, or if any of its values is not greater than 0, return false.
     1. If |options|.{{MLResample2dOptions/axes}} does not [=map/exists=], set it to `« 2, 3 »`.
-    1. Otherwise, if its value is not one of `« 0, 1», « 1, 2», « 2, 3 »`, return `false`.
-    1. Return `true`.
+    1. Otherwise, if its value is not one of `« 0, 1», « 1, 2», « 2, 3 »`, return false.
+    1. Return true.
   </div>
 </details>
 
@@ -4811,8 +4811,8 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>resample2d(|input|, |options|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. Check if the input is a 4-dimensional tensor: if the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If running the <a>check resample options</a> steps given |options| returns `false`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Check if the input is a 4-dimensional tensor: if the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If running the <a>check resample options</a> steps given |options| returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| be the result of running the <a>resample output sizes</a> steps given |options|.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -4860,9 +4860,9 @@ partial interface MLGraphBuilder {
     1. Let |outputShape| be an empty array of {{unsigned long}}.
     1. If |newShape| is a scalar [=number=], set |outputShape| to `«  1  »`.
     1. Otherwise, if |newShape| is an array of {{unsigned long}}:
-        1. If the [=list/size=] of |newShape| is `0`, set |outputShape| to `«  1  »` (reshaping to scalar).
+        1. If the [=list/size=] of |newShape| is 0, set |outputShape| to `«  1  »` (reshaping to scalar).
         1. If |newShape| contains more than one `null` value, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. If any value in |newShape| is `0`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If any value in |newShape| is 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Let |inputElementCount| be the product of all elements in |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. If |newShape| contains a `null` value, set that value to |inputElementCount| divided by the product of all other values in |newShape|.
             1. If that value is too large for {{unsigned long}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -5114,7 +5114,7 @@ partial interface MLGraphBuilder {
     : <dfn>steepness</dfn>
     ::
          A {{float}} scalar parameter.
-         The default value is `1`.
+         The default value is 1.
 </dl>
 
 #### The {{MLGraphBuilder/softplus(input, options)}} method #### {#api-mlgraphbuilder-softplus-input-options}
@@ -5267,7 +5267,7 @@ partial interface MLGraphBuilder {
     : <dfn>axis</dfn>
     ::
         An {{unsigned long}} scalar. The dimension along which to split. Its value must be in the range [0, N-1] where N is the [=rank=] of the input tensor.
-        The default value is `0`.
+        The default value is 0.
 </dl>
 
 <details open algorithm>
@@ -5359,7 +5359,7 @@ partial interface MLGraphBuilder {
         1. If |axesLength| is not smaller than the <a>rank</a> of |dimensions|,
         1. For |index| in [=the range=] 0 to |axesLength|, exclusive:
             1. Let |oneDimIndex| be |options|.{{MLSqueezeOptions/axes}}[|index|].
-            1. If |dimensions|[|oneDimIndex|] is not `1`, then [=exception/throw=] a {{TypeError}}.
+            1. If |dimensions|[|oneDimIndex|] is not 1, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:

--- a/index.bs
+++ b/index.bs
@@ -814,7 +814,7 @@ Its <a>default allowlist</a> is <code>'self'</code>.
     The {{ML/createContext(options)}} method steps are:
 </summary>
 <div algorithm=createcontext class=algorithm-steps>
-    1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, return [=a new promise=] [=rejected=] with a "{{SecurityError}}" {{DOMException}} and abort these steps.
+    1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, return [=a new promise=] [=rejected=] with a "{{SecurityError}}" {{DOMException}}.
     1. Let |promise| be [=a new promise=].
     1. Return |promise| and run the following steps [=in parallel=].
     1. Run the <dfn>create context</dfn> steps given |options|:
@@ -827,7 +827,7 @@ Its <a>default allowlist</a> is <code>'self'</code>.
             1. Set |context|.{{[[contextType]]}} to "[=default-context|default=]".
             1. If |options|["{{deviceType}}"] [=map/exists=], then set |context|.{{[[deviceType]]}} to |options|["{{deviceType}}"]. Otherwise, set |context|.{{[[deviceType]]}} to "[=device-type-cpu|cpu=]".
             1. If |options|["{{powerPreference}}"] [=map/exists=], then set |context|.{{[[powerPreference]]}} to |options|["{{powerPreference}}"]. Otherwise, set |context|.{{[[powerPreference]]}} to "[=power-preference-default|default=]".
-    1. If <a>validating MLContext</a> given |context| return `false`, [=reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}} and abort these steps.
+    1. If <a>validating MLContext</a> given |context| returns `false`, [=reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}}.
     1. [=Resolve=] |promise| with |context|.
 </div>
 </details>
@@ -838,9 +838,9 @@ Its <a>default allowlist</a> is <code>'self'</code>.
     The {{ML/createContextSync(options)}} method steps are:
   </summary>
   <div algorithm=createcontextsync class=algorithm-steps>
-    1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, throw a "{{SecurityError}}" {{DOMException}} and abort these steps.
+    1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, then [=exception/throw=] a "{{SecurityError}}" {{DOMException}}.
     1. Let |context| be the result of running the <a>create context</a> steps given |options|.
-    1. If <a>validating MLContext</a> given |context| return `false`, throw a "{{NotSupportedError}}" {{DOMException}} and abort these steps.
+    1. If <a>validating MLContext</a> given |context| return `false`, then [=exception/throw=] a "{{NotSupportedError}}" {{DOMException}}.
     1. Return |context|.
   </div>
 </details>
@@ -1055,12 +1055,12 @@ The {{MLActivation}} objects (including the ones passed as input to methods) are
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |builder| is {{MLGraphBuilder}}.
-    1. If |name| is empty, then throw a "{{TypeError}}" and abort these steps.
+    1. If |name| is empty, then [=exception/throw=] a "{{TypeError}}" and abort these steps.
     1. Let |activation| be a new [=object=].
     1. Set |activation|.{{MLActivation/[[builder]]}} to |builder|.
     1. Set |activation|.{{MLActivation/[[name]]}} to |name|.
     1. If |options| is an [=object=], set |activation|.{{MLActivation/[[options]]}} to |options|.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform operator |opImpl| for the given |name| operation.
             1. Store a reference of |opImpl| in |activation|.{{MLActivation/[[operator]]}}.
@@ -1140,7 +1140,7 @@ When the {{[[contextType]]}} is set to [=default-context|default=] with the {{ML
 </details>
 
 ### Synchronous Execution ### {#api-mlcontext-sync-execution}
-Synchronously carries out the computational workload of a compiled graph {{MLGraph}} on the calling thread, which must be a worker thread, to produce results as defined by the operations in the graph. This method of execution requires an {{MLContext}} created with {{MLContextOptions}}. Otherwise, it throws an "{{OperationError}}" {{DOMException}}.
+Synchronously carries out the computational workload of a compiled graph {{MLGraph}} on the calling thread, which must be a worker thread, to produce results as defined by the operations in the graph. This method of execution requires an {{MLContext}} created with {{MLContextOptions}}. Otherwise, it[=exception/throws=] an "{{OperationError}}" {{DOMException}}.
 
 <script type=idl>
 partial interface MLContext {
@@ -1164,11 +1164,11 @@ partial interface MLContext {
     The {{MLContext/computeSync(graph, inputs, outputs)}} method steps are:
   </summary>
   <div algorithm=mlcontext.computesync class=algorithm-steps>
-    1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=], throw an "{{OperationError}}" {{DOMException}} and stop.
-    1. If <a>validating graph resources</a> given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns `false`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If <a>validating graph resources</a> given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns `false`, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=], [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. If <a>validating graph resources</a> given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns `false`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If <a>validating graph resources</a> given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns `false`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Invoke <a>execute graph</a> given |graph|, |inputs| and |outputs|.
-    1. If that throws an error, re-throw the error and stop.
+    1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return {{undefined}}.
   </div>
 </details>
@@ -1182,7 +1182,7 @@ partial interface MLContext {
     1. [=map/For each=] [=record=] <|key|, |value|> of |resources|:
         1. If |descriptors|[|key|] does not [=map/exist=], return `false`.
         1. [=Assert=]: the type of |value| is {{ArrayBufferView}}.
-        1. If <a>validating buffer with descriptor</a> given |value| and |descriptors|[|key|] return `false`, return `false`.
+        1. If <a>validating buffer with descriptor</a> given |value| and |descriptors|[|key|] returns `false`, then return `false`.
     1. Return `true`.
   </div>
 </details>
@@ -1215,11 +1215,11 @@ partial interface MLContext {
     1. [=Assert=]: the type of |outputs| is {{MLNamedArrayBufferViews}}.
     1. [=map/For each=] <|key|, |outputValue|> of |outputs|:
         1. Issue a compute request to |graph|.{{MLGraph/[[implementation]]}} given |key| and |inputResources| and wait for completion.
-            1. If that returns an error, then throw an "{{OperationError}}" {{DOMException}} and stop.
+            1. If that returns an error, then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
             1. Otherwise, store the result in |outputTensor|.
         1. Let |outputDesc| be |graph|.{{MLGraph/[[outputDescriptors]]}}[|key|].
-        1. If the byte length of |outputTensor| is not equal to the [=byte length=] of |outputDesc|, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If the [=element type=] of |outputTensor| doesn't match the [=element type=] of |outputValue|, then throw a "{{DataError}}" {{DOMException}} and stop.
+        1. If the byte length of |outputTensor| is not equal to the [=byte length=] of |outputDesc|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If the [=element type=] of |outputTensor| doesn't match the [=element type=] of |outputValue|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Request the underlying implementation of |graph| to set the values of elements in |outputValue| to the values of elements in |outputTensor|.
     1. Return {{undefined}}.
   </div>
@@ -1283,7 +1283,7 @@ partial interface MLContext {
 </details>
 
 ### Asynchronous Execution ### {#api-mlcontext-async-execution}
-Asynchronously carries out the computational workload of a compiled graph {{MLGraph}} on a separate timeline, either on a worker thread for the CPU execution, or on a GPU timeline for the submission of GPU workload on the command queue. The asynchronous nature of this call avoids blocking the calling thread while the computation for result is ongoing. This method of execution requires an {{MLContext}} created with {{MLContextOptions}}. Otherwise, it throws an "{{OperationError}}" {{DOMException}}.
+Asynchronously carries out the computational workload of a compiled graph {{MLGraph}} on a separate timeline, either on a worker thread for the CPU execution, or on a GPU timeline for the submission of GPU workload on the command queue. The asynchronous nature of this call avoids blocking the calling thread while the computation for result is ongoing. This method of execution requires an {{MLContext}} created with {{MLContextOptions}}. Otherwise, it[=exception/throws=] an "{{OperationError}}" {{DOMException}}.
 
 <div class="note">
 In accordance with the [=ArrayBufferView/write|Web IDL warning=], to prevent the calling thread from modifying the input and output resources while the computation is ongoing, this method [=MLNamedArrayBufferViews/transfer|transfers=] the input and output {{MLNamedArrayBufferViews}} to new views that share the same backing memory allocations. The transferred views are returned to the caller via the promise fulfillment with the computation result written into the backing memory of the output views.
@@ -1316,18 +1316,18 @@ partial interface MLContext {
   <div algorithm=mlcontext.compute class=algorithm-steps>
     1. Let |promise| be [=a new promise=].
     1. Return |promise| and run the following steps [=in parallel=]:
-        1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=], [=reject=] |promise| with an "{{OperationError}}" {{DOMException}} and stop.
-        1. If <a>validating graph resources</a> given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns `false`, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}} and stop.
-        1. If <a>validating graph resources</a> given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns `false`, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}} and stop.
+        1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=], [=reject=] |promise| with an "{{OperationError}}" {{DOMException}}.
+        1. If <a>validating graph resources</a> given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns `false`, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}}.
+        1. If <a>validating graph resources</a> given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns `false`, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}}.
         1. Let |transferredInputs| be the result of [=MLNamedArrayBufferViews/transfer|transferring=] {{MLNamedArrayBufferViews}} |inputs|.
         1. Let |transferredOutputs| be the result of [=MLNamedArrayBufferViews/transfer|transferring=] {{MLNamedArrayBufferViews}} |outputs|.
         1. Invoke <a>execute graph</a> given |graph|, |transferredInputs| and |transferredOutputs|.
-        1. If that throws an error, [=reject=] |promise| with the error and stop.
+        1. If that [=exception/throws=] an error, [=reject=] |promise| with the error.
         1. Otherwise, when <a>execute graph</a> has completed:
             1. Let |result| be a new {{MLComputeResult}}.
             1. Set |result|.{{MLComputeResult/inputs}} to |transferredInputs|.
             1. Set |result|.{{MLComputeResult/outputs}} to |transferredOutputs|.
-            1. [=Resolve=] |promise| with |result| and stop.
+            1. [=Resolve=] |promise| with |result|.
   </div>
 </details>
 
@@ -1365,7 +1365,7 @@ partial interface MLContext {
 </div>
 
 ### WebGPU Interoperability ### {#api-mlcontext-webgpu-interop}
-Create {{MLCommandEncoder}} interface used to record the ML workload onto a WebGPU-compatible {{GPUCommandBuffer}} to allow mixing of ML workload with other GPU workload in an application that leverages WebGPU. This method only succeeds on an {{MLContext}} created with {{GPUDevice}}. Otherwise, it throws an "{{OperationError}}" {{DOMException}}.
+Create {{MLCommandEncoder}} interface used to record the ML workload onto a WebGPU-compatible {{GPUCommandBuffer}} to allow mixing of ML workload with other GPU workload in an application that leverages WebGPU. This method only succeeds on an {{MLContext}} created with {{GPUDevice}}. Otherwise, it[=exception/throws=] an "{{OperationError}}" {{DOMException}}.
 
 <script type=idl>
 partial interface MLContext {
@@ -1452,7 +1452,7 @@ partial interface MLCommandEncoder {
     The {{MLCommandEncoder/dispatch(graph, inputs, outputs)}} steps are:
   </summary>
   <div algorithm=mlcommandencoder.dispatch class=algorithm-steps>
-    1. If any of the following requirements are unmet, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If any of the following requirements are unmet, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         <div class=validusage>
             1. [=map/For each=] |key| &rarr; |value| of |inputs|:
                 1. |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|] must [=map/exist=].
@@ -1471,7 +1471,7 @@ partial interface MLCommandEncoder {
         1. Set the output of |graph|.{{MLGraph/[[implementation]]}} that is associated with |key| to |value|.
     1. Issue a compute request of |graph|.{{MLGraph/[[implementation]]}}.
     1. If there is an error returned by |graph|.{{MLGraph/[[implementation]]}}, then:
-        1. Throw an "{{OperationError}}" {{DOMException}} and stop.
+        1. Throw an "{{OperationError}}" {{DOMException}}.
     1. Return {{undefined}}.
   </div>
 </details>
@@ -1497,7 +1497,7 @@ partial interface MLCommandEncoder {
     The {{MLCommandEncoder/finish(descriptor)}} method steps are:
   </summary>
   <div algorithm=mlcommandencoder.finish class=algorithm-steps>
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Make a request to the underlying platform to complete the recording of the ML workload, given |descriptor|.
             <div class="note">
                 See the related <a href="https://www.w3.org/TR/webgpu/#dom-gpucommandencoder-finish">WebGPU steps</a>.
@@ -1578,8 +1578,8 @@ Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGr
     The [=new=] {{MLGraphBuilder(context)}} constructor steps are:
   </summary>
   <div class=algorithm-steps>
-    1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, throw a "{{SecurityError}}" {{DOMException}} and abort these steps.
-    1. If <a>validating MLContext</a> given |context| return `false`, throw a "{{TypeError}}" and abort these steps.
+    1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, then [=exception/throw=] a "{{SecurityError}}" {{DOMException}}.
+    1. If <a>validating MLContext</a> given |context| returns `false`, then [=exception/throw=] a "{{TypeError}}" and abort these steps.
     1. Set {{MLGraphBuilder/[[context]]}} to |context|.
   </div>
 </details>
@@ -1602,13 +1602,13 @@ Create a named {{MLOperand}} based on a descriptor, that can be used as an input
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
-    1. If |name| is empty, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If |name| is empty, then [=exception/throw=] a {{TypeError}}.
     1. [=Assert=]: the type of |descriptor| is {{MLOperandDescriptor}}.
     1. [=Assert=]: If |descriptor|.{{MLOperandDescriptor/dimensions}} does not [=map/exist=], then |descriptor| defines a scalar input.
     1. If |descriptor|.{{MLOperandDescriptor/dimensions}} [=map/exists=]:
-        1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return `false`, throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+        1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return `false`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
         1. Set |operand|.{{MLOperand/[[name]]}} to |name|.
         1. Make a request to the underlying platform to:
@@ -1634,7 +1634,7 @@ Build a composed graph up to a given output operand into a computational graph, 
     1. Let |promise| be [=a new promise=].
     1. Return |promise| and run the following steps [=in parallel=].
     1. Return the result of invoking {{MLGraphBuilder/buildSync(outputs)}} given |outputs|.
-        1. If that throws, re-throw the error and stop.
+        1. If that [=exception/throws=], re-[=exception/throw=] the error.
   </div>
 </details>
 
@@ -1648,12 +1648,12 @@ Build a composed graph up to a given output operand into a computational graph, 
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
     1. [=Assert=]: the type of |outputs| is {{MLNamedOperands}}.
-    1. If |outputs| is empty, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If |outputs| is empty, then [=exception/throw=] a {{TypeError}}.
     1. [=map/For each=] |element| in |outputs|:
         1. [=Assert=]: the type of |element|.key is [=string=].
-        1. If |element|.key is empty, then [=exception/throw=] a {{TypeError}} and stop.
+        1. If |element|.key is empty, then [=exception/throw=] a {{TypeError}}.
         1. [=Assert=]: the type of |element|.value is {{MLOperand}}.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |graph| be a new {{MLGraph}}:
             1. Set |graph|.{{MLGraph/[[context]]}} to [=this=].{{MLGraphBuilder/[[context]]}}.
         1. Make a request to the underlying platform to:
@@ -1661,9 +1661,9 @@ Build a composed graph up to a given output operand into a computational graph, 
             1. Store a reference to |graphImpl| in |graph|.{{MLGraph/[[implementation]]}}.
         1. Make a request to the underlying platform to initialize the graph:
             1. [=map/For each=] |operand| in |outputs|:
-                1. If <a>validating MLOperand</a> given |operand| and [=this=] returns `false`, then [=exception/throw=] a {{TypeError}} and stop.
+                1. If <a>validating MLOperand</a> given |operand| and [=this=] returns `false`, then [=exception/throw=] a {{TypeError}}.
                 1. If |operand| was created as an input by the underlying platform:
-                    1. If |operand|.{{MLOperand/[[name]]}}] is not unique for |graphImpl|, then [=exception/throw=] a {{TypeError}} and stop.
+                    1. If |operand|.{{MLOperand/[[name]]}}] is not unique for |graphImpl|, then [=exception/throw=] a {{TypeError}}.
                     1. Add |operand|.{{MLOperand/[[descriptor]]}} to |graph|.{{MLGraph/[[inputDescriptors]]}}[|operand|.{{MLOperand/[[name]]}}].
                 1. If |operand| was created as a constant by the underlying platform:
                     1. Implementations MAY preprocess and optimize the tensor data of |operand| for the underlying platform.
@@ -1693,10 +1693,10 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
     1. [=Assert=]: the type of |descriptor| is {{MLOperandDescriptor}}.
-    1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return `false`, throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If <a>validating buffer with descriptor</a> given |bufferView| and |descriptor| return `false`, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return `false`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If <a>validating buffer with descriptor</a> given |bufferView| and |descriptor| returns `false`, then [=exception/throw=] a {{TypeError}}.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
         1. Let |bytes| be the result of invoking the [[=get a copy of the bytes held by the buffer source=]] steps given |bufferView|.
         1. Make a request to the underlying platform to:
@@ -1724,15 +1724,15 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
-    1. If |value| is not a [=number=], then [=exception/throw=] a {{TypeError}} and stop.
-    1. Otherwise, if |type| is not one of {{MLOperandType}}, then  [=exception/throw=] a {{TypeError}} and stop.
+    1. If |value| is not a [=number=], then [=exception/throw=] a {{TypeError}}.
+    1. Otherwise, if |type| is not one of {{MLOperandType}}, then  [=exception/throw=] a {{TypeError}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
         1. Set |descriptor|.{{MLOperandDescriptor/type}} to |type|.
         1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to `undefined`.
             <div class="note">
                 In the case of a scalar constant, |descriptor|.{{MLOperandDescriptor/dimensions}} is ignored.
             </div>
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform operand |constantImpl| to represent a constant, given |descriptor|.
@@ -1799,11 +1799,11 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=batchnorm class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |mean| and |variance| is {{MLOperand}}.
-    1. If |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} from which the dimension represented by |options|.axis is removed, then  [=exception/throw=] a {{TypeError}} and abort these steps.
-    1. If |options|.axis is not a number between 0 and the rank of |input|, then [=exception/throw=] a {{TypeError}} and abort these steps.
+    1. If |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} from which the dimension represented by |options|.axis is removed, then  [=exception/throw=] a {{TypeError}}.
+    1. If |options|.axis is not a number between 0 and the rank of |input|, then [=exception/throw=] a {{TypeError}}.
     1. If |input| is a 4-D tensor of the *"nchw"* layout, set |options|.axis to 1.
     1. If |input| is a 4-D tensor of the *"nhwc"* layout, set |options|.axis to 3.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|, that may use the same underlying data as |input|.
         1. Make a request to the underlying platform to initialize the batch normalization:
             1. Create an [=implementation-defined=] platform operator |batchNormImpl| for this method, given |input|, |mean|, |variance| and |options|.
@@ -1903,8 +1903,8 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=clamp class=algorithm-steps>
     1. [=Assert=]: the type of |operand| is {{MLOperand}}.
-    1. If running the <a>check clamp options</a> steps given |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If running the <a>check clamp options</a> steps given |options| returns `false`, then [=exception/throw=] a {{TypeError}}.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |operand|.
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform operator |clampImpl| for this method, given |options|.{{MLClampOptions/minValue}} and |options|.{{MLClampOptions/maxValue}}.
@@ -1932,9 +1932,9 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/clamp(options)}} method steps are:
   </summary>
   <div algorithm=clamp-options class=algorithm-steps>
-    1. If running the <a>check clamp options</a> steps given |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
+    1. If running the <a>check clamp options</a> steps given |options| returns `false`, then [=exception/throw=] a {{TypeError}}.
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=],  `"clamp"` and |options|.
-        1. If that throws an error, re-throw the error and abort these steps.
+        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
@@ -1970,7 +1970,7 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |axis| is `unsigned long`.
     1. [=Assert=]: the shape, i.e. {{MLOperandDescriptor/dimensions}}) of each operand in |inputs| is the same, except on the dimension given by |axis| on which they are concatenated.
     1. [=Assert=]: the {{MLOperandDescriptor/type}} of each operand in |inputs| is the same.
-    1. If any of the following steps fail, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If any of the following steps fail, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |axis| is greater than or equal to the <a>rank</a> of |inputs|, fail.
         1. Let |desc| be |inputs|[0].{{MLOperand/[[descriptor]]}}.
         1. Let |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] be `0`.
@@ -1983,7 +1983,7 @@ partial interface MLGraphBuilder {
                 1. If |dim| is not equal to |axis| and if |inputs|[|index|].{{MLOperandDescriptor/dimensions}}[|dim|] is not equal to |inputs|[0].{{MLOperandDescriptor/dimensions}}[|dim|], fail.
                 1. If |inputs|[|dim|].{{MLOperandDescriptor/type}} is not equal to |inputs|[0].{{MLOperandDescriptor/type}}.
                 1. If |dim| is equal to |axis|, add to |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] the value of |inputs|[|index|].{{MLOperandDescriptor/dimensions}}[|dim|].
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform operator |concatImpl| for this method, given |inputs| and |axis|.
@@ -2124,32 +2124,32 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |input| and |filter| is {{MLOperand}}.
     1. Let |input_size| be the size of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Let |filter_size| be the size of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-    1. If |input_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |filter_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If |input_size| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |filter_size| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/padding}} does not [=map/exist=], set it to `« 0, 0, 0, 0 »`.
-    1. Else if |options|.{{MLConv2dOptions/padding}}.length is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. Else if |options|.{{MLConv2dOptions/padding}}.length is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConv2dOptions/strides}} does not [=map/exist=], set it to `« 1, 1 »`.
-    1. Else if |options|.{{MLConv2dOptions/strides}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then [=exception/throw=] a {{TypeError}} and stop.
+    1. Else if |options|.{{MLConv2dOptions/strides}}.length is not `2`, then [=exception/throw=] a {{TypeError}}.
+    1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/dilations}} does not [=map/exist=], set it to `« 1, 1 »`.
-    1. Else if |options|.{{MLConv2dOptions/dilations}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
+    1. Else if |options|.{{MLConv2dOptions/dilations}}.length is not `2`, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/autoPad}} does not [=map/exist=], set it to `"explicit"`.
-    1. If |options|.{{MLConv2dOptions/groups}} is 0, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |input_size| / |options|.{{MLConv2dOptions/groups}} is not equal to |filter_size|, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. Else if |input_size| % |options|.{{MLConv2dOptions/groups}} is not 0, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLConv2dOptions/groups}} is 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |input_size| / |options|.{{MLConv2dOptions/groups}} is not equal to |filter_size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Else if |input_size| % |options|.{{MLConv2dOptions/groups}} is not 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConv2dOptions/bias}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConv2dOptions/bias}} is {{MLOperand}}.
-    1. If the length of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If the length of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/activation}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConv2dOptions/activation}} is {{MLActivation}}.
     1. Let |output_shape| be the result of invoking the underlying implementation for calculating output dimensions, given |options|.
-    1. If |output_shape| is not the same as the shape of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If |output_shape| is not the same as the shape of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |output_shape|.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform operator |conv2dImpl| for this method, given |options| and |filter|.
@@ -2299,35 +2299,35 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |input| and |filter| is {{MLOperand}}.
     1. Let |input_size| be the size of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Let |filter_size| be the size of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-    1. If |input_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |filter_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If |input_size| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |filter_size| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/padding}} does not [=map/exist=], set it to `« 0, 0, 0, 0 »`.
-    1. Else if |options|.{{MLConvTranspose2dOptions/padding}}.length is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. Else if |options|.{{MLConvTranspose2dOptions/padding}}.length is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConvTranspose2dOptions/strides}} does not [=map/exist=], set it to `« 1, 1 »`.
-    1. Else if |options|.{{MLConvTranspose2dOptions/strides}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then [=exception/throw=] a {{TypeError}} and stop.
+    1. Else if |options|.{{MLConvTranspose2dOptions/strides}}.length is not `2`, then [=exception/throw=] a {{TypeError}}.
+    1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/dilations}} does not [=map/exist=], set it to `« 1, 1 »`.
-    1. Else if |options|.{{MLConvTranspose2dOptions/dilations}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
+    1. Else if |options|.{{MLConvTranspose2dOptions/dilations}}.length is not `2`, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/outputPadding}} does not [=map/exist=], set it to `« 0, 0 »`.
-    1. Else if |options|.{{MLConvTranspose2dOptions/outputPadding}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
+    1. Else if |options|.{{MLConvTranspose2dOptions/outputPadding}}.length is not `2`, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/outputSizes}} [=map/exists=]:
-        1. If |options|.{{MLConvTranspose2dOptions/outputSizes}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
-        1. If the elements of |options|.{{MLConvTranspose2dOptions/outputSizes}} are not smaller than the elements at the same dimension (index) for |options|.{{MLConvTranspose2dOptions/strides}}, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |input_size| / |options|.{{MLConvTranspose2dOptions/groups}} is not equal to |filter_size|, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. Else if |input_size| % |options|.{{MLConvTranspose2dOptions/groups}} is not 0, then throw a "{{DataError}}" {{DOMException}} and stop.
+        1. If |options|.{{MLConvTranspose2dOptions/outputSizes}}.length is not `2`, then [=exception/throw=] a {{TypeError}}.
+        1. If the elements of |options|.{{MLConvTranspose2dOptions/outputSizes}} are not smaller than the elements at the same dimension (index) for |options|.{{MLConvTranspose2dOptions/strides}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |input_size| / |options|.{{MLConvTranspose2dOptions/groups}} is not equal to |filter_size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Else if |input_size| % |options|.{{MLConvTranspose2dOptions/groups}} is not 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConvTranspose2dOptions/bias}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConvTranspose2dOptions/bias}} is {{MLOperand}}.
-    1. If the length of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If the length of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/activation}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConvTranspose2dOptions/activation}} is {{MLActivation}}.
     1. Let |output_shape| be the result of invoking the underlying implementation for calculating output dimensions, given |options|.
-    1. If |output_shape| is not the same as the shape of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If |output_shape| is not the same as the shape of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |output_shape|.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform operator |convTranspose2dImpl| for this method, given |options| and |filter|.
@@ -2387,12 +2387,12 @@ partial interface MLGraphBuilder {
   <div algorithm=binary class=algorithm-steps>
     1. [=Assert=]: |op| is one of "add", "sub", "mul", "div", "max", "min", "pow".
     1. [=Assert=]: the type of |a| and |b| is {{MLOperand}}.
-    1. If |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not equal to |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not equal to |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
     1. Set |descriptor|.{{MLOperandDescriptor/type}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. Let |descriptor|.{{MLOperandDescriptor/dimensions}} be the result of running the [=MLGraphBuilder/broadcast-shapes=] steps given |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-        1. If that throws an error, re-throw the error and stop.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the binary operation |op|, given |a| and |b|.
@@ -2412,7 +2412,7 @@ partial interface MLGraphBuilder {
   <div algorithm=broadcast-shape class=algorithm-steps>
     1. [=Assert=]: The type of |shape1| and |shape2| is `sequence of unsigned long`.
     1. Let |output| be the result of invoking the [=implementation-defined=] shape broadcast on |shape1| and |shape2|.
-            1. If that fails, throw a "{{DataError}}" {{DOMException}} and stop.
+            1. If that fails, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Return |output|.
         <div class = "note">
         The most common implementation is that two shapes are compatible, when each of their corresponding dimensions are equal, or one of them is 1. The output shape consists of the maximum of the corresponding dimensions.
@@ -2427,37 +2427,37 @@ partial interface MLGraphBuilder {
   <div class=algorithm-steps>
     The {{MLGraphBuilder/add(a, b)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "add", |a| and |b|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/sub(a, b)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "sub", |a| and |b|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/mul(a, b)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "mul", |a| and |b|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/div(a, b)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "div", |a| and |b|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/max(a, b)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "max", |a| and |b|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/min(a, b)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "min", |a| and |b|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/pow(a, b)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "pow", |a| and |b|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 </div>
 </details>
@@ -2507,7 +2507,7 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: |op| is one of "abs", "ceil", "cos", "exp", "floor", "log", "neg", "sin", "tan".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the unary operation |op|.
@@ -2527,47 +2527,47 @@ partial interface MLGraphBuilder {
   <div class=algorithm-steps>
     The {{MLGraphBuilder/abs(input)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "abs" and |input|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/ceil(input)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "ceil" and |input|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/cos(input)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "cos" and |input|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/exp(input)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "exp" and |input|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/floor(input)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "floor" and |input|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/log(input)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "log" and |input|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/neg(input)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "neg" and |input|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/sin(input)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "sin" and |input|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/tan(input)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "tan" and |input|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
   </div>
 </details>
@@ -2622,7 +2622,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/elu(input, options)}} method steps are:
   </summary>
   <div algorithm=elu-input-options class=algorithm-steps>
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the ELU operation, given |options|.
@@ -2712,18 +2712,18 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |a| and |b| is {{MLOperand}}.
     1. Let |shapeA| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeA| the size of |shapeA|.
     1. Let |shapeB| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeB| the size of |shapeB|.
-    1. If |sizeA| is not `2` or |sizeB| is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If |sizeA| is not `2` or |sizeB| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGemmOptions/aTranspose}} is `true`, then let |shapeA| be the reverse array of |shapeA|.
     1. If |options|.{{MLGemmOptions/bTranspose}} is `true`, then let |shapeB| be the reverse array of |shapeB|.
-    1. If |shapeA|[1] is not equal to |shapeB|[0], then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLGemmOptions/c}} [=map/exists=] and is not unidirectionally broadcastable to the shape [|shapeA|[0], |shapeB|[1]] according to the [[!numpy-broadcasting-rule]], then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If |shapeA|[1] is not equal to |shapeB|[0], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |options|.{{MLGemmOptions/c}} [=map/exists=] and is not unidirectionally broadcastable to the shape [|shapeA|[0], |shapeB|[1]] according to the [[!numpy-broadcasting-rule]], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         <div class="note">
             Type compatibility between |a|, |b| and |options|.{{MLGemmOptions/c}} can be also checked.
         </div>
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [|shapeA|[0], |shapeB|[1]].
     1. Set |desc|.{{MLOperandDescriptor/type}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the GEMM operation, given |options|.
@@ -2841,23 +2841,23 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=gru class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
-    1. If the rank of |input| or |weight| is not `3`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If the rank of |weight| or |recurrentWeight| is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If the rank of |input| or |weight| is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the rank of |weight| or |recurrentWeight| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/bias}} [=map/exists=].
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
+        1. If its rank is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/recurrentBias}} [=map/exists=].
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
+        1. If its rank is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/initialHiddenState}} [=map/exists=].
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `3`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLGruOptions/direction}} is not one of {{MLRecurrentNetworkDirection}}, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options|.{{MLGruOptions/layout}} is not one of {{MLGruWeightLayout}}, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of {{MLActivation}} objects with size `2`, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |steps| is not a [=number=] or it is `0`, then [=exception/throw=] a {{TypeError}} and stop.
+        1. If its rank is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |options|.{{MLGruOptions/direction}} is not one of {{MLRecurrentNetworkDirection}}, then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLGruOptions/layout}} is not one of {{MLGruWeightLayout}}, then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of {{MLActivation}} objects with size `2`, then [=exception/throw=] a {{TypeError}}.
+    1. If |steps| is not a [=number=] or it is `0`, then [=exception/throw=] a {{TypeError}}.
     1. Let |output| be an empty sequence of {{MLOperand}} objects.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for `"gru"`, given |weight|, |recurrentWeight|, |steps|, |hiddenSize| and |options| as parameters.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
@@ -2991,20 +2991,20 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=grucell class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
-    1. If the rank of |input| or |weight| is not `3`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If the rank of |weight| or |recurrentWeight| is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If the rank of |input| or |weight| is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the rank of |weight| or |recurrentWeight| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/bias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `1`, then throw a "{{DataError}}" {{DOMException}} and stop.
+        1. If its rank is not `1`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/recurrentBias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `1`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLGruOptions/layout}} is not one of {{MLGruWeightLayout}}, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of {{MLActivation}} objects with size `2`, then [=exception/throw=] a {{TypeError}} and stop.
+        1. If its rank is not `1`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |options|.{{MLGruOptions/layout}} is not one of {{MLGruWeightLayout}}, then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of {{MLActivation}} objects with size `2`, then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |input|.{{MLOperandDescriptor/dimensions}}[0], |hiddenSize| ].
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for `"gruCell"`, given |weight|, |recurrentWeight|, |hiddenState|, |hiddenSize| and |options| as parameters.
@@ -3180,7 +3180,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=hardsigmoid-input-options class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the hard sigmoid operation, given |options|.
@@ -3208,7 +3208,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=hard-sigmoid-options class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=], `"hardSigmoid"` and |options|.
-        1. If that throws an error, re-throw the error and abort these steps.
+        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
@@ -3258,7 +3258,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/hardSwish(input)}} method steps are:
   </summary>
   <div algorithm=hardswish-input class=algorithm-steps>
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the hard-swish operation.
@@ -3286,7 +3286,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=hardswish class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"hardSwish"`.
-        1. If that throws an error, re-throw the error and abort these steps.
+        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
  </div>
 </details>
@@ -3342,13 +3342,13 @@ The {{MLInstanceNormalizationOptions}} members are:
   </summary>
   <div algorithm=instancenorm class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If the rank of |input| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If the rank of |input| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=Assert=]:  the type of |options|.{{MLInstanceNormalizationOptions/scale}} is {{MLOperand}}.
-    1. If the rank of |options|.{{MLInstanceNormalizationOptions/scale}} is not equal to the size of the channel dimension of |input|, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If the rank of |options|.{{MLInstanceNormalizationOptions/scale}} is not equal to the size of the channel dimension of |input|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=Assert=]: the type of |options|.{{MLInstanceNormalizationOptions/bias}} is  {{MLOperand}}.
-    1. If the rank of |options|.{{MLInstanceNormalizationOptions/bias}} is not equal to the size of the channel dimension of |input|, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. Otherwise if |options|.{{MLInstanceNormalizationOptions/layout}} is not one of {{MLInputOperandLayout}}, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If the rank of |options|.{{MLInstanceNormalizationOptions/bias}} is not equal to the size of the channel dimension of |input|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Otherwise if |options|.{{MLInstanceNormalizationOptions/layout}} is not one of {{MLInputOperandLayout}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the instance normalization operation, given |options|.
@@ -3451,7 +3451,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/leakyRelu(input, options)}} method steps are:
   </summary>
   <div algorithm=leakyrelu-input-options class=algorithm-steps>
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the Leaky RELU operation, given |options|.
@@ -3479,7 +3479,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=leakyrelu-options class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=], `"leakyRelu"` and |options|.
-        1. If that throws an error, re-throw the error and abort these steps.
+        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
@@ -3542,7 +3542,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/linear(input, options)}} method steps are:
   </summary>
   <div algorithm=linear-input-options class=algorithm-steps>
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the linear operation, given |options|.
@@ -3570,7 +3570,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=linear-options class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=],  `"linear"` and |options|.
-        1. If that throws an error, re-throw the error and abort these steps.
+        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
@@ -3659,46 +3659,46 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/lstm(input, weight, recurrentWeight, steps, hiddenSize, options)}} steps are:
   </summary>
   <div algorithm=lstm class=algorithm-steps>
-    1. If |options|.{{MLLstmOptions/direction}} is not one of {{MLRecurrentNetworkDirection}}, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If |options|.{{MLLstmOptions/direction}} is not one of {{MLRecurrentNetworkDirection}}, then [=exception/throw=] a {{TypeError}}.
     1. Let |num_directions| be `1` if |options|.{{MLLstmOptions/direction}} is `"forward"`, or otherwise let it be `2`.
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
         <div class="note">
             The shape of |input|, |weight| or |recurrentWeight| could be also checked here.
         </div>
-    1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not equal to |steps|, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not equal to |steps|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |batch_size| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1].
     1. If |options|.{{MLLstmOptions/bias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If |options|.{{MLLstmOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If |options|.{{MLLstmOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not 4 * |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
+        1. If its rank is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not 4 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmOptions/recurrentBias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If |options|.{{MLLstmOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If |options|.{{MLLstmOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not 4 * |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
+        1. If its rank is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not 4 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmOptions/peepholeWeight}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If |options|.{{MLLstmOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If |options|.{{MLLstmOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not 4 * |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
+        1. If its rank is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not 4 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmOptions/initialHiddenState}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `3`, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If |options|.{{MLLstmOptions/initialHiddenState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If |options|.{{MLLstmOptions/initialHiddenState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to |batch_size|, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If |options|.{{MLLstmOptions/initialHiddenState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[2] is not |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
+        1. If its rank is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/initialHiddenState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/initialHiddenState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to |batch_size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/initialHiddenState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[2] is not |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmOptions/initialCellState}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `3`, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to |batch_size|, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[2] is not |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLLstmOptions/layout}} is not one of {{MLLstmWeightLayout}}, then [=exception/throw=] a {{TypeError}} and stop.
+        1. If its rank is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to |batch_size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[2] is not |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |options|.{{MLLstmOptions/layout}} is not one of {{MLLstmWeightLayout}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLLstmOptions/activations}} [=map/exists=]:
-        1. If it is not an array of size `3`, then [=exception/throw=] a {{TypeError}} and stop.
+        1. If it is not an array of size `3`, then [=exception/throw=] a {{TypeError}}.
         1. [=Assert=]: the type of its elements is {{MLActivation}}.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |desc| a new {{MLOperandDescriptor}}.
         1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |nume_directions|, |batch_size|, |hiddenSize| ].
         1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
@@ -3860,28 +3860,28 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=lstmcell class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |weight|, |recurrentWeight|, |hiddenState| and |cellState| is {{MLOperand}}.
-    1. If the rank of |input|, |weight|, |recurrentWeight|, |hiddenState| or |cellState| is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If the rank of |input|, |weight|, |recurrentWeight|, |hiddenState| or |cellState| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |batch_size| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0].
     1. If |options|.{{MLLstmCellOptions/bias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `1`, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If |options|.{{MLLstmCellOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not 4 * |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
+        1. If its rank is not `1`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmCellOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not 4 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmCellOptions/recurrentBias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `1`, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If |options|.{{MLLstmCellOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not 4 * |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
+        1. If its rank is not `1`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmCellOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not 4 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmCellOptions/peepholeWeight}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `1`, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If |options|.{{MLLstmCellOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not 3 * |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLLstmCellOptions/layout}} is not one of {{MLLstmWeightLayout}}, then [=exception/throw=] a {{TypeError}} and stop.
+        1. If its rank is not `1`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmCellOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not 3 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |options|.{{MLLstmCellOptions/layout}} is not one of {{MLLstmWeightLayout}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLLstmCellOptions/activations}} [=map/exists=]:
-        1. If it is not an array of size `3`, then [=exception/throw=] a {{TypeError}} and stop.
+        1. If it is not an array of size `3`, then [=exception/throw=] a {{TypeError}}.
         1. [=Assert=]: the type of its elements is {{MLActivation}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |batch_size|, |hiddenSize| ].
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output0| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Let |output1| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Let |output| be the array [ |output0|, |output1| ].
@@ -4065,7 +4065,7 @@ partial interface MLGraphBuilder {
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of invoking the <a>calculate matmul output sizes</a> steps given |a| and |b|.
     1. Set |desc|.{{MLOperandDescriptor/type}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the matrix multiplication operation.
@@ -4147,11 +4147,11 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=pad class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If |beginningPadding| or |endingPadding| is not a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options|.{{MLPadOptions/mode}} is not one of {{MLPaddingMode}}, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If |beginningPadding| or |endingPadding| is not a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLPadOptions/mode}} is not one of {{MLPaddingMode}}, then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of invoking the <a>calculate padding output sizes</a> steps given |input|, |beginningPadding| and |endingPadding|.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the padding operation, given |beginningPadding|, |endingPadding| and |options|.
@@ -4328,18 +4328,18 @@ partial interface MLGraphBuilder {
   <div algorithm=create-pooling-operation class=algorithm-steps>
     1. [=Assert=]: |op| is one of "averagePool2d", "l2Pool2d", "maxPool2d".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If the length of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If the length of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLPool2dOptions/outputSizes}} [=map/exists=], or if |options|.{{MLPool2dOptions/padding}} does not [=map/exist=], set |options|.{{MLPool2dOptions/padding}} to `« 0, 0, 0, 0 »`.
-    1. If the length of |padding|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If the length of |padding|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLPool2dOptions/strides}} does not [=map/exist=], set |options|.{{MLPool2dOptions/strides}} to `« 1, 1 »`.
-    1. If the length of |options|.{{MLPool2dOptions/strides}} is not 2, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If any value in |options|.{{MLPool2dOptions/strides}} is not greater than 0, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If the length of |options|.{{MLPool2dOptions/strides}} is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If any value in |options|.{{MLPool2dOptions/strides}} is not greater than 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLPool2dOptions/dilations}} does not [=map/exist=], set |options|.{{MLPool2dOptions/dilations}} to `« 1, 1 »`.
-    1. If the length of |options|.{{MLPool2dOptions/dilations}} is not 2, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If any value in |options|.{{MLPool2dOptions/dilations}} is not greater than 0, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If the length of |options|.{{MLPool2dOptions/dilations}} is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If any value in |options|.{{MLPool2dOptions/dilations}} is not greater than 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLPool2dOptions/autoPad}} is not `"explicit"`, set |options|.{{MLPool2dOptions/padding}} to `« 0, 0, 0, 0 »`.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Make a request to the underlying platform to:
             1. Calculate the output dimensions given |input| and |options|. Let |desc|.{{MLOperandDescriptor/dimensions}} be the result of that.
             1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
@@ -4360,21 +4360,21 @@ partial interface MLGraphBuilder {
   <div algorithm=averagePool2d class=algorithm-steps>
     The {{MLGraphBuilder/averagePool2d(input, options)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/pooling-op | create pooling operation=] given `"averagePool2d"`, |input| and |options|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
   </div>
 
   <div algorithm=l2Pool2d class=algorithm-steps>
     The {{MLGraphBuilder/l2Pool2d(input, options)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/pooling-op | create pooling operation=] given `"l2Pool2d"`, |input| and |options|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
   </div>
 
   <div algorithm=maxPool2d class=algorithm-steps>
     The {{MLGraphBuilder/maxPool2d(input, options)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/pooling-op | create pooling operation=] given `"maxPool2d"`, |input| and |options|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
   </div>
 </details>
@@ -4405,8 +4405,8 @@ partial interface MLGraphBuilder {
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
     1. Set |descriptor|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. Let |descriptor|.{{MLOperandDescriptor/dimensions}} be the result of running the [=MLGraphBuilder/broadcast-shapes=] steps given |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |slope|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-        1. If that throws an error, re-throw the error and stop.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the PreLU operation, given |slope|.
@@ -4489,7 +4489,7 @@ partial interface MLGraphBuilder {
   <div algorithm=reduce class=algorithm-steps>
     1. [=Assert=]: |op| is one of "reduceL1", "reduceL2", "reduceLogSum", "reduceLogSumExp", "reduceMax", "reduceMean", "reduceMin", "reduceProduct", "reduceSum", "reduceSumSquare".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the |op| reduce operation, given |options|.
@@ -4508,52 +4508,52 @@ partial interface MLGraphBuilder {
   </summary>
     The {{MLGraphBuilder/reduceL1(input, options)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceL1", |input| and |options|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceL2(input, options)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceL2", |input| and |options|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceLogSum(input, options)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceLogSum", |input| and |options|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceLogSumExp(input, options)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceLogSumExp", |input| and |options|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceMax(input, options)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceMax", |input| and |options|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceMean(input, options)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceMean", |input| and |options|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceMin(input, options)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceMin", |input| and |options|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceProduct(input, options)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceProduct", |input| and |options|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceSum(input, options)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceSum", |input| and |options|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceSumSquare(input, options)}} steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceSumSquare", |input| and |options|.
-            1. If that throws an error, then re-throw the error and stop.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
 </details>
 
@@ -4596,7 +4596,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=relu-input class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the ReLU operation.
@@ -4624,7 +4624,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=relu class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"relu"`.
-        1. If that throws an error, re-throw the error and abort these steps.
+        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
@@ -4707,7 +4707,7 @@ partial interface MLGraphBuilder {
     1. For |index| between `0` and the rank of |desc|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}:
         1. Let |inputSize| be the size of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|index|].
         1. Let |outputSize| be |inputSize| multiplied by |options|.{{MLResample2dOptions/scales}}.
-            1. If that fails or |outputSize| is not a positive [=number=], then throw a "{{DataError}}" {{DOMException}} and stop.
+            1. If that fails or |outputSize| is not a positive [=number=], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Set |desc|.{{MLOperandDescriptor/dimensions}}[|index|] to |outputSize|.
     1. Return |desc|.
   </div>
@@ -4718,11 +4718,11 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/resample2d(input, options)}} steps are:
   </summary>
   <div algorithm=resample2d class=algorithm-steps>
-    1. Check if the input is a 4-dimensional tensor: if the size of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not `4`, throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If running the <a>check resample options</a> steps given |options| returns `false`, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. Check if the input is a 4-dimensional tensor: if the size of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If running the <a>check resample options</a> steps given |options| returns `false`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| be the result of running the <a>resample output sizes</a> steps given |options|.
-        1. If that throws an error, re-throw the error and stop.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the resample 2D operation, given |options|.
@@ -4767,15 +4767,15 @@ partial interface MLGraphBuilder {
     1. If |newShape| is a scalar [=number=], set |outputShape| to `«  1  »`.
     1. Otherwise, if |newShape| is an array of {{unsigned long}}:
         1. If the size of |newShape| is `0`, set |outputShape| to `«  1  »` (reshaping to scalar).
-        1. If |newShape| contains more than one `null` value, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If any value in |newShape| is `0`, then throw a "{{DataError}}" {{DOMException}} and stop.
+        1. If |newShape| contains more than one `null` value, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If any value in |newShape| is `0`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Let |inputElementCount| be the product of all elements in |inputs|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. If |newShape| contains a `null` value, set that value to |inputElementCount| divided by the product of all other values in |newShape|.
-            1. If that value is too large for {{unsigned long}}, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If product of all values in |newShape| is not equal to |inputElementCount|, then throw a "{{DataError}}" {{DOMException}} and stop.
+            1. If that value is too large for {{unsigned long}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If product of all values in |newShape| is not equal to |inputElementCount|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |newShape|.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the reshape operation.
@@ -4830,7 +4830,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=sigmoid-input class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the sigmoid operation.
@@ -4858,7 +4858,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=sigmoid class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"sigmoid"`.
-        1. If that throws an error, re-throw the error and abort these steps.
+        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
@@ -4885,12 +4885,12 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=slice class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If |starts| or |sizes| is not a sequence of {{long}}, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |sizes|.size is 0, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If |starts| or |sizes| is not a sequence of {{long}}, then [=exception/throw=] a {{TypeError}}.
+    1. If |sizes|.size is 0, then [=exception/throw=] a {{TypeError}}.
         <div class="note">
             Further validation of |starts| and |sizes| given |input| is left [=implementation-defined=].
         </div>
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the slice operation, given |starts| and |sizes|.
@@ -4949,8 +4949,8 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=softmax-input class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If the length of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 2, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If the length of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the softmax operation.
@@ -4977,7 +4977,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=softmax class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given  and  `"softmax"`.
-        1. If that throws an error, re-throw the error and abort these steps.
+        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
@@ -5037,7 +5037,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/softplus(input, options)}} method steps are:
   </summary>
   <div algorithm=softplus-input-options class=algorithm-steps>
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the softplus operation, given |options|.
@@ -5065,7 +5065,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=softplus-options class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=], `"softplus"` and |options|.
-        1. If that throws an error, re-throw the error and abort these steps.
+        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
@@ -5108,7 +5108,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=softsign-input class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the softsign operation, given |options|.
@@ -5135,7 +5135,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=softsign class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"softsign"`.
-        1. If that throws an error, re-throw the error and abort these steps.
+        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
@@ -5177,8 +5177,8 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=split class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If |splits| is not {{unsigned long}} or a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If |splits| is not {{unsigned long}} or a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}}.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the split operation, given |splits| and |options|.
@@ -5255,8 +5255,8 @@ partial interface MLGraphBuilder {
         1. Let |dimensions| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. For |index| between 0 and the size of |options|.{{MLSqueezeOptions/axes}}:
             1. Let |oneDimIndex| be |options|.{{MLSqueezeOptions/axes}}[|index|].
-            1. If |dimensions|[|oneDimIndex|] is not `1`, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+            1. If |dimensions|[|oneDimIndex|] is not `1`, then [=exception/throw=] a {{TypeError}}.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the squeeze operation, given |options|.
@@ -5309,7 +5309,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=tanh-input class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the hyperbolic tangent operation.
@@ -5337,7 +5337,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=tanh class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"tanh"`.
-        1. If that throws an error, re-throw the error and abort these steps.
+        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
@@ -5380,11 +5380,11 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |options|.{{MLTransposeOptions/permutation}} does not [=map/exist=], let |options|.{{MLTransposeOptions/permutation}} be the reversed sequence of all indices for |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Otherwise if |options|.{{MLTransposeOptions/permutation}} [=map/exists=]:
-        1. If |options|.{{MLTransposeOptions/permutation}} is not a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}} and stop.
-        1. If the rank of |options|.{{MLTransposeOptions/permutation}} is not the same as the rank of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a {{TypeError}} and stop.
-        1. If the values in |options|.{{MLTransposeOptions/permutation}} are not between `0` and the rank of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} minus `1`, then [=exception/throw=] a {{TypeError}} and stop.
-        1. If the values in |options|.{{MLTransposeOptions/permutation}} contain duplicate value, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+        1. If |options|.{{MLTransposeOptions/permutation}} is not a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}}.
+        1. If the rank of |options|.{{MLTransposeOptions/permutation}} is not the same as the rank of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a {{TypeError}}.
+        1. If the values in |options|.{{MLTransposeOptions/permutation}} are not between `0` and the rank of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} minus `1`, then [=exception/throw=] a {{TypeError}}.
+        1. If the values in |options|.{{MLTransposeOptions/permutation}} contain duplicate value, then [=exception/throw=] a {{TypeError}}.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the transpose operation, given |options|.

--- a/index.bs
+++ b/index.bs
@@ -2869,7 +2869,7 @@ partial interface MLGraphBuilder {
 
     : <dfn>layout</dfn>
     ::
-        An {{MLGruWeightLayout}}. The ordering of the weight and bias vectors for the internal gates of GRU, specifically the `update (z)`, `reset (r)`, and `new (n)` gate, as indicated in the second dimension of the weight and bias tensor shape. When not specified, the default layout is `"zrn"`.
+        An {{MLGruWeightLayout}}. The ordering of the weight and bias vectors for the internal gates of GRU, specifically the `update (z)`, `reset (r)`, and `new (n)` gate, as indicated in the second dimension of the weight and bias tensor shape. When not specified, the default layout is `"zrn"`.bias
 
     : <dfn>activations</dfn>
     ::
@@ -2895,21 +2895,20 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
-    1. If the [=rank=] of |input| or |weight| is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If the [=rank=] of |weight| or |recurrentWeight| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |input| or |weight| or |recurrentWeight| is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/bias}} [=map/exists=].
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLGruOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to `3 * hiddenSize`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/recurrentBias}} [=map/exists=].
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLGruOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to `3 * hiddenSize`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/initialHiddenState}} [=map/exists=].
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/direction}} is not one of {{MLRecurrentNetworkDirection}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLGruOptions/layout}} is not one of {{MLGruWeightLayout}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of {{MLActivation}} objects with size `2`, then [=exception/throw=] a {{TypeError}}.
-    1. If |steps| is not a [=number=] or it is `0`, then [=exception/throw=] a {{TypeError}}.
+    1. If |steps| is not equal to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0], then [=exception/throw=] a {{TypeError}}.
     1. Let |output| be an empty sequence of {{MLOperand}} objects.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Make a request to the underlying platform to:
@@ -3046,14 +3045,15 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
-    1. If the [=rank=] of |input| or |weight| is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If the [=rank=] of |weight| or |recurrentWeight| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |input| or |weight| or |recurrentWeight| or |hiddenState| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |weight|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not equal to 3 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |recurrentWeight|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not equal to `3 * hiddenSize`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/bias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `1`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If its rank is not equal to 3 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/recurrentBias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
-        1. If its rank is not `1`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If its rank is not equal to 3 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/layout}} is not one of {{MLGruWeightLayout}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of {{MLActivation}} objects with size `2`, then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
@@ -4115,8 +4115,11 @@ partial interface MLGraphBuilder {
     1. Let |shapeA| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeA| the [=list/size=] of |shapeA|.
     1. Let |shapeB| be |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeB| the [=list/size=] of |shapeB|.
     1. If |sizeA| and |sizeB| is `1`, return `«  1  »`.
-    1. If | sizeA| is `1` and |sizeB| is not, then insert `1` in the front of |shapeA| to become [ 1 | |shapeA| ] and let |sizeA| be `2`.
-    1. If | sizeB| is `1` and |sizeA| is not, then insert `1` in the front of |shapeB| to become [ 1 | |shapeB| ] and let |sizeB| be `2`.
+    1. If |sizeA| is `1` and |sizeB| is not, then insert `1` in the front of |shapeA| to become [ 1 | |shapeA| ] and let |sizeA| be `2`.
+    1. If |shapeA|[0] is not equal to |shapeB|[|sizeB| - 2], then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. If |sizeB| is `1` and |sizeA| is not, then insert `1` in the front of |shapeB| to become [ 1 | |shapeB| ] and let |sizeB| be `2`.
+    1. If |shapeA|[|sizeA| - 1] is not equal to |shapeB|[0], then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. If |shapeA| is not equal to |shapeB|, then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
     1. Let |shape| be an array whose size |size| is the maximum of |sizeA| and |sizeB|.
     1. [=map/For each=] |index| in [=the range=] 0 to |size|, exclusive:
        1. Set |shape|[|index|] to the maximum of |shapeA|[|index|] and |shapeB|[|index|].
@@ -4133,6 +4136,7 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |a| and |b| is {{MLOperand}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of invoking the <a>calculate matmul output sizes</a> steps given |a| and |b|.
+    1. If that throws an error, re-[=exception/throw=] the error.
     1. Set |desc|.{{MLOperandDescriptor/type}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.

--- a/index.bs
+++ b/index.bs
@@ -1993,14 +1993,15 @@ partial interface MLGraphBuilder {
         1. If |axis| is greater than or equal to the [=rank=] of |desc|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Let |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] be 0.
         1. [=map/For each=] |index| in [=the range=] 0 to the [=rank=] of |inputs|, exclusive:
-            1. If <a>validating MLOperand</a> given |inputs|[|index|] and [=this=] returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-            1. [=map/For each=] |dim| in [=the range=] 0 to the [=rank=] of |inputs|[|index|].{{MLOperandDescriptor/dimensions}}, exclusive:
+            1. Let |input| be |inputs|[|index|].
+            1. If <a>validating MLOperand</a> given |input| and [=this=] returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+            1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not equal to |inputs|[0].{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+            1. [=map/For each=] |dim| in [=the range=] 0 to the [=rank=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, exclusive:
                 <div class="note">
                     If the shape of each corresponding dimension and type of the operands, except for those of the dimension given by |axis|, is not the same, fail.
                 </div>
-                1. If |inputs|[|index|].{{MLOperandDescriptor/type}} is not equal to |inputs|[0].{{MLOperandDescriptor/type}}.
-                1. If |dim| is not equal to |axis| and if |inputs|[|index|].{{MLOperandDescriptor/dimensions}}[|dim|] is not equal to |inputs|[0].{{MLOperandDescriptor/dimensions}}[|dim|], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-                1. If |dim| is equal to |axis|, add to |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] the value of |inputs|[|index|].{{MLOperandDescriptor/dimensions}}[|dim|].
+                1. If |dim| is not equal to |axis| and if |input|.{{MLOperandDescriptor/dimensions}}[|dim|] is not equal to |inputs|[0].{{MLOperandDescriptor/dimensions}}[|dim|], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+                1. If |dim| is equal to |axis|, add to |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] the value of |input|.{{MLOperandDescriptor/dimensions}}[|dim|].
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:

--- a/index.bs
+++ b/index.bs
@@ -1175,7 +1175,7 @@ When the {{[[contextType]]}} is set to [=default-context|default=] with the {{ML
 ### The {{MLContext}} validation algorithm ### {#api-mlcontext-validate}
 <details open>
   <summary>
-    To <dfn lt="validate MLContext">validate MLContext</dfn>, given |context|, run these steps:
+    To <dfn>validate MLContext</dfn>, given |context|, run these steps:
   </summary>
   <div class=algorithm-steps>
     1. If |context|.{{[[contextType]]}} is not "[=webgpu-context|webgpu=]" or "[=default-context|default=]", return `false`.
@@ -1222,7 +1222,7 @@ partial interface MLContext {
 
 <details open>
   <summary>
-    To <dfn lt="validate graph resources">validate graph resources</dfn>, given |resources| and |descriptors|, run the following steps:
+    To <dfn>validate graph resources</dfn>, given |resources| and |descriptors|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |resources| is {{MLNamedArrayBufferViews}}.
@@ -1247,7 +1247,7 @@ partial interface MLContext {
 
 <details open>
   <summary>
-    To <dfn lt="execute graph">execute graph</dfn>, given |graph|, |inputs| and |outputs|, run the following steps:
+    To <dfn>execute graph</dfn>, given |graph|, |inputs| and |outputs|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |inputs| is {{MLNamedArrayBufferViews}}.

--- a/index.bs
+++ b/index.bs
@@ -5083,6 +5083,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=softmax-input class=algorithm-steps>
     1. If |input| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If the length of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 2, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:

--- a/index.bs
+++ b/index.bs
@@ -1814,7 +1814,10 @@ partial interface MLGraphBuilder {
 </details>
 
 <div class="note">
+  <details open>
+    <summary>
     The behavior of this operation when the input tensor is 4-D of the *"nchw"* layout and the activation is of operator type *relu* can be generically emulated from the usage of other operations as follow. However, user agents typically have a more efficient implementation for it, therefore its usage is encouraged from the performance standpoint.
+    </summary>
     <pre highlight="js">
     const shape = [1,null,1,1];
     return builder.relu(
@@ -1829,7 +1832,7 @@ partial interface MLGraphBuilder {
             )),
         builder.reshape(options.bias, shape)));
     </pre>
-    </div>
+  </details>
 </div>
 
 ### The clamp() method ### {#api-mlgraphbuilder-clamp}
@@ -2573,10 +2576,13 @@ partial interface MLGraphBuilder {
 </script>
 
 <div class="note">
+  <details open>
+    <summary>
     The behavior of this operation can be generically emulated from the usage of
     other operations as follow. However, user agents typically have a more
     efficient implementation for it, therefore its usage is encouraged from the
     performance standpoint.
+    </summary>
     <pre highlight="js">
     return builder.add(
               builder.max(builder.constant(0), x),
@@ -2586,6 +2592,7 @@ partial interface MLGraphBuilder {
                   builder.exp(builder.min(builder.constant(0), x)),
                   builder.constant(1))));
     </pre>
+  </details>
 </div>
 
 <details open>
@@ -3148,10 +3155,13 @@ partial interface MLGraphBuilder {
 </script>
 
 <div class="note">
+  <details open>
+    <summary>
     The behavior of this operation can be generically emulated from the usage of
     other operations as follow. However, user agents typically have a more
     efficient implementation for it, therefore its usage is encouraged from the
     performance standpoint.
+    </summary>
     <pre highlight="js">
     return builder.max(
                builder.min(
@@ -3161,6 +3171,7 @@ partial interface MLGraphBuilder {
                    builder.constant(1)),
                builder.constant(0));
     </pre>
+  </details>
 </div>
 
 {{MLHardSigmoidOptions}} has the following members:
@@ -3442,14 +3453,18 @@ partial interface MLGraphBuilder {
 </script>
 
 <div class="note">
+  <details open>
+    <summary>
     The behavior of this operation can be generically emulated from the usage of
     other operations as follow. However, user agents typically have a more
     efficient implementation for it, therefore its usage is encouraged from the
     performance standpoint.
+    </summary>
     <pre highlight="js">
     return builder.add(builder.max(builder.constant(0), x),
               builder.mul(builder.constant(options.alpha), builder.min(builder.constant(0), x)));
     </pre>
+  </details>
 </div>
 
 {{MLLeakyReluOptions}} has the following members:
@@ -3543,15 +3558,19 @@ partial interface MLGraphBuilder {
 </script>
 
 <div class="note">
+  <details open>
+    <summary>
     The behavior of this operation can be generically emulated from the usage of
     other operations as follow. However, user agents typically have a more
     efficient implementation for it, therefore its usage is encouraged from the
     performance standpoint.
+    </summary>
     <pre highlight="js">
     return builder.add(
               builder.mul(x, builder.constant(options.alpha)),
               builder.constant(options.beta));
     </pre>
+  </details>
 </div>
 
 {{MLLinearOptions}} has the following members:
@@ -4485,14 +4504,18 @@ partial interface MLGraphBuilder {
 </details>
 
 <div class="note">
+  <details open>
+    <summary>
     The behavior of this operation can be generically emulated from the usage of
     other operations as follow. However, user agents typically have a more
     efficient implementation for it, therefore its usage is encouraged from the
     performance standpoint.
+    </summary>
     <pre highlight="js">
     return builder.add(builder.max(builder.constant(0), x),
                        builder.mul(slope, builder.min(builder.constant(0), x)));
     </pre>
+  </details>
 </div>
 
 ### Reduction operations ### {#api-mlgraphbuilder-reduce}
@@ -4630,13 +4653,17 @@ partial interface MLGraphBuilder {
 </script>
 
 <div class="note">
+  <details open>
+    <summary>
     The behavior of this operation can be generically emulated from the usage of
     other operations as follow. However, user agents typically have a more
     efficient implementation for it, therefore its usage is encouraged from the
     performance standpoint.
+    </summary>
     <pre highlight="js">
     return builder.max(builder.constant(0), x);
     </pre>
+  </details>
 </div>
 
 #### The {{MLGraphBuilder/relu(input)}} method #### {#api-mlgraphbuilder-relu-input}
@@ -4862,10 +4889,13 @@ partial interface MLGraphBuilder {
 </script>
 
 <div class="note">
+  <details open>
+    <summary>
     The behavior of this operation can be generically emulated from the usage of
     other operations as follow. However, user agents typically have a more
     efficient implementation for it, therefore its usage is encouraged from the
     performance standpoint.
+    </summary>
     <pre highlight="js">
     return builder.div(
               builder.constant(1),
@@ -4873,6 +4903,7 @@ partial interface MLGraphBuilder {
                 builder.exp(builder.neg(x)),
                 builder.constant(1)));
     </pre>
+  </details>
 </div>
 
 #### The {{MLGraphBuilder/sigmoid(input)}} method #### {#api-mlgraphbuilder-sigmoid-input}
@@ -5055,10 +5086,13 @@ partial interface MLGraphBuilder {
 </script>
 
 <div class="note">
+  <details open>
+    <summary>
     The behavior of this operation can be generically emulated from the usage of
     other operations as follow. However, user agents typically have a more
     efficient implementation for it, therefore its usage is encouraged from the
     performance standpoint.
+    </summary>
     <pre highlight="js">
     return builder.div(
               builder.log(
@@ -5067,6 +5101,7 @@ partial interface MLGraphBuilder {
                   builder.constant(1))),
               builder.constant(options.steepness));
     </pre>
+  </details>
 </div>
 
 {{MLSoftplusOptions}} has the following members:
@@ -5152,13 +5187,17 @@ partial interface MLGraphBuilder {
 </script>
 
 <div class="note">
+  <details open>
+    <summary>
     The behavior of this operation can be generically emulated from the usage of
     other operations as follow. However, user agents typically have a more
     efficient implementation for it, therefore its usage is encouraged from the
     performance standpoint.
+    </summary>
     <pre highlight="js">
     return builder.div(x, builder.add(builder.constant(1), builder.abs(x)));
     </pre>
+  </details>
 </div>
 
 #### The {{MLGraphBuilder/softsign(input)}} method #### {#api-mlgraphbuilder-softsign-input}
@@ -5350,15 +5389,19 @@ partial interface MLGraphBuilder {
 </script>
 
 <div class="note">
+  <details open>
+    <summary>
     The behavior of this operation can be generically emulated from the usage of
     other operations as follow. However, user agents typically have a more
     efficient implementation for it, therefore its usage is encouraged from the
     performance standpoint.
+    </summary>
     <pre highlight="js">
     return builder.div(
               builder.sub(builder.exp(builder.mul(builder.constant(2), x)), builder.constant(1)),
               builder.add(builder.exp(builder.mul(builder.constant(2), x)), builder.constant(1)));
     </pre>
+  </details>
 </div>
 
 #### The {{MLGraphBuilder/tanh(input)}} method #### {#api-mlgraphbuilder-tanh-input}

--- a/index.bs
+++ b/index.bs
@@ -4566,6 +4566,7 @@ partial interface MLGraphBuilder {
   <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "reduceL1", "reduceL2", "reduceLogSum", "reduceLogSumExp", "reduceMax", "reduceMean", "reduceMin", "reduceProduct", "reduceSum", "reduceSumSquare".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
+    1. If |options|.{{MLReduceOptions/axes}} [=map/exists=], if any of its elements is not in [=the range=] 0 to the [=rank=] of |input|, exclusive, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:

--- a/index.bs
+++ b/index.bs
@@ -4441,10 +4441,16 @@ partial interface MLGraphBuilder {
   <div algorithm=create-pooling-operation class=algorithm-steps>
     1. [=Assert=]: |op| is one of "averagePool2d", "l2Pool2d", "maxPool2d".
     1. If |input| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If the length of of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options| is `undefined`, let |options| be a new {{MLPool2dOptions}} object.
     1. If |options|.{{MLPool2dOptions/outputSizes}} [=map/exists=], or if |options|.{{MLPool2dOptions/padding}} is `undefined`, set |options|.{{MLPool2dOptions/padding}} to `[0, 0, 0, 0]`.
+    1. If the length of of |padding|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLPool2dOptions/strides}} is `undefined`, set |options|.{{MLPool2dOptions/strides}} to `[1, 1]`.
+    1. If the length of of |options|.{{MLPool2dOptions/strides}} is not 2, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If any value in |options|.{{MLPool2dOptions/strides}} is not greater than 0, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLPool2dOptions/dilations}} is `undefined`, set |options|.{{MLPool2dOptions/dilations}} to `[1, 1]`.
+    1. If the length of of |options|.{{MLPool2dOptions/dilations}} is not 2, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If any value in |options|.{{MLPool2dOptions/dilations}} is not greater than 0, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLPool2dOptions/autoPad}} is `undefined`, set |options|.{{MLPool2dOptions/autoPad}} to `"explicit"`.
     1. If |options|.{{MLPool2dOptions/autoPad}} is not `"explicit"`, set |options|.{{MLPool2dOptions/padding}} to `[0, 0, 0, 0]`.
     1. If |options|.{{MLPool2dOptions/layout}} is `undefined`, set |options|.{{MLPool2dOptions/layout}} to `"nchw"`.

--- a/index.bs
+++ b/index.bs
@@ -1990,16 +1990,16 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the {{MLOperandDescriptor/type}} of each operand in |inputs| is the same.
     1. If any of the following steps fail, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Let |desc| be |inputs|[0].{{MLOperand/[[descriptor]]}}.
-        1. If |axis| is greater than or equal to the [=rank=] of |desc|, fail.
+        1. If |axis| is greater than or equal to the [=rank=] of |desc|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Let |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] be 0.
         1. [=map/For each=] |index| in [=the range=] 0 to the [=rank=] of |inputs|, exclusive:
-            1. If <a>validating MLOperand</a> given |inputs|[|index|] and [=this=] returns false, then fail.
+            1. If <a>validating MLOperand</a> given |inputs|[|index|] and [=this=] returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
             1. [=map/For each=] |dim| in [=the range=] 0 to the [=rank=] of |inputs|[|index|].{{MLOperandDescriptor/dimensions}}, exclusive:
                 <div class="note">
                     If the shape of each corresponding dimension and type of the operands, except for those of the dimension given by |axis|, is not the same, fail.
                 </div>
-                1. If |dim| is not equal to |axis| and if |inputs|[|index|].{{MLOperandDescriptor/dimensions}}[|dim|] is not equal to |inputs|[0].{{MLOperandDescriptor/dimensions}}[|dim|], fail.
-                1. If |inputs|[|dim|].{{MLOperandDescriptor/type}} is not equal to |inputs|[0].{{MLOperandDescriptor/type}}.
+                1. If |inputs|[|index|].{{MLOperandDescriptor/type}} is not equal to |inputs|[0].{{MLOperandDescriptor/type}}.
+                1. If |dim| is not equal to |axis| and if |inputs|[|index|].{{MLOperandDescriptor/dimensions}}[|dim|] is not equal to |inputs|[0].{{MLOperandDescriptor/dimensions}}[|dim|], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
                 1. If |dim| is equal to |axis|, add to |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] the value of |inputs|[|index|].{{MLOperandDescriptor/dimensions}}[|dim|].
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.

--- a/index.bs
+++ b/index.bs
@@ -950,7 +950,7 @@ interface MLOperand {};
 
 To get the <dfn for="MLOperand">rank</dfn> of an {{MLOperand}} |operand|, run the following steps:
 <div algorithm=rank class=algorithm-steps>
-    1. Return the size of |operand|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+    1. Return the [=list/size=] of |operand|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
 </div>
 
 Since the {{MLOperand/[[builder]]}} object is bound by the {{MLGraphBuilder/constructor()}} constructor to an {{MLContext}} object, an {{MLOperand}} is also always bound to the same {{MLContext}} object.
@@ -992,8 +992,8 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
   </summary>
   <div class=algorithm-steps>
     1. If |dimensions| is not an array of positive numbers, return `false`;
-    1. If |dimensions|.length is 0, return `false`.
-    1. If |dimensions|.length is too large to be supported by the implementation, return `false`.
+    1. If the [=list/size=] of |dimensions| is 0, return `false`.
+    1. If the [=list/size=] of |dimensions| is too large to be supported by the implementation, return `false`.
     1. If any element of |dimensions| is not a positive number, or it is too large to be supported by the implementation given |type|, return `false`.
     1. Return `true`.
   </div>
@@ -1772,7 +1772,7 @@ partial interface MLGraphBuilder {
 
     : <dfn>axis</dfn>
     ::
-        A {{long}} scalar. Specifies the index to the feature count dimension of the input shape for which the mean and variance values are. Its value must be in the range [0, N-1] where N is the rank of input tensor. The default value is 1, corresponding to the channel (*"c"*) dimension in the *"nchw"* data layout.
+        A {{long}} scalar. Specifies the index to the feature count dimension of the input shape for which the mean and variance values are. Its value must be in the range [0, N-1] where N is the [=rank=] of the input tensor. The default value is 1, corresponding to the channel (*"c"*) dimension in the *"nchw"* data layout.
 
     : <dfn>epsilon</dfn>
     ::
@@ -1800,7 +1800,7 @@ partial interface MLGraphBuilder {
   <div algorithm=batchnorm class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |mean| and |variance| is {{MLOperand}}.
     1. If |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} from which the dimension represented by |options|.axis is removed, then  [=exception/throw=] a {{TypeError}}.
-    1. If |options|.axis is not a number between 0 and the rank of |input|, then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.axis is not a number between 0 and the [=rank=] of |input|, then [=exception/throw=] a {{TypeError}}.
     1. If |input| is a 4-D tensor of the *"nchw"* layout, set |options|.axis to 1.
     1. If |input| is a 4-D tensor of the *"nhwc"* layout, set |options|.axis to 3.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -1950,7 +1950,7 @@ partial interface MLGraphBuilder {
     **Arguments:**
         - *inputs*: a sequence of {{MLOperand}}. All input tensors must have the
             same shape, except for the size of the dimension to concatenate on.
-        - *axis*: an {{unsigned long}} scalar. The axis that the inputs concatenate along. Its value must be in the range [0, N-1] where N is the rank of input tensors.
+        - *axis*: an {{unsigned long}} scalar. The axis that the inputs concatenate along. Its value must be in the range [0, N-1] where N is the [=rank=] of the input tensors.
 
     **Returns:** an {{MLOperand}}. The concatenated tensor of all the inputs along
     the *axis*. The output tensor has the same shape except on the dimension
@@ -1971,12 +1971,12 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the shape, i.e. {{MLOperandDescriptor/dimensions}}) of each operand in |inputs| is the same, except on the dimension given by |axis| on which they are concatenated.
     1. [=Assert=]: the {{MLOperandDescriptor/type}} of each operand in |inputs| is the same.
     1. If any of the following steps fail, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. If |axis| is greater than or equal to the <a>rank</a> of |inputs|, fail.
+        1. If |axis| is greater than or equal to the [=rank=] of |inputs|, fail.
         1. Let |desc| be |inputs|[0].{{MLOperand/[[descriptor]]}}.
         1. Let |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] be `0`.
-        1. [=map/For each=] |index| between 0 and the <a>rank</a> of |inputs|:
+        1. [=map/For each=] |index| between 0 and the [=rank=] of |inputs|:
             1. If <a>validating MLOperand</a> given |inputs|[|index|] and [=this=] returns `false`, then fail.
-            1. [=map/For each=] |dim| between 0 and the <a>rank</a> of |inputs|[|index|]:
+            1. [=map/For each=] |dim| between 0 and the [=rank=] of |inputs|[|index|]:
                 <div class="note">
                     If the shape of each corresponding dimension and type of the operands, except for those of the dimension given by |axis|, is not the same, fail.
                 </div>
@@ -2122,18 +2122,18 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=conv2d class=algorithm-steps>
     1. [=Assert=]: the type of |input| and |filter| is {{MLOperand}}.
-    1. Let |input_size| be the size of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-    1. Let |filter_size| be the size of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+    1. Let |input_size| be the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+    1. Let |filter_size| be the [=list/size=] of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. If |input_size| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |filter_size| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/padding}} does not [=map/exist=], set it to `« 0, 0, 0, 0 »`.
-    1. Else if |options|.{{MLConv2dOptions/padding}}.length is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Else if the [=list/size=] of |options|.{{MLConv2dOptions/padding}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConv2dOptions/strides}} does not [=map/exist=], set it to `« 1, 1 »`.
-    1. Else if |options|.{{MLConv2dOptions/strides}}.length is not `2`, then [=exception/throw=] a {{TypeError}}.
+    1. Else if the [=list/size=] of |options|.{{MLConv2dOptions/strides}} is not `2`, then [=exception/throw=] a {{TypeError}}.
     1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/dilations}} does not [=map/exist=], set it to `« 1, 1 »`.
-    1. Else if |options|.{{MLConv2dOptions/dilations}}.length is not `2`, then [=exception/throw=] a {{TypeError}}.
+    1. Else if the [=list/size=] of |options|.{{MLConv2dOptions/dilations}} is not `2`, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/autoPad}} does not [=map/exist=], set it to `"explicit"`.
     1. If |options|.{{MLConv2dOptions/groups}} is 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |input_size| / |options|.{{MLConv2dOptions/groups}} is not equal to |filter_size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -2297,22 +2297,22 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=convtranspose2d class=algorithm-steps>
     1. [=Assert=]: the type of |input| and |filter| is {{MLOperand}}.
-    1. Let |input_size| be the size of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-    1. Let |filter_size| be the size of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+    1. Let |input_size| be the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+    1. Let |filter_size| be the [=list/size=] of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. If |input_size| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |filter_size| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/padding}} does not [=map/exist=], set it to `« 0, 0, 0, 0 »`.
-    1. Else if |options|.{{MLConvTranspose2dOptions/padding}}.length is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Else if the [=list/size=] of |options|.{{MLConvTranspose2dOptions/padding}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConvTranspose2dOptions/strides}} does not [=map/exist=], set it to `« 1, 1 »`.
-    1. Else if |options|.{{MLConvTranspose2dOptions/strides}}.length is not `2`, then [=exception/throw=] a {{TypeError}}.
+    1. Else if the [=list/size=] of |options|.{{MLConvTranspose2dOptions/strides}} is not `2`, then [=exception/throw=] a {{TypeError}}.
     1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/dilations}} does not [=map/exist=], set it to `« 1, 1 »`.
-    1. Else if |options|.{{MLConvTranspose2dOptions/dilations}}.length is not `2`, then [=exception/throw=] a {{TypeError}}.
+    1. Else if the [=list/size=] of |options|.{{MLConvTranspose2dOptions/dilations}} is not `2`, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/outputPadding}} does not [=map/exist=], set it to `« 0, 0 »`.
-    1. Else if |options|.{{MLConvTranspose2dOptions/outputPadding}}.length is not `2`, then [=exception/throw=] a {{TypeError}}.
+    1. Else if the [=list/size=] of |options|.{{MLConvTranspose2dOptions/outputPadding}} is not `2`, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/outputSizes}} [=map/exists=]:
-        1. If |options|.{{MLConvTranspose2dOptions/outputSizes}}.length is not `2`, then [=exception/throw=] a {{TypeError}}.
+        1. If the [=list/size=] of |options|.{{MLConvTranspose2dOptions/outputSizes}} is not `2`, then [=exception/throw=] a {{TypeError}}.
         1. If the elements of |options|.{{MLConvTranspose2dOptions/outputSizes}} are not smaller than the elements at the same dimension (index) for |options|.{{MLConvTranspose2dOptions/strides}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |input_size| / |options|.{{MLConvTranspose2dOptions/groups}} is not equal to |filter_size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Else if |input_size| % |options|.{{MLConvTranspose2dOptions/groups}} is not 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -2345,8 +2345,8 @@ partial interface MLGraphBuilder {
 Compute the element-wise binary addition, subtraction, multiplication, division, power, maximum and minimum of the two input tensors.
 
 The element-wise binary operations will be broadcasted according to
-[[!numpy-broadcasting-rule]]. The rank of the output tensor is the maximum
-rank of the input tensors. For each dimension of the output tensor, its size
+[[!numpy-broadcasting-rule]]. The [=rank=] of the output tensor is the maximum
+[=rank=] of the input tensors. For each dimension of the output tensor, its size
 is the maximum size along that dimension of the input tensors.
 
 <script type=idl>
@@ -2710,8 +2710,8 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=gemm class=algorithm-steps>
     1. [=Assert=]: the type of |a| and |b| is {{MLOperand}}.
-    1. Let |shapeA| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeA| the size of |shapeA|.
-    1. Let |shapeB| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeB| the size of |shapeB|.
+    1. Let |shapeA| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeA| the [=list/size=] of |shapeA|.
+    1. Let |shapeB| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeB| the [=list/size=] of |shapeB|.
     1. If |sizeA| is not `2` or |sizeB| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGemmOptions/aTranspose}} is `true`, then let |shapeA| be the reverse array of |shapeA|.
     1. If |options|.{{MLGemmOptions/bTranspose}} is `true`, then let |shapeB| be the reverse array of |shapeB|.
@@ -2841,8 +2841,8 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=gru class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
-    1. If the rank of |input| or |weight| is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If the rank of |weight| or |recurrentWeight| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |input| or |weight| is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |weight| or |recurrentWeight| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/bias}} [=map/exists=].
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -2991,8 +2991,8 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=grucell class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
-    1. If the rank of |input| or |weight| is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If the rank of |weight| or |recurrentWeight| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |input| or |weight| is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |weight| or |recurrentWeight| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/bias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `1`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -3342,11 +3342,11 @@ The {{MLInstanceNormalizationOptions}} members are:
   </summary>
   <div algorithm=instancenorm class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If the rank of |input| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |input| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=Assert=]:  the type of |options|.{{MLInstanceNormalizationOptions/scale}} is {{MLOperand}}.
-    1. If the rank of |options|.{{MLInstanceNormalizationOptions/scale}} is not equal to the size of the channel dimension of |input|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |options|.{{MLInstanceNormalizationOptions/scale}} is not equal to the [=list/size=] of the channel dimension of |input|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=Assert=]: the type of |options|.{{MLInstanceNormalizationOptions/bias}} is  {{MLOperand}}.
-    1. If the rank of |options|.{{MLInstanceNormalizationOptions/bias}} is not equal to the size of the channel dimension of |input|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |options|.{{MLInstanceNormalizationOptions/bias}} is not equal to the [=list/size=] of the channel dimension of |input|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Otherwise if |options|.{{MLInstanceNormalizationOptions/layout}} is not one of {{MLInputOperandLayout}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
@@ -3860,7 +3860,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=lstmcell class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |weight|, |recurrentWeight|, |hiddenState| and |cellState| is {{MLOperand}}.
-    1. If the rank of |input|, |weight|, |recurrentWeight|, |hiddenState| or |cellState| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |input|, |weight|, |recurrentWeight|, |hiddenState| or |cellState| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |batch_size| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0].
     1. If |options|.{{MLLstmCellOptions/bias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
@@ -4033,7 +4033,7 @@ partial interface MLGraphBuilder {
     Computes the matrix product of two input tensors as follows:
         - If both *a* and *b* are 2-dimensional, they are multiplied like conventional
             matrices and produce a 2-dimensional tensor as the output.
-        - If either *a* or *b* is `N`-dimensional where `N > 2`, it is treated as a stack of matrices with dimensions corresponding to the last two indices. The matrix multiplication will be broadcasted accordingly by following the [[!numpy-broadcasting-rule]]. The output is a `N`-dimensional tensor whose rank is the maximum rank of the input tensors. For each dimension, except the last two, of the output tensor, its size is the maximum size along that dimension of the input tensors.
+        - If either *a* or *b* is `N`-dimensional where `N > 2`, it is treated as a stack of matrices with dimensions corresponding to the last two indices. The matrix multiplication will be broadcasted accordingly by following the [[!numpy-broadcasting-rule]]. The output is a `N`-dimensional tensor whose rank is the maximum [=rank=] of the input tensors. For each dimension, except the last two, of the output tensor, its size is the maximum size along that dimension of the input tensors.
         - If *a* is 1-dimensional, it is converted to a 2-dimensional tensor by prepending a 1 to its dimensions.
         - If *b* is 1-dimensional, it is converted to a 2-dimensional tensor by by appending a 1 to its dimensions.
         - If both *a* and *b* are 1-dimensional, the operation is a vector dot-product, which produces a scalar output.
@@ -4044,8 +4044,8 @@ partial interface MLGraphBuilder {
     To <dfn dfn-for=MLGraphBuilder>calculate matmul output sizes</dfn>, given |a| and |b| run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. Let |shapeA| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeA| the size of |shapeA|.
-    1. Let |shapeB| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeB| the size of |shapeB|.
+    1. Let |shapeA| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeA| the [=list/size=] of |shapeA|.
+    1. Let |shapeB| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeB| the [=list/size=] of |shapeB|.
     1. If |sizeA| and |sizeB| is `1`, return `«  1  »`.
     1. If | sizeA| is `1` and |sizeB| is not, then insert `1` in the front of |shapeA| to become [ 1 | |shapeA| ] and let |sizeA| be `2`.
     1. If | sizeB| is `1` and |sizeA| is not, then insert `1` in the front of |shapeB| to become [ 1 | |shapeB| ] and let |sizeB| be `2`.
@@ -4119,8 +4119,8 @@ partial interface MLGraphBuilder {
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input tensor.
-        - *beginningPadding*: a sequence of {{unsigned long}}. The sequence of unsigned integer values indicating the number of padding values to add at the beginning of each input dimension, of length *N* where *N* is the rank of the input tensor. For each dimension *d* of *input*, *beginningPadding[d]* indicates how many values to add before the content in that dimension.
-        - *endingPadding*: a sequence of {{unsigned long}}. The sequence of unsigned integer values indicating the number of padding values to add at the ending of each input dimension, of length *N* where *N* is the rank of the input tensor. For each dimension *d* of *input*, *endingPadding[d]* indicates how many values to add after the content in that dimension.
+        - *beginningPadding*: a sequence of {{unsigned long}}. The sequence of unsigned integer values indicating the number of padding values to add at the beginning of each input dimension, of length *N* where *N* is the [=rank=] of the input tensor. For each dimension *d* of *input*, *beginningPadding[d]* indicates how many values to add before the content in that dimension.
+        - *endingPadding*: a sequence of {{unsigned long}}. The sequence of unsigned integer values indicating the number of padding values to add at the ending of each input dimension, of length *N* where *N* is the [=rank=] of the input tensor. For each dimension *d* of *input*, *endingPadding[d]* indicates how many values to add after the content in that dimension.
         - *options*: an optional {{MLPadOptions}}. The optional parameters of the operation.
 
     **Returns:** an {{MLOperand}}. The padded output tensor. Each dimension of the output tensor can be calculated as follow:
@@ -4134,7 +4134,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. Let |shape| be a copy of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-    1. For |index| between `0` and the rank of |shape|:
+    1. For |index| between `0` and the [=rank=] of |shape|:
         1. Add to |shape|[|index|] the value of |beginningPadding|[|index|].
         1. Add to |shape|[|index|] the value of |endingPadding|[|index|].
     1. Return |shape|.
@@ -4460,9 +4460,9 @@ partial interface MLGraphBuilder {
     **Arguments:**
         - *input*: an {{MLOperand}}. The input tensor.
         - *options*: an optional {{MLReduceOptions}}. The optional parameters of the operation.
-            - *axes*: a sequence of {{unsigned long}}. The dimensions to reduce. The values in the sequence must be in the range [0, N-1] where N is the rank of input tensor.
+            - *axes*: a sequence of {{unsigned long}}. The dimensions to reduce. The values in the sequence must be in the range [0, N-1] where N is the [=rank=] of the input tensor.
                 If not present, all dimensions are reduced.
-            - *keepDimensions*: a {{boolean}}. If true, retains reduced dimensions with size of 1.
+            - *keepDimensions*: a {{boolean}}. If true, retains reduced dimensions with [=list/size=] 1.
                 The default value is false.
 
     **Returns:** an {{MLOperand}}. The reduced output tensor.
@@ -4692,7 +4692,7 @@ partial interface MLGraphBuilder {
     1. Otherwise, if any of its values is not greater than `0`, return `false`.
     1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], and if its size is not `2`, or if any of its values is not greater than `0`, return `false`.
     1. If |options|.{{MLResample2dOptions/axes}} does not [=map/exists=], set it to `« 2, 3 »`.
-    1. Otherwise, if its value is not one of `« 0, 1], « 1, 2], « 2, 3 »`, return `false`.
+    1. Otherwise, if its value is not one of `« 0, 1», « 1, 2», « 2, 3 »`, return `false`.
     1. Return `true`.
   </div>
 </details>
@@ -4704,8 +4704,8 @@ partial interface MLGraphBuilder {
   <div algorithm=resample-output-sizes class=algorithm-steps>
     1. Let |desc| be an {{MLOperandDescriptor}} initialized to |input|.{{MLOperand/[[descriptor]]}}.
     1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], then set |desc|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} to |options|.{{MLResample2dOptions/sizes}} and return |desc|.
-    1. For |index| between `0` and the rank of |desc|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}:
-        1. Let |inputSize| be the size of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|index|].
+    1. For |index| between `0` and the [=rank=] of |desc|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}:
+        1. Let |inputSize| be the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|index|].
         1. Let |outputSize| be |inputSize| multiplied by |options|.{{MLResample2dOptions/scales}}.
             1. If that fails or |outputSize| is not a positive [=number=], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Set |desc|.{{MLOperandDescriptor/dimensions}}[|index|] to |outputSize|.
@@ -4718,7 +4718,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/resample2d(input, options)}} steps are:
   </summary>
   <div algorithm=resample2d class=algorithm-steps>
-    1. Check if the input is a 4-dimensional tensor: if the size of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Check if the input is a 4-dimensional tensor: if the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If running the <a>check resample options</a> steps given |options| returns `false`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| be the result of running the <a>resample output sizes</a> steps given |options|.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
@@ -4766,7 +4766,7 @@ partial interface MLGraphBuilder {
     1. Let |outputShape| be an empty array of {{unsigned long}}.
     1. If |newShape| is a scalar [=number=], set |outputShape| to `«  1  »`.
     1. Otherwise, if |newShape| is an array of {{unsigned long}}:
-        1. If the size of |newShape| is `0`, set |outputShape| to `«  1  »` (reshaping to scalar).
+        1. If the [=list/size=] of |newShape| is `0`, set |outputShape| to `«  1  »` (reshaping to scalar).
         1. If |newShape| contains more than one `null` value, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If any value in |newShape| is `0`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Let |inputElementCount| be the product of all elements in |inputs|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
@@ -4873,8 +4873,8 @@ partial interface MLGraphBuilder {
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input tensor.
-        - *starts*: a sequence of {{unsigned long}}. The sequence of unsigned integer values indicating the starting index to slice of each input dimension, of length N where N is the rank of the input tensor. For each dimension *d* of *input*, *starts[d]* indicates the starting index to slice in that dimension. The starting index must be in the range [0, input size - 1] in that dimension.
-        - *sizes*: a sequence of {{unsigned long}}. The sequence of unsigned integer values indicating the number of elements to slice of each input dimension, of length N where N is the rank of the input tensor. For each dimension *d* of *input*, *sizes[d]* indicates the number of elements to slice in that dimension. The size must not be 0 and must satisfy the constraint *starting index + size <= input size* in that dimension.
+        - *starts*: a sequence of {{unsigned long}}. The sequence of unsigned integer values indicating the starting index to slice of each input dimension, of length N where N is the [=rank=] of the input tensor. For each dimension *d* of *input*, *starts[d]* indicates the starting index to slice in that dimension. The starting index must be in the range [0, input size - 1] in that dimension.
+        - *sizes*: a sequence of {{unsigned long}}. The sequence of unsigned integer values indicating the number of elements to slice of each input dimension, of length N where N is the [=rank=] of the input tensor. For each dimension *d* of *input*, *sizes[d]* indicates the number of elements to slice in that dimension. The size must not be 0 and must satisfy the constraint *starting index + size <= input size* in that dimension.
 
     **Returns:** an {{MLOperand}}. The output tensor of the same rank as the input tensor with tensor values stripped to the specified starting and ending indices in each dimension.
 </div>
@@ -5167,7 +5167,7 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLSplitOptions>
     : <dfn>axis</dfn>
     ::
-        An {{unsigned long}} scalar. The dimension along which to split. Its value must be in the range [0, N-1] where N is the rank of input tensor.
+        An {{unsigned long}} scalar. The dimension along which to split. Its value must be in the range [0, N-1] where N is the [=rank=] of the input tensor.
         The default value is `0`.
 </dl>
 
@@ -5217,7 +5217,7 @@ partial interface MLGraphBuilder {
 </div>
 
 ### The squeeze() method ### {#api-mlgraphbuilder-squeeze}
-Reduce the rank of a tensor by eliminating dimensions with size 1 of the tensor shape. Squeeze only affects the tensor's logical dimensions. It does not copy or change the content in the tensor.
+Reduce the [=rank=] of a tensor by eliminating dimensions with size 1 of the tensor shape. Squeeze only affects the tensor's logical dimensions. It does not copy or change the content in the tensor.
 <script type=idl>
 dictionary MLSqueezeOptions {
   sequence<unsigned long> axes;
@@ -5241,7 +5241,7 @@ partial interface MLGraphBuilder {
     : <dfn>axes</dfn>
     ::
         A sequence of {{unsigned long}}.
-        Specifies the indices to the shape dimensions of size 1 to eliminate. The values in the sequence must be in the range [0, N-1] where N is the rank of input tensor.
+        Specifies the indices to the shape dimensions of size 1 to eliminate. The values in the sequence must be in the range [0, N-1] where N is the [=rank=] of the input tensor.
         When not specified, every shape dimensions of size 1 in the tensor are eliminated.
 </dl>
 
@@ -5253,7 +5253,7 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |options|.{{MLSqueezeOptions/axes}} [=map/exists=], then:
         1. Let |dimensions| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-        1. For |index| between 0 and the size of |options|.{{MLSqueezeOptions/axes}}:
+        1. For |index| between 0 and the [=list/size=] of |options|.{{MLSqueezeOptions/axes}}:
             1. Let |oneDimIndex| be |options|.{{MLSqueezeOptions/axes}}[|index|].
             1. If |dimensions|[|oneDimIndex|] is not `1`, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -5368,8 +5368,8 @@ partial interface MLGraphBuilder {
     ::
         A sequence of {{unsigned long}} values.
         Specifies the values used to permute the output shape.
-        The default value is [N-1, ..., 0], where N is the rank of the input tensor, e.g. [2,1,0] for a 3-D tensor.
-        These default values cause the output to become a transposed tensor of the input. When specified, the number of values in the sequence must be the same as the rank of the input tensor, and the values in the sequence must be within the range from 0 to N-1 with no two or more same values found in the sequence.
+        The default value is [N-1, ..., 0], where N is the [=rank=] of the input tensor, e.g. [2,1,0] for a 3-D tensor.
+        These default values cause the output to become a transposed tensor of the input. When specified, the number of values in the sequence must be the same as the [=rank=] of the input tensor, and the values in the sequence must be within the range from 0 to N-1 with no two or more same values found in the sequence.
 </dl>
 
 <details open>
@@ -5381,8 +5381,8 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLTransposeOptions/permutation}} does not [=map/exist=], let |options|.{{MLTransposeOptions/permutation}} be the reversed sequence of all indices for |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Otherwise if |options|.{{MLTransposeOptions/permutation}} [=map/exists=]:
         1. If |options|.{{MLTransposeOptions/permutation}} is not a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}}.
-        1. If the rank of |options|.{{MLTransposeOptions/permutation}} is not the same as the rank of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a {{TypeError}}.
-        1. If the values in |options|.{{MLTransposeOptions/permutation}} are not between `0` and the rank of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} minus `1`, then [=exception/throw=] a {{TypeError}}.
+        1. If the [=rank=] of |options|.{{MLTransposeOptions/permutation}} is not the same as the [=rank=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a {{TypeError}}.
+        1. If the values in |options|.{{MLTransposeOptions/permutation}} are not between `0` and the [=rank=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} minus `1`, then [=exception/throw=] a {{TypeError}}.
         1. If the values in |options|.{{MLTransposeOptions/permutation}} contain duplicate value, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.

--- a/index.bs
+++ b/index.bs
@@ -2081,19 +2081,19 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLConv2dOptions>
     : <dfn>padding</dfn>
     ::
-        A sequence of {{unsigned long}} of length 4: [beginning_height, ending_height, beginning_width, ending_width].
+        A sequence of {{unsigned long}} of length 4: [beginningHeight, endingHeight, beginningWidth, endingWidth].
         Specifies the additional rows and columns added to the beginning and ending of each spatial dimension of the convolution input.
         The default value is [0, 0, 0, 0].
 
     : <dfn>strides</dfn>
     ::
-        A sequence of {{unsigned long}} of length 2: [stride_height, stride_width].
+        A sequence of {{unsigned long}} of length 2: [strideHeight, strideWidth].
         Specifies the stride of the sliding window for each spatial dimension of the convolution input.
         The default value is [1, 1].
 
     : <dfn>dilations</dfn>
     ::
-        A sequence of {{unsigned long}} of length 2: [dilation_height, dilation_width]. Specifies the dilation factor for each spatial dimension applied on the convolution filter (kernel).
+        A sequence of {{unsigned long}} of length 2: [dilationHeight, dilationWidth]. Specifies the dilation factor for each spatial dimension applied on the convolution filter (kernel).
         The default value is [1, 1].
 
     : <dfn>autoPad</dfn>
@@ -2118,27 +2118,27 @@ partial interface MLGraphBuilder {
         An {{MLInputOperandLayout}} [=string=].
         Specifies the layout format of the input and output tensor as follows:
             - **"nchw"**
-                - input tensor: *[batches, input_channels, height, width]*
-                - output tensor: *[batches, output_channels, height, width]*
+                - input tensor: *[batches, inputChannels, height, width]*
+                - output tensor: *[batches, outputChannels, height, width]*
             - **"nhwc"**:
-                - input tensor: *[batches, height, width, input_channels]*
-                - output tensor: *[batches, height, width, output_channels]*
+                - input tensor: *[batches, height, width, inputChannels]*
+                - output tensor: *[batches, height, width, outputChannels]*
         The default value is *"nchw"*.
 
     : <dfn>filterLayout</dfn>
     ::
           An {{MLConv2dFilterOperandLayout}} [=string=].
           Specifies the layout format of the filter tensor as follow:
-              - **"oihw"**: *[output_channels, input_channels/groups, height, width]*
-              - **"hwio"**: *[height, width, input_channels/groups, output_channels]*
-              - **"ohwi"**: *[output_channels, height, width, input_channels/groups]*
-              - **"ihwo"**: *[input_channels/groups, height, width, output_channels]*
+              - **"oihw"**: *[outputChannels, inputChannels/groups, height, width]*
+              - **"hwio"**: *[height, width, inputChannels/groups, outputChannels]*
+              - **"ohwi"**: *[outputChannels, height, width, inputChannels/groups]*
+              - **"ihwo"**: *[inputChannels/groups, height, width, outputChannels]*
           The default value is *"oihw"*.
 
     : <dfn>bias</dfn>
     ::
           An {{MLOperand}} object.
-          Specifies the additional 1-D tensor with the shape of *[output_channels]* whose values are to be added to the convolution result.
+          Specifies the additional 1-D tensor with the shape of *[outputChannels]* whose values are to be added to the convolution result.
 
     : <dfn>activation</dfn>
     ::
@@ -2156,11 +2156,11 @@ partial interface MLGraphBuilder {
 
     **Returns:** an {{MLOperand}}. The output 4-D tensor that contains the convolution result. The output shape is interpreted according to the *options*.{{MLConv2dOptions/inputLayout}} value. More specifically, the spatial dimensions or the sizes of the last two dimensions of the output tensor for the *nchw* input layout can be calculated as follow:
 
-    *output_size = 1 + (input_size - (filter_size - 1) ** *dilation - 1 + beginning_padding + ending_padding) / stride*
+    *outputSize = 1 + (inputSize - (filterSize - 1) ** *dilation - 1 + beginningPadding + endingPadding) / stride*
 </div>
 
 <div class="note">
-    A *depthwise* conv2d operation is a variant of grouped convolution, used in models like the MobileNet, where the *options.groups* = input_channels = output_channels and the shape of filter tensor is [options.groups, 1, height, width]
+    A *depthwise* conv2d operation is a variant of grouped convolution, used in models like the MobileNet, where the *options.groups* = inputChannels = outputChannels and the shape of filter tensor is [options.groups, 1, height, width]
     for *"oihw"* layout, [height, width, 1, options.groups] for *"hwio"* layout, [options.groups, height, width, 1] for *"ohwi"* layout and [1, height, width, options.groups] for *"ihwo"* layout.
 </div>
 
@@ -2171,10 +2171,10 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| and |filter| is {{MLOperand}}.
-    1. Let |input_size| be the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-    1. Let |filter_size| be the [=list/size=] of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-    1. If |input_size| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |filter_size| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Let |inputSize| be the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+    1. Let |filterSize| be the [=list/size=] of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+    1. If |inputSize| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |filterSize| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/padding}} does not [=map/exist=], set it to `« 0, 0, 0, 0 »`.
     1. Else if the [=list/size=] of |options|.{{MLConv2dOptions/padding}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -2185,19 +2185,19 @@ partial interface MLGraphBuilder {
     1. Else if the [=list/size=] of |options|.{{MLConv2dOptions/dilations}} is not `2`, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/autoPad}} does not [=map/exist=], set it to `"explicit"`.
     1. If |options|.{{MLConv2dOptions/groups}} is 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |input_size| / |options|.{{MLConv2dOptions/groups}} is not equal to |filter_size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. Else if |input_size| % |options|.{{MLConv2dOptions/groups}} is not 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |inputSize| / |options|.{{MLConv2dOptions/groups}} is not equal to |filterSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Else if |inputSize| % |options|.{{MLConv2dOptions/groups}} is not 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConv2dOptions/bias}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConv2dOptions/bias}} is {{MLOperand}}.
     1. If the [=list/size=] of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/activation}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConv2dOptions/activation}} is {{MLActivation}}.
-    1. Let |output_shape| be the result of invoking the underlying implementation for calculating output dimensions, given |options|.
-    1. If |output_shape| is not the same as the shape of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Let |outputShape| be the result of invoking the underlying implementation for calculating output dimensions, given |options|.
+    1. If |outputShape| is not the same as the shape of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
-    1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |output_shape|.
+    1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |outputShape|.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
@@ -2246,19 +2246,19 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLConvTranspose2dOptions>
     : <dfn>padding</dfn>
     ::
-        A sequence of {{unsigned long}} of length 4: [beginning_height, ending_height, beginning_width, ending_width].
+        A sequence of {{unsigned long}} of length 4: [beginningHeight, endingHeight, beginningWidth, endingWidth].
         Specifies the additional rows and columns added to the beginning and ending of each spatial dimension of the convolution input.
         The default value is [0, 0, 0, 0].
 
     : <dfn>strides</dfn>
     ::
-        A sequence of {{unsigned long}} of length 2: [stride_height, stride_width].
+        A sequence of {{unsigned long}} of length 2: [strideHeight, strideWidth].
         Specifies the stride of the sliding window for each spatial dimension of the convolution input.
         The default value is [1, 1].
 
     : <dfn>dilations</dfn>
     ::
-        A sequence of {{unsigned long}} of length 2: [dilation_height, dilation_width]. Specifies the dilation factor for each spatial dimension applied on the convolution filter (kernel).
+        A sequence of {{unsigned long}} of length 2: [dilationHeight, dilationWidth]. Specifies the dilation factor for each spatial dimension applied on the convolution filter (kernel).
         The default value is [1, 1].
 
     : <dfn>outputPadding</dfn>
@@ -2300,26 +2300,26 @@ partial interface MLGraphBuilder {
         An {{MLInputOperandLayout}} [=string=].
         Specifies the layout format of the input and output tensor as follows:
             - **"nchw"**
-                - input tensor: *[batches, input_channels, height, width]*
-                - output tensor: *[batches, output_channels, height, width]*
+                - input tensor: *[batches, inputChannels, height, width]*
+                - output tensor: *[batches, outputChannels, height, width]*
             - **"nhwc"**:
-                - input tensor: *[batches, height, width, input_channels]*
-                - output tensor: *[batches, height, width, output_channels]*
+                - input tensor: *[batches, height, width, inputChannels]*
+                - output tensor: *[batches, height, width, outputChannels]*
         The default value is *"nchw"*.
 
     : <dfn>filterLayout</dfn>
     ::
         An {{MLConvTranspose2dFilterOperandLayout}} [=string=].
         Specifies the layout format of the filter tensor as follow:
-            - **"iohw"**: [input_channels, output_channels/groups, height, width]
-            - **"hwoi"**: [height, width, output_channels/groups, input_channels]
-            - **"ohwi"**: [output_channels/groups, height, width, input_channels]
+            - **"iohw"**: [inputChannels, outputChannels/groups, height, width]
+            - **"hwoi"**: [height, width, outputChannels/groups, inputChannels]
+            - **"ohwi"**: [outputChannels/groups, height, width, inputChannels]
         The default value is *"iohw"*.
 
     : <dfn>bias</dfn>
     ::
         An {{MLOperand}} object.
-        Specifies the additional 1-D tensor with the shape of *[output_channels]* whose values are to be added to the convolution result.
+        Specifies the additional 1-D tensor with the shape of *[outputChannels]* whose values are to be added to the convolution result.
 
     : <dfn>activation</dfn>
     ::
@@ -2337,7 +2337,7 @@ partial interface MLGraphBuilder {
 
     **Returns:** an {{MLOperand}}. The output 4-D tensor that contains the transposed convolution result. The output shape is interpreted according to the *options*.{{MLConvTranspose2dOptions/inputLayout}} value. More specifically, unless the *options*.{{MLConvTranspose2dOptions/outputSizes}} values are explicitly specified, the *options*.{{MLConvTranspose2dOptions/outputPadding}} may be needed to compute the spatial dimension values of the output tensor as follow:
 
-    *output_size = (input_size - 1) ** *stride + (filter_size - 1) ** *dilation + 1 - beginning_padding - ending_padding + output_padding*
+    *outputSize = (inputSize - 1) ** *stride + (filterSize - 1) ** *dilation + 1 - beginningPadding - endingPadding + outputPadding*
 </div>
 
 <details open algorithm>
@@ -2347,10 +2347,10 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| and |filter| is {{MLOperand}}.
-    1. Let |input_size| be the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-    1. Let |filter_size| be the [=list/size=] of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-    1. If |input_size| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |filter_size| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Let |inputSize| be the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+    1. Let |filterSize| be the [=list/size=] of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+    1. If |inputSize| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |filterSize| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/padding}} does not [=map/exist=], set it to `« 0, 0, 0, 0 »`.
     1. Else if the [=list/size=] of |options|.{{MLConvTranspose2dOptions/padding}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -2364,19 +2364,19 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLConvTranspose2dOptions/outputSizes}} [=map/exists=]:
         1. If the [=list/size=] of |options|.{{MLConvTranspose2dOptions/outputSizes}} is not `2`, then [=exception/throw=] a {{TypeError}}.
         1. If the elements of |options|.{{MLConvTranspose2dOptions/outputSizes}} are not smaller than the elements at the same dimension (index) for |options|.{{MLConvTranspose2dOptions/strides}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |input_size| / |options|.{{MLConvTranspose2dOptions/groups}} is not equal to |filter_size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. Else if |input_size| % |options|.{{MLConvTranspose2dOptions/groups}} is not 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |inputSize| / |options|.{{MLConvTranspose2dOptions/groups}} is not equal to |filterSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Else if |inputSize| % |options|.{{MLConvTranspose2dOptions/groups}} is not 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConvTranspose2dOptions/bias}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConvTranspose2dOptions/bias}} is {{MLOperand}}.
     1. If the [=list/size=] of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/activation}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConvTranspose2dOptions/activation}} is {{MLActivation}}.
-    1. Let |output_shape| be the result of invoking the underlying implementation for calculating output dimensions, given |options|.
-    1. If |output_shape| is not the same as the shape of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Let |outputShape| be the result of invoking the underlying implementation for calculating output dimensions, given |options|.
+    1. If |outputShape| is not the same as the shape of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
-    1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |output_shape|.
+    1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |outputShape|.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
@@ -2877,15 +2877,15 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLGruOptions>
     : <dfn>bias</dfn>
     ::
-        An {{MLOperand}}. Specifies the 2-D input bias tensor of shape [num_directions, 3 * hidden_size]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to the {{MLGruOptions/layout}} argument.
+        An {{MLOperand}}. Specifies the 2-D input bias tensor of shape [numDirections, 3 * hiddenSize]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to the {{MLGruOptions/layout}} argument.
 
     : <dfn>recurrentBias</dfn>
     ::
-        An {{MLOperand}}. Specifies the 2-D recurrent bias tensor of shape [num_directions, 3 * hidden_size]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to the {{MLGruOptions/layout}} argument.
+        An {{MLOperand}}. Specifies the 2-D recurrent bias tensor of shape [numDirections, 3 * hiddenSize]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to the {{MLGruOptions/layout}} argument.
 
     : <dfn>initialHiddenState</dfn>
     ::
-        An {{MLOperand}}. The 3-D initial hidden state tensor of shape [num_directions, batch_size, hidden_size].
+        An {{MLOperand}}. The 3-D initial hidden state tensor of shape [numDirections, batchSize, hiddenSize].
         When not specified, implementations SHOULD use a tensor filled with zero.
 
     : <dfn>resetAfter</dfn>
@@ -2912,14 +2912,14 @@ partial interface MLGraphBuilder {
 
 <div>
     **Arguments:**
-        - *input*: an {{MLOperand}}. The input 3-D tensor of shape [steps, batch_size, input_size].
-        - *weight*: an {{MLOperand}}. The 3-D input weight tensor of shape [num_directions, 3 * hidden_size, input_size]. The ordering of the weight vectors in the second dimension of the tensor shape is specified according to the |options|.{{MLGruOptions/layout}} argument.
-        - *recurrentWeight*: an {{MLOperand}}. The 3-D recurrent weight tensor of shape [num_directions, 3 * hidden_size, hidden_size]. The ordering of the weight vectors in the second dimension of the tensor shape is specified according to the |options|.{{MLGruOptions/layout}} argument.
+        - *input*: an {{MLOperand}}. The input 3-D tensor of shape [steps, batchSize, inputSize].
+        - *weight*: an {{MLOperand}}. The 3-D input weight tensor of shape [numDirections, 3 * hiddenSize, inputSize]. The ordering of the weight vectors in the second dimension of the tensor shape is specified according to the |options|.{{MLGruOptions/layout}} argument.
+        - *recurrentWeight*: an {{MLOperand}}. The 3-D recurrent weight tensor of shape [numDirections, 3 * hiddenSize, hiddenSize]. The ordering of the weight vectors in the second dimension of the tensor shape is specified according to the |options|.{{MLGruOptions/layout}} argument.
         - *steps*: an {{unsigned long}} scalar. The number of time steps in the recurrent network. The value must be greater than 0.
         - *hiddenSize*: an {{unsigned long}} scalar. The value of the third dimension of the cell output tensor shape. It indicates the number of features in the hidden state.
         - *options*: an optional {{MLGruOptions}}. The optional parameters of the operation.
 
-    **Returns:** a sequence of {{MLOperand}}. The first element of the sequence is a 3-D tensor of shape [num_directions, batch_size, hidden_size], the cell output from the last time step of the network. Additionally, if |options|.{{MLGruOptions/returnSequence}} is set to `true`, the second element is the 4-D output tensor of shape [steps, num_directions, batch_size, hidden_size] containing every cell outputs from each time step in the temporal sequence.
+    **Returns:** a sequence of {{MLOperand}}. The first element of the sequence is a 3-D tensor of shape [numDirections, batchSize, hiddenSize], the cell output from the last time step of the network. Additionally, if |options|.{{MLGruOptions/returnSequence}} is set to `true`, the second element is the 4-D output tensor of shape [steps, numDirections, batchSize, hiddenSize] containing every cell outputs from each time step in the temporal sequence.
 </div>
 
 <details open algorithm>
@@ -2976,11 +2976,11 @@ partial interface MLGraphBuilder {
     let currentRecurrentBias = [];
 
     for (let dir = 0; dir < numDirections; ++dir) {
-      currentWeight.push(builder.squeeze(builder.slice(weight, [dir, 0, 0], [1, 3 * hidden_size, input_size]), { axes: [0] }));
-      currentRecurrentWeight.push(builder.squeeze(builder.slice(recurrentWeight, [dir, 0, 0], [1, 3 * hidden_size, hidden_size]), { axes: [0] }));
-      currentBias.push(options.bias ? (builder.squeeze(builder.slice(options.bias, [dir, 0], [1, 3 * hidden_size]), { axes: [0] })) : null);
+      currentWeight.push(builder.squeeze(builder.slice(weight, [dir, 0, 0], [1, 3 * hiddenSize, inputSize]), { axes: [0] }));
+      currentRecurrentWeight.push(builder.squeeze(builder.slice(recurrentWeight, [dir, 0, 0], [1, 3 * hiddenSize, hiddenSize]), { axes: [0] }));
+      currentBias.push(options.bias ? (builder.squeeze(builder.slice(options.bias, [dir, 0], [1, 3 * hiddenSize]), { axes: [0] })) : null);
       currentRecurrentBias.push(options.recurrentBias ?
-        (builder.squeeze(builder.slice(options.recurrentBias, [dir, 0], [1, 3 * hidden_size]), { axes: [0] })) : null);
+        (builder.squeeze(builder.slice(options.recurrentBias, [dir, 0], [1, 3 * hiddenSize]), { axes: [0] })) : null);
     }
 
     for (let step = 0; step < steps; ++step) {
@@ -2988,12 +2988,12 @@ partial interface MLGraphBuilder {
       let currentOutput = null;
 
       for (let dir = 0; dir < numDirections; ++dir) {
-        currentHidden.push(builder.squeeze(builder.slice(hiddenState, [dir, 0, 0], [1, batch_size, hidden_size]), { axes: [0] }));
+        currentHidden.push(builder.squeeze(builder.slice(hiddenState, [dir, 0, 0], [1, batchSize, hiddenSize]), { axes: [0] }));
       }
 
       for (let dir = 0; dir < numDirections; ++dir) {
         let slice = (dir == 1 || options.direction == "backward" ? steps - step - 1 : step);
-        let currentInput = builder.squeeze(builder.slice(input, [slice, 0, 0], [1, batch_size, input_size]), { axes: [0] });
+        let currentInput = builder.squeeze(builder.slice(input, [slice, 0, 0], [1, batchSize, inputSize]), { axes: [0] });
 
         let result = builder.reshape(
           builder.gruCell(
@@ -3042,11 +3042,11 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLGruCellOptions>
     : <dfn>bias</dfn>
     ::
-        An {{MLOperand}}. Specifies the 1-D input bias tensor of shape [3 * hidden_size]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to the {{MLGruOptions/layout}} argument.
+        An {{MLOperand}}. Specifies the 1-D input bias tensor of shape [3 * hiddenSize]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to the {{MLGruOptions/layout}} argument.
 
     : <dfn>recurrentBias</dfn>
     ::
-        An {{MLOperand}}. Specifies the 1-D recurrent bias tensor of shape [3 * hidden_size]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to the {{MLGruOptions/layout}} argument.
+        An {{MLOperand}}. Specifies the 1-D recurrent bias tensor of shape [3 * hiddenSize]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to the {{MLGruOptions/layout}} argument.
 
     : <dfn>resetAfter</dfn>
     ::
@@ -3063,14 +3063,14 @@ partial interface MLGraphBuilder {
 
 <div>
     **Arguments:**
-        - *input*: an {{MLOperand}}. The input 2-D tensor of shape [batch_size, input_size].
-        - *weight*: an {{MLOperand}}. The 2-D input weight tensor of shape [3 * hidden_size, input_size]. The ordering of the weight vectors in the first dimension of the tensor shape is specified according to the *options.layout* argument.
-        - *recurrentWeight*: an {{MLOperand}}. The 2-D recurrent weight tensor of shape [3 * hidden_size, hidden_size]. The ordering of the weight vectors in the first dimension of the tensor shape is specified according to the *options.layout* argument.
-        - *hiddenState*: an {{MLOperand}}. The 2-D input hidden state tensor of shape [batch_size, hidden_size].
+        - *input*: an {{MLOperand}}. The input 2-D tensor of shape [batchSize, inputSize].
+        - *weight*: an {{MLOperand}}. The 2-D input weight tensor of shape [3 * hiddenSize, inputSize]. The ordering of the weight vectors in the first dimension of the tensor shape is specified according to the *options.layout* argument.
+        - *recurrentWeight*: an {{MLOperand}}. The 2-D recurrent weight tensor of shape [3 * hiddenSize, hiddenSize]. The ordering of the weight vectors in the first dimension of the tensor shape is specified according to the *options.layout* argument.
+        - *hiddenState*: an {{MLOperand}}. The 2-D input hidden state tensor of shape [batchSize, hiddenSize].
         - *hiddenSize*: an {{unsigned long}} scalar. The value of the second dimension of the output tensor shape. It indicates the number of features in the hidden state.
         - *options*: an optional {{MLGruCellOptions}}. The optional parameters of the operation.
 
-    **Returns:** an {{MLOperand}}. The 2-D tensor of shape [batch_size, hidden_size], the cell output hidden state of a single time step of the recurrent network.
+    **Returns:** an {{MLOperand}}. The 2-D tensor of shape [batchSize, hiddenSize], the cell output hidden state of a single time step of the recurrent network.
 </div>
 
 <details open algorithm>
@@ -3125,11 +3125,11 @@ partial interface MLGraphBuilder {
         builder.add(
           builder.matmul(
             input,
-            builder.transpose(builder.slice(weight, [0, 0], [hiddenSize, input_size]))
+            builder.transpose(builder.slice(weight, [0, 0], [hiddenSize, inputSize]))
             ),
           builder.matmul(
             hiddenState,
-            builder.transpose(builder.slice(recurrentWeight, [0, 0], [hiddenSize, hidden_size]))
+            builder.transpose(builder.slice(recurrentWeight, [0, 0], [hiddenSize, hiddenSize]))
             )
           )
         )
@@ -3145,11 +3145,11 @@ partial interface MLGraphBuilder {
         builder.add(
           builder.matmul(
             input,
-            builder.transpose(builder.slice(weight, [hiddenSize, 0], [hiddenSize, input_size]))
+            builder.transpose(builder.slice(weight, [hiddenSize, 0], [hiddenSize, inputSize]))
             ),
           builder.matmul(
             hiddenState,
-            builder.transpose(builder.slice(recurrentWeight, [hiddenSize, 0], [hiddenSize, hidden_size]))
+            builder.transpose(builder.slice(recurrentWeight, [hiddenSize, 0], [hiddenSize, hiddenSize]))
             )
           )
         )
@@ -3164,7 +3164,7 @@ partial interface MLGraphBuilder {
           builder.add(
             builder.matmul(
               input,
-              builder.transpose(builder.slice(weight, [2 * hiddenSize, 0], [hiddenSize, input_size]))
+              builder.transpose(builder.slice(weight, [2 * hiddenSize, 0], [hiddenSize, inputSize]))
               ),
             builder.mul(
               r,
@@ -3172,7 +3172,7 @@ partial interface MLGraphBuilder {
                 (options.recurrentBias ? builder.slice(options.recurrentBias, [2 * hiddenSize], [hiddenSize]) : zero),
                 builder.matmul(
                   hiddenState,
-                  builder.transpose(builder.slice(recurrentWeight, [2 * hiddenSize, 0], [hiddenSize, hidden_size]))
+                  builder.transpose(builder.slice(recurrentWeight, [2 * hiddenSize, 0], [hiddenSize, hiddenSize]))
                   )
                 )
               )
@@ -3190,11 +3190,11 @@ partial interface MLGraphBuilder {
           builder.add(
             builder.matmul(
               input,
-              builder.transpose(builder.slice(weight, [2 * hiddenSize, 0], [hiddenSize, input_size]))
+              builder.transpose(builder.slice(weight, [2 * hiddenSize, 0], [hiddenSize, inputSize]))
               ),
             builder.matmul(
               builder.mul(r, hiddenState),
-              builder.transpose(builder.slice(recurrentWeight, [2 * hiddenSize, 0], [hiddenSize, hidden_size]))
+              builder.transpose(builder.slice(recurrentWeight, [2 * hiddenSize, 0], [hiddenSize, hiddenSize]))
               )
             )
           )
@@ -3705,23 +3705,23 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLLstmOptions>
     : <dfn>bias</dfn>
     ::
-        An {{MLOperand}}. Specifies the 2-D input bias tensor of shape [num_directions, 4 * hidden_size]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to {{MLLstmOptions/layout}}.
+        An {{MLOperand}}. Specifies the 2-D input bias tensor of shape [numDirections, 4 * hiddenSize]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to {{MLLstmOptions/layout}}.
 
     : <dfn>recurrentBias</dfn>
     ::
-        An {{MLOperand}}. Specifies the 2-D recurrent bias tensor of shape [num_directions, 4 * hidden_size]. The ordering of the bias vectors in the first dimension of the tensor shape is specified according to {{MLLstmOptions/layout}}.
+        An {{MLOperand}}. Specifies the 2-D recurrent bias tensor of shape [numDirections, 4 * hiddenSize]. The ordering of the bias vectors in the first dimension of the tensor shape is specified according to {{MLLstmOptions/layout}}.
 
     : <dfn>peepholeWeight</dfn>
     ::
-        An {{MLOperand}}. Specifies the 2-D weight tensor for peepholes of shape [num_directions, 3 * hidden_size]. The pack ordering of the weight vectors is for the `input (i)`, `output (o)`, and `forget (f)` gate, respectively.
+        An {{MLOperand}}. Specifies the 2-D weight tensor for peepholes of shape [numDirections, 3 * hiddenSize]. The pack ordering of the weight vectors is for the `input (i)`, `output (o)`, and `forget (f)` gate, respectively.
 
     : <dfn>initialHiddenState</dfn>
     ::
-        An {{MLOperand}}. Specifies the 3-D initial hidden state tensor of shape [num_directions, batch_size, hidden_size]. When not specified, implementations SHOULD use a tensor filled with zero.
+        An {{MLOperand}}. Specifies the 3-D initial hidden state tensor of shape [numDirections, batchSize, hiddenSize]. When not specified, implementations SHOULD use a tensor filled with zero.
 
     : <dfn>initialCellState</dfn>
     ::
-        An {{MLOperand}}. Specifies the 3-D initial hidden state tensor of shape [num_directions, batch_size, hidden_size]. When not specified, implementations SHOULD use a tensor filled with zero.
+        An {{MLOperand}}. Specifies the 3-D initial hidden state tensor of shape [numDirections, batchSize, hiddenSize]. When not specified, implementations SHOULD use a tensor filled with zero.
 
     : <dfn>returnSequence</dfn>
     ::
@@ -3742,14 +3742,14 @@ partial interface MLGraphBuilder {
 
 <div>
     **Arguments:**
-        - *input*: an {{MLOperand}}. The input 3-D tensor of shape [steps, batch_size, input_size].
-        - *weight*: an {{MLOperand}}. The 3-D input weight tensor of shape [num_directions, 4 * hidden_size, input_size]. The ordering of the weight vectors in the second dimension of the tensor shape is specified according to the |options|.{{MLLstmOptions/layout}}.
-        - *recurrentWeight*: an {{MLOperand}}. The 3-D recurrent weight tensor of shape [num_directions, 4 * hidden_size, hidden_size]. The ordering of the weight vectors in the second dimension of the tensor shape is specified according to the |options|.{{MLLstmOptions/layout}} argument.
+        - *input*: an {{MLOperand}}. The input 3-D tensor of shape [steps, batchSize, inputSize].
+        - *weight*: an {{MLOperand}}. The 3-D input weight tensor of shape [numDirections, 4 * hiddenSize, inputSize]. The ordering of the weight vectors in the second dimension of the tensor shape is specified according to the |options|.{{MLLstmOptions/layout}}.
+        - *recurrentWeight*: an {{MLOperand}}. The 3-D recurrent weight tensor of shape [numDirections, 4 * hiddenSize, hiddenSize]. The ordering of the weight vectors in the second dimension of the tensor shape is specified according to the |options|.{{MLLstmOptions/layout}} argument.
         - *steps*: an {{unsigned long}} scalar. The number of time steps in the recurrent network. The value must be greater than 0.
         - *hiddenSize*: an {{unsigned long}} scalar. The value of the third dimension of the cell output tensor shape. It indicates the number of features in the hidden state.
         - *options*: an optional {{MLLstmOptions}}. The optional parameters of the operation.
 
-    **Returns:** a sequence of {{MLOperand}}. The first element of the sequence is a 3-D tensor of shape [num_directions, batch_size, hidden_size], the output hidden state from the last time step of the network. The second element is a 3-D tensor of shape [num_directions, batch_size, hidden_size], the output cell state from the last time step of the network. Additionally, if |options|.{{MLLstmOptions/returnSequence}} is set to true, the third element is the 4-D output tensor of shape [steps, num_directions, batch_size, hidden_size] containing every output from each time step in the temporal sequence.
+    **Returns:** a sequence of {{MLOperand}}. The first element of the sequence is a 3-D tensor of shape [numDirections, batchSize, hiddenSize], the output hidden state from the last time step of the network. The second element is a 3-D tensor of shape [numDirections, batchSize, hiddenSize], the output cell state from the last time step of the network. Additionally, if |options|.{{MLLstmOptions/returnSequence}} is set to true, the third element is the 4-D output tensor of shape [steps, numDirections, batchSize, hiddenSize] containing every output from each time step in the temporal sequence.
 </div>
 
 <details open algorithm>
@@ -3759,39 +3759,39 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. If |options|.{{MLLstmOptions/direction}} is not one of {{MLRecurrentNetworkDirection}}, then [=exception/throw=] a {{TypeError}}.
-    1. Let |num_directions| be `1` if |options|.{{MLLstmOptions/direction}} is `"forward"`, or otherwise let it be `2`.
+    1. Let |numDirections| be `1` if |options|.{{MLLstmOptions/direction}} is `"forward"`, or otherwise let it be `2`.
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
         <div class="note">
             The shape of |input|, |weight| or |recurrentWeight| could be also checked here.
         </div>
     1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not equal to |steps|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. Let |batch_size| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1].
+    1. Let |batchSize| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1].
     1. If |options|.{{MLLstmOptions/bias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. If |options|.{{MLLstmOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |numDirections|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not 4 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmOptions/recurrentBias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. If |options|.{{MLLstmOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |numDirections|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not 4 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmOptions/peepholeWeight}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. If |options|.{{MLLstmOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |numDirections|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not 4 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmOptions/initialHiddenState}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. If |options|.{{MLLstmOptions/initialHiddenState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. If |options|.{{MLLstmOptions/initialHiddenState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to |batch_size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/initialHiddenState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |numDirections|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/initialHiddenState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to |batchSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/initialHiddenState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[2] is not |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmOptions/initialCellState}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to |batch_size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |numDirections|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to |batchSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[2] is not |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmOptions/layout}} is not one of {{MLLstmWeightLayout}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLLstmOptions/activations}} [=map/exists=]:
@@ -3799,11 +3799,11 @@ partial interface MLGraphBuilder {
         1. [=Assert=]: the type of its elements is {{MLActivation}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |desc| a new {{MLOperandDescriptor}}.
-        1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |num_directions|, |batch_size|, |hiddenSize| ].
+        1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |numDirections|, |batchSize|, |hiddenSize| ].
         1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
         1. Let |output0| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Let |output1| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
-        1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |steps|, |num_directions|, |batch_size|, |hiddenSize| ].
+        1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |steps|, |numDirections|, |batchSize|, |hiddenSize| ].
         1. If |options|.{{MLLstmOptions/returnSequence}} is set to true:
             1. Let |output2| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
             1. Let |output| be the array [ |output0|, |output1|, |output2| ].
@@ -3849,13 +3849,13 @@ partial interface MLGraphBuilder {
     let currentPeepholeWeight = [];
 
     for (let dir = 0; dir < numDirections; ++dir) {
-      currentWeight.push(builder.squeeze(builder.slice(weight, [dir, 0, 0], [1, 4 * hidden_size, input_size]), { axes: [0] }));
-      currentRecurrentWeight.push(builder.squeeze(builder.slice(recurrentWeight, [dir, 0, 0], [1, 4 * hidden_size, hidden_size]), { axes: [0] }));
-      currentBias.push(options.bias ? (builder.squeeze(builder.slice(options.bias, [dir, 0], [1, 4 * hidden_size]), { axes: [0] })) : null);
+      currentWeight.push(builder.squeeze(builder.slice(weight, [dir, 0, 0], [1, 4 * hiddenSize, inputSize]), { axes: [0] }));
+      currentRecurrentWeight.push(builder.squeeze(builder.slice(recurrentWeight, [dir, 0, 0], [1, 4 * hiddenSize, hiddenSize]), { axes: [0] }));
+      currentBias.push(options.bias ? (builder.squeeze(builder.slice(options.bias, [dir, 0], [1, 4 * hiddenSize]), { axes: [0] })) : null);
       currentRecurrentBias.push(options.recurrentBias ?
-        (builder.squeeze(builder.slice(options.recurrentBias, [dir, 0], [1, 4 * hidden_size]), { axes: [0] })) : null);
+        (builder.squeeze(builder.slice(options.recurrentBias, [dir, 0], [1, 4 * hiddenSize]), { axes: [0] })) : null);
       currentPeepholeWeight.push(options.peepholeWeight ?
-        (builder.squeeze(builder.slice(options.peepholeWeight, [dir, 0], [1, 3 * hidden_size]), { axes: [0] })) : null);
+        (builder.squeeze(builder.slice(options.peepholeWeight, [dir, 0], [1, 3 * hiddenSize]), { axes: [0] })) : null);
     }
 
     for (let step = 0; step < steps; ++step) {
@@ -3865,13 +3865,13 @@ partial interface MLGraphBuilder {
       let nextCell = null;
 
       for (let dir = 0; dir < numDirections; ++dir) {
-        currentHidden.push(builder.squeeze(builder.slice(hiddenState, [dir, 0, 0], [1, batch_size, hidden_size]), { axes: [0] }));
-        currentCell.push(builder.squeeze(builder.slice(cellState, [dir, 0, 0], [1, batch_size, hidden_size]), { axes: [0] }));
+        currentHidden.push(builder.squeeze(builder.slice(hiddenState, [dir, 0, 0], [1, batchSize, hiddenSize]), { axes: [0] }));
+        currentCell.push(builder.squeeze(builder.slice(cellState, [dir, 0, 0], [1, batchSize, hiddenSize]), { axes: [0] }));
       }
 
       for (let dir = 0; dir < numDirections; ++dir) {
         let slice = (dir == 1 || options.direction == "backward" ? steps - step - 1 : step);
-        let currentInput = builder.squeeze(builder.slice(input, [slice, 0, 0], [1, batch_size, input_size]), { axes: [0] });
+        let currentInput = builder.squeeze(builder.slice(input, [slice, 0, 0], [1, batchSize, inputSize]), { axes: [0] });
 
         let results = builder.lstmCell(
           currentInput, currentWeight[dir], currentRecurrentWeight[dir],
@@ -3923,15 +3923,15 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLLstmCellOptions>
     : <dfn>bias</dfn>
     ::
-        An {{MLOperand}}. The 1-D input bias tensor of shape [4 * hidden_size]. The ordering of the bias vectors in the first dimension of the tensor shape is specified according to the {{MLLstmCellOptions/layout}} argument.
+        An {{MLOperand}}. The 1-D input bias tensor of shape [4 * hiddenSize]. The ordering of the bias vectors in the first dimension of the tensor shape is specified according to the {{MLLstmCellOptions/layout}} argument.
 
     : <dfn>recurrentBias</dfn>
     ::
-        An {{MLOperand}}. The 1-D recurrent bias tensor of shape [4 * hidden_size]. The ordering of the bias vectors in the first dimension of the tensor shape is specified according to the {{MLLstmCellOptions/layout}} argument.
+        An {{MLOperand}}. The 1-D recurrent bias tensor of shape [4 * hiddenSize]. The ordering of the bias vectors in the first dimension of the tensor shape is specified according to the {{MLLstmCellOptions/layout}} argument.
 
     : <dfn>peepholeWeight</dfn>
     ::
-        An {{MLOperand}}. The 1-D weight tensor for peepholes of shape [3 * hidden_size]. The pack ordering of the weight vectors is for the `input (i)`, `output (o)`, and `forget (f)` gate, respectively.
+        An {{MLOperand}}. The 1-D weight tensor for peepholes of shape [3 * hiddenSize]. The pack ordering of the weight vectors is for the `input (i)`, `output (o)`, and `forget (f)` gate, respectively.
 
     : <dfn>layout</dfn>
     ::
@@ -3944,15 +3944,15 @@ partial interface MLGraphBuilder {
 
 <div>
     **Arguments:**
-        - *input*: an {{MLOperand}}. The input 2-D tensor of shape [batch_size, input_size].
-        - *weight*: an {{MLOperand}}. The 2-D input weight tensor of shape [4 * hidden_size, input_size]. The ordering of the weight vectors in the first dimension of the tensor shape is specified according to the *options.layout* argument.
-        - *recurrentWeight*: an {{MLOperand}}. The 2-D recurrent weight tensor of shape [4 * hidden_size, hidden_size]. The ordering of the weight vectors in the first dimension of the tensor shape is specified according to the *options.layout* argument.
-        - *hiddenState*: an {{MLOperand}}. The 2-D input hidden state tensor of shape [batch_size, hidden_size].
-        - *cellState*: an {{MLOperand}}. The 2-D input cell state tensor of shape [batch_size, hidden_size].
+        - *input*: an {{MLOperand}}. The input 2-D tensor of shape [batchSize, inputSize].
+        - *weight*: an {{MLOperand}}. The 2-D input weight tensor of shape [4 * hiddenSize, inputSize]. The ordering of the weight vectors in the first dimension of the tensor shape is specified according to the *options.layout* argument.
+        - *recurrentWeight*: an {{MLOperand}}. The 2-D recurrent weight tensor of shape [4 * hiddenSize, hiddenSize]. The ordering of the weight vectors in the first dimension of the tensor shape is specified according to the *options.layout* argument.
+        - *hiddenState*: an {{MLOperand}}. The 2-D input hidden state tensor of shape [batchSize, hiddenSize].
+        - *cellState*: an {{MLOperand}}. The 2-D input cell state tensor of shape [batchSize, hiddenSize].
         - *hiddenSize*: an {{unsigned long}} scalar. The value of the second dimension of the output tensor shape. It indicates the number of features in the hidden state.
         - *options*: an optional {{MLLstmCellOptions}}. The optional parameters of the operation.
 
-    **Returns:** a sequence of {{MLOperand}}. The first element of the sequence is the output hidden state of the current time step of the recurrent network. The following element is the output cell state. Both elements are 2-D tensors of shape [batch_size, hidden_size].
+    **Returns:** a sequence of {{MLOperand}}. The first element of the sequence is the output hidden state of the current time step of the recurrent network. The following element is the output cell state. Both elements are 2-D tensors of shape [batchSize, hiddenSize].
 </div>
 
 <details open algorithm>
@@ -3963,7 +3963,7 @@ partial interface MLGraphBuilder {
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |weight|, |recurrentWeight|, |hiddenState| and |cellState| is {{MLOperand}}.
     1. If the [=rank=] of |input|, |weight|, |recurrentWeight|, |hiddenState| or |cellState| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. Let |batch_size| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0].
+    1. Let |batchSize| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0].
     1. If |options|.{{MLLstmCellOptions/bias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `1`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -3981,7 +3981,7 @@ partial interface MLGraphBuilder {
         1. If it is not an array of size `3`, then [=exception/throw=] a {{TypeError}}.
         1. [=Assert=]: the type of its elements is {{MLActivation}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
-    1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |batch_size|, |hiddenSize| ].
+    1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |batchSize|, |hiddenSize| ].
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output0| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
@@ -4021,11 +4021,11 @@ partial interface MLGraphBuilder {
           builder.add(
             builder.matmul(
               input,
-              builder.transpose(builder.slice(weight, [0, 0], [hiddenSize, input_size]))
+              builder.transpose(builder.slice(weight, [0, 0], [hiddenSize, inputSize]))
             ),
             builder.matmul(
               hiddenState,
-              builder.transpose(builder.slice(recurrentWeight, [0, 0], [hiddenSize, hidden_size]))
+              builder.transpose(builder.slice(recurrentWeight, [0, 0], [hiddenSize, hiddenSize]))
             )
           )
         )
@@ -4047,11 +4047,11 @@ partial interface MLGraphBuilder {
           builder.add(
             builder.matmul(
               input,
-              builder.transpose(builder.slice(weight, [2 * hiddenSize, 0], [hiddenSize, input_size]))
+              builder.transpose(builder.slice(weight, [2 * hiddenSize, 0], [hiddenSize, inputSize]))
             ),
             builder.matmul(
               hiddenState,
-              builder.transpose(builder.slice(recurrentWeight, [2 * hiddenSize, 0], [hiddenSize, hidden_size]))
+              builder.transpose(builder.slice(recurrentWeight, [2 * hiddenSize, 0], [hiddenSize, hiddenSize]))
             )
           )
         )
@@ -4068,11 +4068,11 @@ partial interface MLGraphBuilder {
         builder.add(
           builder.matmul(
             input,
-            builder.transpose(builder.slice(weight, [3 * hiddenSize, 0], [hiddenSize, input_size]))
+            builder.transpose(builder.slice(weight, [3 * hiddenSize, 0], [hiddenSize, inputSize]))
           ),
           builder.matmul(
             hiddenState,
-            builder.transpose(builder.slice(recurrentWeight, [3 * hiddenSize, 0], [hiddenSize, hidden_size]))
+            builder.transpose(builder.slice(recurrentWeight, [3 * hiddenSize, 0], [hiddenSize, hiddenSize]))
           )
         )
       )
@@ -4093,11 +4093,11 @@ partial interface MLGraphBuilder {
           builder.add(
             builder.matmul(
               input,
-              builder.transpose(builder.slice(weight, [hiddenSize, 0], [hiddenSize, input_size]))
+              builder.transpose(builder.slice(weight, [hiddenSize, 0], [hiddenSize, inputSize]))
             ),
             builder.matmul(
               hiddenState,
-              builder.transpose(builder.slice(recurrentWeight, [hiddenSize, 0], [hiddenSize, hidden_size]))
+              builder.transpose(builder.slice(recurrentWeight, [hiddenSize, 0], [hiddenSize, hiddenSize]))
             )
           )
         )
@@ -4366,25 +4366,25 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLPool2dOptions>
     : <dfn>windowDimensions</dfn>
     ::
-         A sequence of {{unsigned long}} of length 2: [window_height, window_width].
+         A sequence of {{unsigned long}} of length 2: [windowHeight, windowWidth].
          Specifies the dimensions of the sliding window.
          The default value for the window dimensions are the height and width dimensions of the input shape.
 
     : <dfn>padding</dfn>
     ::
-        A sequence of {{unsigned long}} of length 4: [beginning_height, ending_height, beginning_width, ending_width].
+        A sequence of {{unsigned long}} of length 4: [beginningHeight, endingHeight, beginningWidth, endingWidth].
         Specifies the additional rows and columns added to the beginning and ending of each spatial dimension of the convolution input.
         The default value is [0,0,0,0].
 
     : <dfn>strides</dfn>
     ::
-        A sequence of {{unsigned long}} of length 2: [stride_height, stride_width].
+        A sequence of {{unsigned long}} of length 2: [strideHeight, strideWidth].
         Specifies the stride of the sliding window for each spatial dimension of the convolution input.
         The default value is [1,1].
 
     : <dfn>dilations</dfn>
     ::
-        A sequence of {{unsigned long}} of length 2: [dilation_height, dilation_width]. Specifies the dilation factor for each spatial dimension applied on the convolution filter (kernel).
+        A sequence of {{unsigned long}} of length 2: [dilationHeight, dilationWidth]. Specifies the dilation factor for each spatial dimension applied on the convolution filter (kernel).
         The default value is [1,1].
 
     : <dfn>autoPad</dfn>
@@ -4403,11 +4403,11 @@ partial interface MLGraphBuilder {
         An {{MLInputOperandLayout}} [=string=].
         Specifies the layout format of the input and output tensor as follows:
             - **"nchw"**
-                - input tensor: *[batches, input_channels, height, width]*
-                - output tensor: *[batches, output_channels, height, width]*
+                - input tensor: *[batches, inputChannels, height, width]*
+                - output tensor: *[batches, outputChannels, height, width]*
             - **"nhwc"**:
-                - input tensor: *[batches, height, width, input_channels]*
-                - output tensor: *[batches, height, width, output_channels]*
+                - input tensor: *[batches, height, width, inputChannels]*
+                - output tensor: *[batches, height, width, outputChannels]*
         The default value is *"nchw"*.
 
     : <dfn>roundingType</dfn>
@@ -4799,13 +4799,13 @@ partial interface MLGraphBuilder {
     : <dfn>scales</dfn>
     ::
         A sequence of {{float}} of length 2.
-        Specifies the scaling factor in each spatial dimensions of the input: [scale_height, scale_width].
+        Specifies the scaling factor in each spatial dimensions of the input: [scaleHeight, scaleWidth].
         The default value is [1.0, 1.0].
 
     : <dfn>sizes</dfn>
     ::
         A sequence of {{unsigned long}} of length 2.
-        Specifies the target sizes for each spatial dimensions of the input: [size_height, size_width]. When the target sizes are specified, the {{MLResample2dOptions/scales}} argument is ignored, since the scaling factor values are derived from the target sizes of each spatial dimension of the input.
+        Specifies the target sizes for each spatial dimensions of the input: [sizeHeight, sizeWidth]. When the target sizes are specified, the {{MLResample2dOptions/scales}} argument is ignored, since the scaling factor values are derived from the target sizes of each spatial dimension of the input.
 
     : <dfn>axes</dfn>
     ::

--- a/index.bs
+++ b/index.bs
@@ -1972,12 +1972,12 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the shape, i.e. {{MLOperandDescriptor/dimensions}}) of each operand in |inputs| is the same, except on the dimension given by |axis| on which they are concatenated.
     1. [=Assert=]: the {{MLOperandDescriptor/type}} of each operand in |inputs| is the same.
     1. If any of the following steps fail, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. If |axis| is greater than or equal to the [=rank=] of |inputs|, fail.
         1. Let |desc| be |inputs|[0].{{MLOperand/[[descriptor]]}}.
+        1. If |axis| is greater than or equal to the [=rank=] of |desc|, fail.
         1. Let |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] be `0`.
         1. [=map/For each=] |index| between 0 and the [=rank=] of |inputs|:
             1. If <a>validating MLOperand</a> given |inputs|[|index|] and [=this=] returns `false`, then fail.
-            1. [=map/For each=] |dim| between 0 and the [=rank=] of |inputs|[|index|]:
+            1. [=map/For each=] |dim| between 0 and the [=rank=] of |inputs|[|index|].{{MLOperandDescriptor/dimensions}}:
                 <div class="note">
                     If the shape of each corresponding dimension and type of the operands, except for those of the dimension given by |axis|, is not the same, fail.
                 </div>
@@ -3313,7 +3313,7 @@ The {{MLInstanceNormalizationOptions}} members are:
 <dl dfn-type=dict-member dfn-for=MLInstanceNormalizationOptions>
     : <dfn>scale</dfn>
     ::
-        An {{MLOperand}}. Specifies he 1-D tensor of the scaling values whose [=list/size=] is equal to the number of channels, i.e. the size of the feature dimension of the input. For example, for an |input| tensor with `nchw` layout, the [=list/size=] is the value of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1].
+        An {{MLOperand}}. Specifies the 1-D tensor of the scaling values whose [=list/size=] is equal to the number of channels, i.e. the size of the feature dimension of the input. For example, for an |input| tensor with `nchw` layout, the [=list/size=] is the value of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1].
 
     : <dfn>bias</dfn>
     ::
@@ -5183,7 +5183,9 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=split class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If |splits| is not {{unsigned long}} or a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}}.
+    1. If |splits| is not a non-zero {{unsigned long}} or a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}}.
+    1. If |splits| is an {{unsigned long}}, and |input|.{{MLOperandDescriptor/dimensions}}[|options|.{{MLSplitOptions/axis}}] % |splits| is not 0, then [=exception/throw=] a {{TypeError}}.
+    1. If |splits| is a sequence of {{unsigned long}}, and the sum of its elements is not equal to |input|.{{MLOperandDescriptor/dimensions}}[|options|.{{MLSplitOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:

--- a/index.bs
+++ b/index.bs
@@ -1937,7 +1937,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=clamp-options class=algorithm-steps>
     1. If running the <a>check clamp options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"clamp"` and |options|.
+    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=],  `"clamp"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -2655,7 +2655,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/elu(options)}} method steps are:
   </summary>
   <div algorithm=elu-options class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"elu"` and |options|.
+    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=], `"elu"` and |options|.
     1. Return |op|.
   </div>
 </details>
@@ -3206,7 +3206,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/hardSigmoid(options)}} method steps are:
   </summary>
   <div algorithm=hard-sigmoid-options class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"hardSigmoid"` and |options|.
+    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=], `"hardSigmoid"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -3284,7 +3284,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/hardSwish()}} method steps are:
   </summary>
   <div algorithm=hardswish class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"hardSwish"`.
+    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=] and `"hardSwish"`.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
  </div>
@@ -3477,7 +3477,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/leakyRelu(options)}} method steps are:
   </summary>
   <div algorithm=leakyrelu-options class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"leakyRelu"` and |options|.
+    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=], `"leakyRelu"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -3568,7 +3568,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/linear(options)}} method steps are:
   </summary>
   <div algorithm=linear-options class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"linear"` and |options|.
+    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=],  `"linear"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -4622,7 +4622,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/relu()}} method steps are:
   </summary>
   <div algorithm=relu class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"relu"`.
+    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=] and `"relu"`.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -4856,7 +4856,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/sigmoid()}} method steps are:
   </summary>
   <div algorithm=sigmoid class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"sigmoid"`.
+    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=] and `"sigmoid"`.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -4975,7 +4975,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/softmax()}} method steps are:
   </summary>
   <div algorithm=softmax class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"softmax"`.
+    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with  and  `"softmax"`.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -5063,7 +5063,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/softplus(options)}} method steps are:
   </summary>
   <div algorithm=softplus-options class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"softplus"` and |options|.
+    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=], `"softplus"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -5133,7 +5133,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/softsign()}} method steps are:
   </summary>
   <div algorithm=softsign class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"softsign"`.
+    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=] and `"softsign"`.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -5335,7 +5335,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/tanh()}} method steps are:
   </summary>
   <div algorithm=tanh class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"tanh"`.
+    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=] and `"tanh"`.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>

--- a/index.bs
+++ b/index.bs
@@ -1873,16 +1873,16 @@ partial interface MLGraphBuilder {
   <pre highlight="js">
     if (options.minValue === undefined) {
       if (options.maxValue === undefined) {
-        return x;
+        return operand;
       } else {
-        return builder.min(x, builder.constant(options.maxValue));
+        return builder.min(operand, builder.constant(options.maxValue));
       }
     } else {
       if (options.maxValue === undefined) {
-        return builder.max(x, builder.constant(options.minValue));
+        return builder.max(operand, builder.constant(options.minValue));
       } else {
         return builder.min(
-            builder.max(x, builder.constant(options.minValue)),
+            builder.max(operand, builder.constant(options.minValue)),
             builder.constant(options.maxValue));
       }
     }
@@ -1923,7 +1923,7 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |operand|.
         1. Make a request to the underlying platform to:
-            1. Create an [=implementation-defined=] platform operator |clampImpl| for this method, given |options|.{{MLClampOptions/minValue}} and |options|.{{MLClampOptions/minValue}}.
+            1. Create an [=implementation-defined=] platform operator |clampImpl| for this method, given |options|.{{MLClampOptions/minValue}} and |options|.{{MLClampOptions/maxValue}}.
             1. Store a reference of |clampImpl| in |output|.{{MLOperand/[[operator]]}}.
             1. Create an [=implementation-defined=] platform operand |outputImpl| to represent clamp output, given |output| and |clampImpl|.
             1. Store a reference to |outputImpl| in |output|.{{MLOperand/[[operand]]}}.

--- a/index.bs
+++ b/index.bs
@@ -1799,8 +1799,8 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=batchnorm class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |mean| and |variance| is {{MLOperand}}.
-    1. If |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} from which the dimension represented by |options|.axis is removed, then  [=exception/throw=] a {{TypeError}}.
     1. If |options|.axis is not a number between 0 and the [=rank=] of |input|, then [=exception/throw=] a {{TypeError}}.
+    1. If |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} from which the dimension represented by |options|.axis is removed, then [=exception/throw=] a {{TypeError}}.
     1. If |input| is a 4-D tensor of the *"nchw"* layout, set |options|.axis to 1.
     1. If |input| is a 4-D tensor of the *"nhwc"* layout, set |options|.axis to 3.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.

--- a/index.bs
+++ b/index.bs
@@ -4893,9 +4893,7 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |starts| or |sizes| is not a sequence of {{long}}, then [=exception/throw=] a {{TypeError}}.
     1. If |sizes|.size is 0, then [=exception/throw=] a {{TypeError}}.
-        <div class="note">
-            Further validation of |starts| and |sizes| given |input| is left [=implementation-defined=].
-        </div>
+    1. If the [=list/size=] of |starts| and |sizes| is not equal to the <a>rank</a> of |input|, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
@@ -5261,7 +5259,9 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |options|.{{MLSqueezeOptions/axes}} [=map/exists=], then:
         1. Let |dimensions| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-        1. For |index| between 0 and the [=list/size=] of |options|.{{MLSqueezeOptions/axes}}:
+        1. Let |axesLength| be the [=list/size=] of |options|.{{MLSqueezeOptions/axes}}.
+        1. If |axesLength| is not smaller than the <a>rank</a> of |dimensions|,
+        1. For |index| between 0 and |axesLength|:
             1. Let |oneDimIndex| be |options|.{{MLSqueezeOptions/axes}}[|index|].
             1. If |dimensions|[|oneDimIndex|] is not `1`, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.

--- a/index.bs
+++ b/index.bs
@@ -827,7 +827,7 @@ Its <a>default allowlist</a> is <code>'self'</code>.
             1. Set |context|.{{[[contextType]]}} to "[=default-context|default=]".
             1. If |options|["{{deviceType}}"] [=map/exists=], then set |context|.{{[[deviceType]]}} to |options|["{{deviceType}}"]. Otherwise, set |context|.{{[[deviceType]]}} to "[=device-type-cpu|cpu=]".
             1. If |options|["{{powerPreference}}"] [=map/exists=], then set |context|.{{[[powerPreference]]}} to |options|["{{powerPreference}}"]. Otherwise, set |context|.{{[[powerPreference]]}} to "[=power-preference-default|default=]".
-    1. If the <a>validate MLContext</a> steps given |context| return `false`, [=reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}} and abort these steps.
+    1. If <a>validating MLContext</a> given |context| return `false`, [=reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}} and abort these steps.
     1. [=Resolve=] |promise| with |context|.
 </div>
 </details>
@@ -840,7 +840,7 @@ Its <a>default allowlist</a> is <code>'self'</code>.
   <div algorithm=createcontextsync class=algorithm-steps>
     1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, throw a "{{SecurityError}}" {{DOMException}} and abort these steps.
     1. Let |context| be the result of running the <a>create context</a> steps given |options|.
-    1. If the <a>validate MLContext</a> steps given |context| return `false`, throw a "{{NotSupportedError}}" {{DOMException}} and abort these steps.
+    1. If <a>validating MLContext</a> given |context| return `false`, throw a "{{NotSupportedError}}" {{DOMException}} and abort these steps.
     1. Return |context|.
   </div>
 </details>
@@ -905,7 +905,7 @@ dictionary MLOperandDescriptor {
   </summary>
   <div class=algorithm-steps>
     1. Let |elementLength| be 1.
-    1. For each |dimension| of |desc|.{{MLOperandDescriptor/dimensions}}:
+    1. [=map/For each=] |dimension| of |desc|.{{MLOperandDescriptor/dimensions}}:
         1. Set |elementLength| to |elementLength| × |dimension|.
     1. Let |elementSize| be the [=element size=] of one of the {{ArrayBufferView}} types that matches |desc|.{{MLOperandDescriptor/type}} according to [this table](#appendices-mloperandtype-arraybufferview-compatibility).
     1. Return |elementLength| × |elementSize|.
@@ -960,11 +960,11 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
 
 <details open>
   <summary>
-    To <dfn>create MLOperand</dfn> given |builder| and |desc|, run the following steps:
+    To <dfn>create an MLOperand</dfn> given |builder| and |desc|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |builder| is {{MLGraphBuilder}}.
-    1. If |desc| is not an [=object=] that [=implements=] {{MLOperandDescriptor}}, then [=exception/throw=] a {{TypeError}} and stop.
+    1. [=Assert=]: the type of |desc| is {{MLOperandDescriptor}}.
     1. Let |operand| be a new [=object=].
     1. Set |operand|.{{MLOperand/[[builder]]}} to |builder|.
     1. Set |operand|.{{MLOperand/[[descriptor]]}} to |desc|.
@@ -974,7 +974,7 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
 
 <details open>
   <summary>
-    To <dfn>copy MLOperand</dfn> given |operand|, run the following steps:
+    To <dfn>copy an MLOperand</dfn> given |operand|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |operand| is {{MLOperand}}.
@@ -1007,7 +1007,6 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
     1. [=Assert=]: the type of |operand|.{{MLOperand/[[builder]]}} is {{MLGraphBuilder}}.
     1. If |builder| [=map/exists=]] and is not equal to |operand|.{{MLOperand/[[builder]]}}, return `false`.
     1. Let |desc| be |operand|.{{MLOperand/[[descriptor]]}}.
-    1. If |desc| is not an [=object=] that [=implements=] {{MLOperandDescriptor}}, return `false`.
     1. If |desc|.{{MLOperandDescriptor/dimensions}} [=map/exists=] and invoking <a>check dimensions</a> given |desc|.{{MLOperandDescriptor/dimensions}} and |desc|.{{MLOperandDescriptor/type}} returns `false`, then return `false`.
     1. Return `true`.
   </div>
@@ -1052,7 +1051,7 @@ The {{MLActivation}} objects (including the ones passed as input to methods) are
 
 <details open>
   <summary>
-    To <dfn>create MLActivation</dfn> given |builder|, |name|, |options| and |init-steps|, run the following steps:
+    To <dfn>create an MLActivation</dfn> given |builder|, |name|, |options| and |init-steps|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |builder| is {{MLGraphBuilder}}.
@@ -1129,7 +1128,7 @@ When the {{[[contextType]]}} is set to [=default-context|default=] with the {{ML
 ### The {{MLContext}} validation algorithm ### {#api-mlcontext-validate}
 <details open>
   <summary>
-    To <dfn lt="validate MLContext">validate {{MLContext}}</dfn>, given |context|, run these steps:
+    To <dfn lt="validate MLContext">validate MLContext</dfn>, given |context|, run these steps:
   </summary>
   <div class=algorithm-steps>
     1. If |context|.{{[[contextType]]}} is not "[=webgpu-context|webgpu=]" or "[=default-context|default=], return `false`.
@@ -1166,8 +1165,8 @@ partial interface MLContext {
   </summary>
   <div algorithm=mlcontext.computesync class=algorithm-steps>
     1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=], throw an "{{OperationError}}" {{DOMException}} and stop.
-    1. If invoking the <a>validate graph resources</a> algorithm given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns `false`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If invoking the <a>validate graph resources</a> algorithm given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns `false`, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If <a>validating graph resources</a> given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns `false`, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If <a>validating graph resources</a> given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns `false`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. Invoke <a>execute graph</a> given |graph|, |inputs| and |outputs|.
     1. If that throws an error, re-throw the error and stop.
     1. Return {{undefined}}.
@@ -1180,10 +1179,10 @@ partial interface MLContext {
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |resources| is {{MLNamedArrayBufferViews}}.
-    1. For each [=record=] <|key|, |value|> of |resources|:
+    1. [=map/For each=] [=record=] <|key|, |value|> of |resources|:
         1. If |descriptors|[|key|] does not [=map/exist=], return `false`.
         1. [=Assert=]: the type of |value| is {{ArrayBufferView}}.
-        1. If running the <a>validate buffer with descriptor</a> given |value| and |descriptors|[|key|] return `false`, return `false`.
+        1. If <a>validating buffer with descriptor</a> given |value| and |descriptors|[|key|] return `false`, return `false`.
     1. Return `true`.
   </div>
 </details>
@@ -1206,7 +1205,7 @@ partial interface MLContext {
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |inputs| is {{MLNamedArrayBufferViews}}.
     1. Let |inputResources| denote the input resources of |graph|.{{MLGraph/[[implementation]]}}.
-    1. For each <|key|, |inputValue|> of |inputs|:
+    1. [=map/For each=] <|key|, |inputValue|> of |inputs|:
         1. Let |inputDescriptor| be |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|].
         1. Let |inputTensor| be a new tensor for |graph|.{{MLGraph/[[implementation]]}} as follows:
             1. Set the data type of |inputTensor| to the one that matches the [=element type=] of |inputValue|.
@@ -1214,7 +1213,7 @@ partial interface MLContext {
             1. Set the values of elements in |inputTensor| to the values of elements in |inputValue|.
         1. Request the underlying implementation of |graph| to bind |inputResources|[|key|] to |inputTensor|.
     1. [=Assert=]: the type of |outputs| is {{MLNamedArrayBufferViews}}.
-    1. For each <|key|, |outputValue|> of |outputs|:
+    1. [=map/For each=] <|key|, |outputValue|> of |outputs|:
         1. Issue a compute request to |graph|.{{MLGraph/[[implementation]]}} given |key| and |inputResources| and wait for completion.
             1. If that returns an error, then throw an "{{OperationError}}" {{DOMException}} and stop.
             1. Otherwise, store the result in |outputTensor|.
@@ -1273,7 +1272,7 @@ partial interface MLContext {
   </summary>
   <div class=algorithm-steps>
     1. Let |transferredViews| be a new {{MLNamedArrayBufferViews}}.
-    1. For each |key| -> |value| of |views|:
+    1. [=map/For each=] |key| &rarr; |value| of |views|:
         1. Let |transferredBuffer| be the result of [=ArrayBuffer/transfer|transferring=] the [=underlying buffer=] of |value|.
         1. Let |constructor| be the appropriate [=view constructor=] for the type of {{ArrayBufferView}} |value|.
         1. Let |elementsNumber| be the result of the [=buffer byte length|byte length=] of |value| ÷ [=element size=] of |value|.
@@ -1318,8 +1317,8 @@ partial interface MLContext {
     1. Let |promise| be [=a new promise=].
     1. Return |promise| and run the following steps [=in parallel=]:
         1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=], [=reject=] |promise| with an "{{OperationError}}" {{DOMException}} and stop.
-        1. If invoking the <a>validate graph resources</a> algorithm given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns `false`, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}} and stop.
-        1. If invoking the <a>validate graph resources</a> algorithm given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns `false`, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}} and stop.
+        1. If <a>validating graph resources</a> given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns `false`, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}} and stop.
+        1. If <a>validating graph resources</a> given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns `false`, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}} and stop.
         1. Let |transferredInputs| be the result of [=MLNamedArrayBufferViews/transfer|transferring=] {{MLNamedArrayBufferViews}} |inputs|.
         1. Let |transferredOutputs| be the result of [=MLNamedArrayBufferViews/transfer|transferring=] {{MLNamedArrayBufferViews}} |outputs|.
         1. Invoke <a>execute graph</a> given |graph|, |transferredInputs| and |transferredOutputs|.
@@ -1455,20 +1454,20 @@ partial interface MLCommandEncoder {
   <div algorithm=mlcommandencoder.dispatch class=algorithm-steps>
     1. If any of the following requirements are unmet, then throw a "{{DataError}}" {{DOMException}} and stop.
         <div class=validusage>
-            1. For each |key| -> |value| of |inputs|:
+            1. [=map/For each=] |key| &rarr; |value| of |inputs|:
                 1. |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|] must [=map/exist=].
                 1. Let |inputDesc| be |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|].
                 1. If |value| is a {{GPUBuffer}}, then:
                     1. |value|.{{GPUBuffer/size}} must equal to [=byte length=] of |inputDesc|.
-            1. For each |key| -> |value| of |outputs|:
+            1. [=map/For each=] |key| &rarr; |value| of |outputs|:
                 1. |graph|.{{MLGraph/[[outputDescriptors]]}}[|key|] must [=map/exist=].
                 1. Let |outputDesc| be |graph|.{{MLGraph/[[outputDescriptors]]}}[|key|].
                 1. If |value| is a {{GPUBuffer}}, then:
                     1. |value|.{{GPUBuffer/size}} must equal to [=byte length=] of |outputDesc|.
         </div>
-    1. For each |key| -> |value| of |inputs|:
+    1. [=map/For each=] |key| &rarr; |value| of |inputs|:
         1. Set the input of |graph|.{{MLGraph/[[implementation]]}} that is associated with |key| to |value|.
-    1. For each |key| -> |value| of |outputs|:
+    1. [=map/For each=] |key| &rarr; |value| of |outputs|:
         1. Set the output of |graph|.{{MLGraph/[[implementation]]}} that is associated with |key| to |value|.
     1. Issue a compute request of |graph|.{{MLGraph/[[implementation]]}}.
     1. If there is an error returned by |graph|.{{MLGraph/[[implementation]]}}, then:
@@ -1580,7 +1579,7 @@ Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGr
   </summary>
   <div class=algorithm-steps>
     1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, throw a "{{SecurityError}}" {{DOMException}} and abort these steps.
-    1. If the <a>validate MLContext</a> steps given |context| return `false`, throw a "{{TypeError}}" and abort these steps.
+    1. If <a>validating MLContext</a> given |context| return `false`, throw a "{{TypeError}}" and abort these steps.
     1. Set {{MLGraphBuilder/[[context]]}} to |context|.
   </div>
 </details>
@@ -1610,7 +1609,7 @@ Create a named {{MLOperand}} based on a descriptor, that can be used as an input
         1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return `false`, throw a "{{DataError}}" {{DOMException}} and stop.
         1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |operand| be the result of invoking the <a>create MLOperand</a> steps with [=this=] and |descriptor|.
+        1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
         1. Set |operand|.{{MLOperand/[[name]]}} to |name|.
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform input operand |operandImpl| given |descriptor|.
@@ -1650,7 +1649,7 @@ Build a composed graph up to a given output operand into a computational graph, 
     </div>
     1. [=Assert=]: the type of |outputs| is {{MLNamedOperands}}.
     1. If |outputs| is empty, then [=exception/throw=] a {{TypeError}} and stop.
-    1. For each |element| in |outputs|:
+    1. [=map/For each=] |element| in |outputs|:
         1. [=Assert=]: the type of |element|.key is [=string=].
         1. If |element|.key is empty, then [=exception/throw=] a {{TypeError}} and stop.
         1. [=Assert=]: the type of |element|.value is {{MLOperand}}.
@@ -1661,8 +1660,8 @@ Build a composed graph up to a given output operand into a computational graph, 
             1. Connect |graph| to a new [=implementation-defined=] graph implementation |graphImpl| given |graph|.
             1. Store a reference to |graphImpl| in |graph|.{{MLGraph/[[implementation]]}}.
         1. Make a request to the underlying platform to initialize the graph:
-            1. For each |operand| in |outputs|:
-                1. If running the <a>validate MLOperand</a> given |operand| and [=this=] returns `false`, then [=exception/throw=] a {{TypeError}} and stop.
+            1. [=map/For each=] |operand| in |outputs|:
+                1. If <a>validating MLOperand</a> given |operand| and [=this=] returns `false`, then [=exception/throw=] a {{TypeError}} and stop.
                 1. If |operand| was created as an input by the underlying platform:
                     1. If |operand|.{{MLOperand/[[name]]}}] is not unique for |graphImpl|, then [=exception/throw=] a {{TypeError}} and stop.
                     1. Add |operand|.{{MLOperand/[[descriptor]]}} to |graph|.{{MLGraph/[[inputDescriptors]]}}[|operand|.{{MLOperand/[[name]]}}].
@@ -1696,10 +1695,10 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
     1. [=Assert=]: the type of |descriptor| is {{MLOperandDescriptor}}.
     1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return `false`, throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If invoking <a>validate buffer with descriptor</a> given |bufferView| and |descriptor| return `false`, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If <a>validating buffer with descriptor</a> given |bufferView| and |descriptor| return `false`, then [=exception/throw=] a {{TypeError}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |operand| be the result of invoking the <a>create MLOperand</a> steps with [=this=] and |descriptor|.
-        1. Let |bytes| be the result of invoking [[=get a copy of the bytes held by the buffer source=]] given |bufferView|.
+        1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
+        1. Let |bytes| be the result of invoking the [[=get a copy of the bytes held by the buffer source=]] steps given |bufferView|.
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform operand |constantImpl| to represent a constant, given |descriptor|.
             1. Store a reference of |constantImpl| in |operand|.{{MLOperand/[[operand]]}}.
@@ -1734,7 +1733,7 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
                 In the case of a scalar constant, |descriptor|.{{MLOperandDescriptor/dimensions}} is ignored.
             </div>
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |operand| be the result of invoking the <a>create MLOperand</a> steps with [=this=] and |descriptor|.
+        1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform operand |constantImpl| to represent a constant, given |descriptor|.
             1. Store a reference of |constantImpl| in |operand|.{{MLOperand/[[operand]]}}.
@@ -1801,14 +1800,12 @@ partial interface MLGraphBuilder {
   <div algorithm=batchnorm class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |mean| and |variance| is {{MLOperand}}.
     1. [=Assert=]: the type of |mean| is
-    1. To validate |mean|, run the following substeps:
-        1. If |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} from which the dimension represented by |options|.axis is removed, then  [=exception/throw=] a {{TypeError}} and abort these steps.
-    1. To validate |options|, run these substeps:
-        1. If |options|.axis is not a number between 0 and the rank of |input|, then [=exception/throw=] a {{TypeError}} and abort these steps.
-        1. If |input| is a 4-D tensor of the *"nchw"* layout, set |options|.axis to 1.
-        1. If |input| is a 4-D tensor of the *"nhwc"* layout, set |options|.axis to 3.
+    1. If |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} from which the dimension represented by |options|.axis is removed, then  [=exception/throw=] a {{TypeError}} and abort these steps.
+    1. If |options|.axis is not a number between 0 and the rank of |input|, then [=exception/throw=] a {{TypeError}} and abort these steps.
+    1. If |input| is a 4-D tensor of the *"nchw"* layout, set |options|.axis to 1.
+    1. If |input| is a 4-D tensor of the *"nhwc"* layout, set |options|.axis to 3.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>create MLOperand</a> steps with [=this=] and |descriptor|, that may use the same underlying data as |input|.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|, that may use the same underlying data as |input|.
         1. Make a request to the underlying platform to initialize the batch normalization:
             1. Create an [=implementation-defined=] platform operator |batchNormImpl| for this method, given |input|, |mean|, |variance| and |options|.
             1. If |options|.activation [=map/exists=],register it as activation to |batchNormImpl|.
@@ -1907,9 +1904,9 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=clamp class=algorithm-steps>
     1. [=Assert=]: the type of |operand| is {{MLOperand}}.
-    1. If running the <a>check clamp options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
+    1. If running the <a>check clamp options</a> steps given |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |operand|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |operand|.
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform operator |clampImpl| for this method, given |options|.{{MLClampOptions/minValue}} and |options|.{{MLClampOptions/maxValue}}.
             1. Store a reference of |clampImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -1936,8 +1933,8 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/clamp(options)}} method steps are:
   </summary>
   <div algorithm=clamp-options class=algorithm-steps>
-    1. If running the <a>check clamp options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=],  `"clamp"` and |options|.
+    1. If running the <a>check clamp options</a> steps given |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
+    1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=],  `"clamp"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -1978,9 +1975,9 @@ partial interface MLGraphBuilder {
         1. If |axis| is greater than or equal to the <a>rank</a> of |inputs|, fail.
         1. Let |desc| be |inputs|[0].{{MLOperand/[[descriptor]]}}.
         1. Let |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] be `0`.
-        1. For each |index| between 0 and the <a>rank</a> of |inputs|:
-            1. If running <a>validate MLOperand</a> given |inputs|[|index|] and [=this=] returns `false`, then fail.
-            1. For each |dim| between 0 and the <a>rank</a> of |inputs|[|index|]:
+        1. [=map/For each=] |index| between 0 and the <a>rank</a> of |inputs|:
+            1. If <a>validating MLOperand</a> given |inputs|[|index|] and [=this=] returns `false`, then fail.
+            1. [=map/For each=] |dim| between 0 and the <a>rank</a> of |inputs|[|index|]:
                 <div class="note">
                     If the shape of each corresponding dimension and type of the operands, except for those of the dimension given by |axis|, is not the same, fail.
                 </div>
@@ -1988,7 +1985,7 @@ partial interface MLGraphBuilder {
                 1. If |inputs|[|dim|].{{MLOperandDescriptor/type}} is not equal to |inputs|[0].{{MLOperandDescriptor/type}}.
                 1. If |dim| is equal to |axis|, add to |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] the value of |inputs|[|index|].{{MLOperandDescriptor/dimensions}}[|dim|].
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |desc|.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform operator |concatImpl| for this method, given |inputs| and |axis|.
             1. Store a reference of |concatImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -2131,12 +2128,12 @@ partial interface MLGraphBuilder {
     1. If |input_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |filter_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options|.{{MLConv2dOptions/padding}} does not [=map/exist=], set it to `[0, 0, 0, 0]`.
+    1. If |options|.{{MLConv2dOptions/padding}} does not [=map/exist=], set it to `« 0, 0, 0, 0 »`.
     1. Else if |options|.{{MLConv2dOptions/padding}}.length is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLConv2dOptions/strides}} does not [=map/exist=], set it to `[1, 1]`.
+    1. If |options|.{{MLConv2dOptions/strides}} does not [=map/exist=], set it to `« 1, 1 »`.
     1. Else if |options|.{{MLConv2dOptions/strides}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
     1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options|.{{MLConv2dOptions/dilations}} does not [=map/exist=], set it to `[1, 1]`.
+    1. If |options|.{{MLConv2dOptions/dilations}} does not [=map/exist=], set it to `« 1, 1 »`.
     1. Else if |options|.{{MLConv2dOptions/dilations}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLConv2dOptions/autoPad}} does not [=map/exist=], set it to `"explicit"`.
     1. If |options|.{{MLConv2dOptions/groups}} is 0, then throw a "{{DataError}}" {{DOMException}} and stop.
@@ -2154,7 +2151,7 @@ partial interface MLGraphBuilder {
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |output_shape|.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |desc|.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform operator |conv2dImpl| for this method, given |options| and |filter|.
                 1. If |options|.{{MLConv2dOptions/activation}} [=map/exists=],register it as activation to |conv2dImpl|.
@@ -2306,14 +2303,14 @@ partial interface MLGraphBuilder {
     1. If |input_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |filter_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options|.{{MLConvTranspose2dOptions/padding}} does not [=map/exist=], set it to `[0, 0, 0, 0]`.
+    1. If |options|.{{MLConvTranspose2dOptions/padding}} does not [=map/exist=], set it to `« 0, 0, 0, 0 »`.
     1. Else if |options|.{{MLConvTranspose2dOptions/padding}}.length is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLConvTranspose2dOptions/strides}} does not [=map/exist=], set it to `[1, 1]`.
+    1. If |options|.{{MLConvTranspose2dOptions/strides}} does not [=map/exist=], set it to `« 1, 1 »`.
     1. Else if |options|.{{MLConvTranspose2dOptions/strides}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
     1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options|.{{MLConvTranspose2dOptions/dilations}} does not [=map/exist=], set it to `[1, 1]`.
+    1. If |options|.{{MLConvTranspose2dOptions/dilations}} does not [=map/exist=], set it to `« 1, 1 »`.
     1. Else if |options|.{{MLConvTranspose2dOptions/dilations}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
-    1. If |options|.{{MLConvTranspose2dOptions/outputPadding}} does not [=map/exist=], set it to `[0, 0]`.
+    1. If |options|.{{MLConvTranspose2dOptions/outputPadding}} does not [=map/exist=], set it to `« 0, 0 »`.
     1. Else if |options|.{{MLConvTranspose2dOptions/outputPadding}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/outputSizes}} [=map/exists=]:
         1. If |options|.{{MLConvTranspose2dOptions/outputSizes}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
@@ -2332,7 +2329,7 @@ partial interface MLGraphBuilder {
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |output_shape|.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |desc|.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform operator |convTranspose2dImpl| for this method, given |options| and |filter|.
                 1. If |options|.{{MLConvTranspose2dOptions/activation}} [=map/exists=],register it as activation to |convTranspose2dImpl|.
@@ -2397,7 +2394,7 @@ partial interface MLGraphBuilder {
     1. Let |descriptor|.{{MLOperandDescriptor/dimensions}} be the result of running the [=MLGraphBuilder/broadcast-shapes=] steps given |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. If that throws an error, re-throw the error and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |descriptor|.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the binary operation |op|, given |a| and |b|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -2513,7 +2510,7 @@ partial interface MLGraphBuilder {
     1. Let |kind| be `"output"`.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the unary operation |op|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -2628,7 +2625,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=elu-input-options class=algorithm-steps>
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the ELU operation, given |options|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -2655,7 +2652,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/elu(options)}} method steps are:
   </summary>
   <div algorithm=elu-options class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=], `"elu"` and |options|.
+    1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=], `"elu"` and |options|.
     1. Return |op|.
   </div>
 </details>
@@ -2729,7 +2726,7 @@ partial interface MLGraphBuilder {
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [|shapeA|[0], |shapeB|[1]].
     1. Set |desc|.{{MLOperandDescriptor/type}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |desc|.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the GEMM operation, given |options|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -3010,7 +3007,7 @@ partial interface MLGraphBuilder {
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |input|.{{MLOperandDescriptor/dimensions}}[0], |hiddenSize| ].
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |desc|.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for `"gruCell"`, given |weight|, |recurrentWeight|, |hiddenState|, |hiddenSize| and |options| as parameters.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -3181,7 +3178,7 @@ partial interface MLGraphBuilder {
 <div algorithm=hardsigmoid-input-options class=algorithm-steps>
     The {{MLGraphBuilder/hardSigmoid(input, options)}} method steps are:
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the hard sigmoid operation, given |options|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -3206,7 +3203,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/hardSigmoid(options)}} method steps are:
   </summary>
   <div algorithm=hard-sigmoid-options class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=], `"hardSigmoid"` and |options|.
+    1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=], `"hardSigmoid"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -3258,7 +3255,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=hardswish-input class=algorithm-steps>
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the hard-swish operation.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -3284,7 +3281,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/hardSwish()}} method steps are:
   </summary>
   <div algorithm=hardswish class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=] and `"hardSwish"`.
+    1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"hardSwish"`.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
  </div>
@@ -3348,7 +3345,7 @@ The {{MLInstanceNormalizationOptions}} members are:
     1. If the rank of |options|.{{MLInstanceNormalizationOptions/bias}} is not equal to the size of the channel dimension of |input|, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. Otherwise if |options|.{{MLInstanceNormalizationOptions/layout}} is not one of {{MLInputOperandLayout}}, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the instance normalization operation, given |options|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -3451,7 +3448,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=leakyrelu-input-options class=algorithm-steps>
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the Leaky RELU operation, given |options|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -3477,7 +3474,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/leakyRelu(options)}} method steps are:
   </summary>
   <div algorithm=leakyrelu-options class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=], `"leakyRelu"` and |options|.
+    1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=], `"leakyRelu"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -3542,7 +3539,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=linear-input-options class=algorithm-steps>
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the linear operation, given |options|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -3568,7 +3565,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/linear(options)}} method steps are:
   </summary>
   <div algorithm=linear-options class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=],  `"linear"` and |options|.
+    1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=],  `"linear"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -3701,10 +3698,10 @@ partial interface MLGraphBuilder {
         1. Let |desc| a new {{MLOperandDescriptor}}.
         1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |nume_directions|, |batch_size|, |hiddenSize| ].
         1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
-        1. Let |output0| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |desc|.
-        1. Let |output1| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |desc|.
+        1. Let |output0| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
+        1. Let |output1| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |steps|, |nume_directions|, |batch_size|, |hiddenSize| ].
-        1. Let |output2| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |desc|.
+        1. Let |output2| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Let |output| be the array [ |output0|, |output1|, |output2 ].
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the LSTM operation, given |weight|, |recurrentWeight|, |steps|, |hiddenSize| and |options|.
@@ -3881,8 +3878,8 @@ partial interface MLGraphBuilder {
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |batch_size|, |hiddenSize| ].
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output0| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |desc|.
-        1. Let |output1| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |desc|.
+        1. Let |output0| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
+        1. Let |output1| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Let |output| be the array [ |output0|, |output1| ].
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the LSTM cell operation, given |weight|, |recurrentWeight|, |hiddenState|, |cellState|, |hiddenSize| and |options|.
@@ -4045,11 +4042,11 @@ partial interface MLGraphBuilder {
   <div class=algorithm-steps>
     1. Let |shapeA| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeA| the size of |shapeA|.
     1. Let |shapeB| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeB| the size of |shapeB|.
-    1. If |sizeA| and |sizeB| is `1`, return `[ 1 ]`.
+    1. If |sizeA| and |sizeB| is `1`, return `«  1  »`.
     1. If | sizeA| is `1` and |sizeB| is not, then insert `1` in the front of |shapeA| to become [ 1 | |shapeA| ] and let |sizeA| be `2`.
     1. If | sizeB| is `1` and |sizeA| is not, then insert `1` in the front of |shapeB| to become [ 1 | |shapeB| ] and let |sizeB| be `2`.
     1. Let |shape| be an array whose size |size| is the maximum of |sizeA| and |sizeB|.
-    1. For each |index| between 0 and |size|:
+    1. [=map/For each=] |index| between 0 and |size|:
        1. Set |shape|[|index|] to the maximum of |shapeA|[|index|] and |shapeB|[|index|].
     1. Return |shape|.
   </div>
@@ -4062,10 +4059,10 @@ partial interface MLGraphBuilder {
   <div algorithm=matmul class=algorithm-steps>
     1. [=Assert=]: the type of |a| and |b| is {{MLOperand}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
-    1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of invoking the <a>calculate matmul output sizes</a> given |a| and |b|.
+    1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of invoking the <a>calculate matmul output sizes</a> steps given |a| and |b|.
     1. Set |desc|.{{MLOperandDescriptor/type}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |desc|.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the matrix multiplication operation.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -4149,9 +4146,9 @@ partial interface MLGraphBuilder {
     1. If |beginningPadding| or |endingPadding| is not a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLPadOptions/mode}} is not one of {{MLPaddingMode}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
-    1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of invoking the <a>calculate padding output sizes</a> given |input|, |beginningPadding| and |endingPadding|.
+    1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of invoking the <a>calculate padding output sizes</a> steps given |input|, |beginningPadding| and |endingPadding|.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |desc|.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the padding operation, given |beginningPadding|, |endingPadding| and |options|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -4328,20 +4325,20 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: |op| is one of "averagePool2d", "l2Pool2d", "maxPool2d".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If the length of of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLPool2dOptions/outputSizes}} [=map/exists=], or if |options|.{{MLPool2dOptions/padding}} does not [=map/exist=], set |options|.{{MLPool2dOptions/padding}} to `[0, 0, 0, 0]`.
+    1. If |options|.{{MLPool2dOptions/outputSizes}} [=map/exists=], or if |options|.{{MLPool2dOptions/padding}} does not [=map/exist=], set |options|.{{MLPool2dOptions/padding}} to `« 0, 0, 0, 0 »`.
     1. If the length of of |padding|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLPool2dOptions/strides}} does not [=map/exist=], set |options|.{{MLPool2dOptions/strides}} to `[1, 1]`.
+    1. If |options|.{{MLPool2dOptions/strides}} does not [=map/exist=], set |options|.{{MLPool2dOptions/strides}} to `« 1, 1 »`.
     1. If the length of of |options|.{{MLPool2dOptions/strides}} is not 2, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If any value in |options|.{{MLPool2dOptions/strides}} is not greater than 0, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLPool2dOptions/dilations}} does not [=map/exist=], set |options|.{{MLPool2dOptions/dilations}} to `[1, 1]`.
+    1. If |options|.{{MLPool2dOptions/dilations}} does not [=map/exist=], set |options|.{{MLPool2dOptions/dilations}} to `« 1, 1 »`.
     1. If the length of of |options|.{{MLPool2dOptions/dilations}} is not 2, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If any value in |options|.{{MLPool2dOptions/dilations}} is not greater than 0, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLPool2dOptions/autoPad}} is not `"explicit"`, set |options|.{{MLPool2dOptions/padding}} to `[0, 0, 0, 0]`.
+    1. If |options|.{{MLPool2dOptions/autoPad}} is not `"explicit"`, set |options|.{{MLPool2dOptions/padding}} to `« 0, 0, 0, 0 »`.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Make a request to the underlying platform to:
             1. Calculate the output dimensions given |input| and |options|. Let |desc|.{{MLOperandDescriptor/dimensions}} be the result of that.
-            1. Let |output| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |desc|.
+            1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the |op| pooling operation, given |options|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
             1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
@@ -4406,7 +4403,7 @@ partial interface MLGraphBuilder {
     1. Let |descriptor|.{{MLOperandDescriptor/dimensions}} be the result of running the [=MLGraphBuilder/broadcast-shapes=] steps given |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |slope|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. If that throws an error, re-throw the error and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |descriptor|.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the PreLU operation, given |slope|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -4489,7 +4486,7 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: |op| is one of "reduceL1", "reduceL2", "reduceLogSum", "reduceLogSumExp", "reduceMax", "reduceMean", "reduceMin", "reduceProduct", "reduceSum", "reduceSumSquare".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the |op| reduce operation, given |options|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -4596,7 +4593,7 @@ partial interface MLGraphBuilder {
   <div algorithm=relu-input class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the ReLU operation.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -4622,7 +4619,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/relu()}} method steps are:
   </summary>
   <div algorithm=relu class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=] and `"relu"`.
+    1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"relu"`.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -4687,11 +4684,11 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=check-resample-options class=algorithm-steps>
     1. If |options|.{{MLResample2dOptions/mode}} [=map/exists=], and if its value is not one of `"nearest-neighbor"` or `"linear"`, return `false`.
-    1. If |options|.{{MLResample2dOptions/scales}} does not [=map/exist=], set it to to `[1.0, 1.0]`.
+    1. If |options|.{{MLResample2dOptions/scales}} does not [=map/exist=], set it to to `« 1.0, 1.0 »`.
     1. Otherwise, if any of its values is not greater than `0`, return `false`.
     1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], and if its size is not `2`, or if any of its values is not greater than `0`, return `false`.
-    1. If |options|.{{MLResample2dOptions/axes}} does not [=map/exists=], set it to `[2, 3]`.
-    1. Otherwise, if its value is not one of `[0, 1], [1, 2], [2, 3]`, return `false`.
+    1. If |options|.{{MLResample2dOptions/axes}} does not [=map/exists=], set it to `« 2, 3 »`.
+    1. Otherwise, if its value is not one of `« 0, 1], « 1, 2], « 2, 3 »`, return `false`.
     1. Return `true`.
   </div>
 </details>
@@ -4722,7 +4719,7 @@ partial interface MLGraphBuilder {
     1. Let |desc| be the result of running the <a>resample output sizes</a> steps given |options|.
         1. If that throws an error, re-throw the error and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |desc|.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the resample 2D operation, given |options|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -4763,9 +4760,9 @@ partial interface MLGraphBuilder {
   <div algorithm=reshape class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. Let |outputShape| be an empty array of {{unsigned long}}.
-    1. If |newShape| is a scalar [=number=], set |outputShape| to `[ 1 ]`.
+    1. If |newShape| is a scalar [=number=], set |outputShape| to `«  1  »`.
     1. Otherwise, if |newShape| is an array of {{unsigned long}}:
-        1. If the size of |newShape| is `0`, set |outputShape| to `[ 1 ]` (reshaping to scalar).
+        1. If the size of |newShape| is `0`, set |outputShape| to `«  1  »` (reshaping to scalar).
         1. If |newShape| contains more than one `null` value, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If any value in |newShape| is `0`, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. Let |inputElementCount| be the product of all elements in |inputs|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
@@ -4775,7 +4772,7 @@ partial interface MLGraphBuilder {
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |newShape|.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |desc|.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the reshape operation.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -4830,7 +4827,7 @@ partial interface MLGraphBuilder {
   <div algorithm=sigmoid-input class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the sigmoid operation.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -4856,7 +4853,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/sigmoid()}} method steps are:
   </summary>
   <div algorithm=sigmoid class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=] and `"sigmoid"`.
+    1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"sigmoid"`.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -4890,7 +4887,7 @@ partial interface MLGraphBuilder {
             Further validation of |starts| and |sizes| given |input| is left [=implementation-defined=].
         </div>
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the slice operation, given |starts| and |sizes|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -4950,7 +4947,7 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If the length of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 2, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the softmax operation.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -4975,7 +4972,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/softmax()}} method steps are:
   </summary>
   <div algorithm=softmax class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with  and  `"softmax"`.
+    1. Let |op| be the result of <a>creating an MLActivation</a> given  and  `"softmax"`.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -5037,7 +5034,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=softplus-input-options class=algorithm-steps>
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the softplus operation, given |options|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -5063,7 +5060,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/softplus(options)}} method steps are:
   </summary>
   <div algorithm=softplus-options class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=], `"softplus"` and |options|.
+    1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=], `"softplus"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -5108,7 +5105,7 @@ partial interface MLGraphBuilder {
   <div algorithm=softsign-input class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the softsign operation, given |options|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -5133,7 +5130,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/softsign()}} method steps are:
   </summary>
   <div algorithm=softsign class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=] and `"softsign"`.
+    1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"softsign"`.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -5178,7 +5175,7 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |splits| is not {{unsigned long}} or a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the split operation, given |splits| and |options|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -5256,7 +5253,7 @@ partial interface MLGraphBuilder {
             1. Let |oneDimIndex| be |options|.{{MLSqueezeOptions/axes}}[|index|].
             1. If |dimensions|[|oneDimIndex|] is not `1`, then [=exception/throw=] a {{TypeError}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the squeeze operation, given |options|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -5309,7 +5306,7 @@ partial interface MLGraphBuilder {
   <div algorithm=tanh-input class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the hyperbolic tangent operation.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -5335,7 +5332,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/tanh()}} method steps are:
   </summary>
   <div algorithm=tanh class=algorithm-steps>
-    1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with [=this=] and `"tanh"`.
+    1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"tanh"`.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
   </div>
@@ -5384,7 +5381,7 @@ partial interface MLGraphBuilder {
         1. If the values in |options|.{{MLTransposeOptions/permutation}} are not between `0` and the rank of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} minus `1`, then [=exception/throw=] a {{TypeError}} and stop.
         1. If the values in |options|.{{MLTransposeOptions/permutation}} contain duplicate value, then [=exception/throw=] a {{TypeError}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-        1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the transpose operation, given |options|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.

--- a/index.bs
+++ b/index.bs
@@ -811,13 +811,12 @@ Its <a>default allowlist</a> is <code>'self'</code>.
 ### The {{ML/createContext()}} method ### {#api-ml-createcontext}
 <details open>
 <summary>
-    The {{ML/createContext()}} method steps are:
+    The {{ML/createContext(options)}} method steps are:
 </summary>
 <div algorithm=createcontext class=algorithm-steps>
     1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, return [=a new promise=] [=rejected=] with a "{{SecurityError}}" {{DOMException}} and abort these steps.
     1. Let |promise| be [=a new promise=].
     1. Return |promise| and run the following steps [=in parallel=].
-    1. Let |options| be the first argument.
     1. Run the <dfn>create context</dfn> steps given |options|:
         1. Let |context| be a new {{MLContext}} object.
         1. If |options| is a {{GPUDevice}} object,
@@ -836,11 +835,10 @@ Its <a>default allowlist</a> is <code>'self'</code>.
 ### The {{ML/createContextSync()}} method ### {#api-ml-createcontextsync}
 <details open>
   <summary>
-    The {{ML/createContextSync()}} method steps are:
+    The {{ML/createContextSync(options)}} method steps are:
   </summary>
   <div algorithm=createcontextsync class=algorithm-steps>
     1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, throw a "{{SecurityError}}" {{DOMException}} and abort these steps.
-    1. Let |options| be the first argument.
     1. Let |context| be the result of running the <a>create context</a> steps given |options|.
     1. If the <a>validate MLContext</a> steps given |context| return `false`, throw a "{{NotSupportedError}}" {{DOMException}} and abort these steps.
     1. Return |context|.
@@ -1578,11 +1576,10 @@ Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGr
 ### The {{MLGraphBuilder}} constructor ### {#api-mlgraphbuilder-constructor}
 <details open>
   <summary>
-    The [=new=] {{MLGraphBuilder}} constructor steps are:
+    The [=new=] {{MLGraphBuilder(context)}} constructor steps are:
   </summary>
   <div class=algorithm-steps>
     1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, throw a "{{SecurityError}}" {{DOMException}} and abort these steps.
-    1. Let |context| be the first argument.
     1. If the <a>validate MLContext</a> steps given |context| return `false`, throw a "{{TypeError}}" and abort these steps.
     1. Set {{MLGraphBuilder/[[context]]}} to |context|.
   </div>
@@ -1606,14 +1603,12 @@ Create a named {{MLOperand}} based on a descriptor, that can be used as an input
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
-    1. Let |name| be the first argument.
-        1. If |name| is `undefined` or an empty [=string=], then [=exception/throw=] a {{TypeError}} and stop.
-    1. Let |descriptor| be the second argument.
-        1. If |descriptor| is not an an object that [=implements=] {{MLOperandDescriptor}}, then [=exception/throw=] a {{TypeError}} and stop.
-        1. [=Assert=]: If |descriptor|.{{MLOperandDescriptor/dimensions}} does not [=map/exist=], then |descriptor| defines a scalar input.
-        1. If |descriptor|.{{MLOperandDescriptor/dimensions}} [=map/exists=]:
-            1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return `false`, throw a "{{DataError}}" {{DOMException}} and stop.
-            1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If |name| is empty, then [=exception/throw=] a {{TypeError}} and stop.
+    1. [=Assert=]: the type of |descriptor| is {{MLOperandDescriptor}}.
+    1. [=Assert=]: If |descriptor|.{{MLOperandDescriptor/dimensions}} does not [=map/exist=], then |descriptor| defines a scalar input.
+    1. If |descriptor|.{{MLOperandDescriptor/dimensions}} [=map/exists=]:
+        1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return `false`, throw a "{{DataError}}" {{DOMException}} and stop.
+        1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |operand| be the result of invoking the <a>create MLOperand</a> steps with [=this=] and |descriptor|.
         1. Set |operand|.{{MLOperand/[[name]]}} to |name|.
@@ -1698,12 +1693,10 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
-    1. Let |descriptor| be the first argument.
-    1. If |descriptor| is not an an object that [=implements=] {{MLOperandDescriptor}}, then [=exception/throw=] a {{TypeError}} and stop.
-        1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return `false`, throw a "{{DataError}}" {{DOMException}} and stop.
-    1. Let |bufferView| be the second argument.
-        1. If invoking <a>validate buffer with descriptor</a> given |bufferView| and |descriptor| return `false`, then [=exception/throw=] a {{TypeError}} and stop.
+    1. [=Assert=]: the type of |descriptor| is {{MLOperandDescriptor}}.
+    1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return `false`, throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If invoking <a>validate buffer with descriptor</a> given |bufferView| and |descriptor| return `false`, then [=exception/throw=] a {{TypeError}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |operand| be the result of invoking the <a>create MLOperand</a> steps with [=this=] and |descriptor|.
         1. Let |bytes| be the result of invoking [[=get a copy of the bytes held by the buffer source=]] given |bufferView|.
@@ -1803,17 +1796,14 @@ partial interface MLGraphBuilder {
 
 <details open>
   <summary>
-    The {{MLGraphBuilder/batchNormalization()}} method steps are:
+    The {{MLGraphBuilder/batchNormalization(input, mean, variance, options)}} method steps are:
   </summary>
   <div algorithm=batchnorm class=algorithm-steps>
-    1. Let |input| be the first argument. To validate |input|, run these substeps:
-        1. If |input| is not an [=object=] that [=implements=] {{MLOperand}}, then [=exception/throw=] a {{TypeError}} and abort these steps.
-    1. Let |mean| be the second argument, representing a vector with the moving mean values for |input|. To validate |mean|, run the following substeps:
-        1. If |mean| is not an [=object=] that [=implements=] {{MLOperand}}, then [=exception/throw=] a {{TypeError}} and abort these steps.
+    1. [=Assert=]: the type of |input|, |mean| and |variance| is {{MLOperand}}.
+    1. [=Assert=]: the type of |mean| is
+    1. To validate |mean|, run the following substeps:
         1. If |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} from which the dimension represented by |options|.axis is removed, then  [=exception/throw=] a {{TypeError}} and abort these steps.
-    1. Let |variance| be the third argument, representing the moving variance values of |input|.
-    1. Let |options| be the fourth argument. To validate |options|, run these substeps:
-        1. If |options|.axis does not [=map/exist=], let |options|."axis" be 1.
+    1. To validate |options|, run these substeps:
         1. If |options|.axis is not a number between 0 and the rank of |input|, then [=exception/throw=] a {{TypeError}} and abort these steps.
         1. If |input| is a 4-D tensor of the *"nchw"* layout, set |options|.axis to 1.
         1. If |input| is a 4-D tensor of the *"nhwc"* layout, set |options|.axis to 3.
@@ -1895,8 +1885,6 @@ partial interface MLGraphBuilder {
     To <dfn>check clamp options</dfn> given |options|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. If |options| is not an [=object=] that [=implements=] {{MLClampOptions}}, then return `false`.
-    1. If |options|.{{MLClampOptions/minValue}} and |options|.{{MLClampOptions/maxValue}} are not a [=numeric type=], then return `false`.
     1. If |options|.{{MLClampOptions/minValue}} is greater than |options|.{{MLClampOptions/maxValue}}, then return `false`.
     1. Return `true`.
   </div>
@@ -1918,9 +1906,8 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/clamp(operand, options)}} method steps are:
   </summary>
   <div algorithm=clamp class=algorithm-steps>
-    1. Let |operand| be the first argument.
-    1. Let |options| be the second argument.
-        1. If running the <a>check clamp options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
+    1. [=Assert=]: the type of |operand| is {{MLOperand}}.
+    1. If running the <a>check clamp options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |operand|.
         1. Make a request to the underlying platform to:
@@ -1949,8 +1936,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/clamp(options)}} method steps are:
   </summary>
   <div algorithm=clamp-options class=algorithm-steps>
-    1. Let |options| be the first argument.
-        1. If running the <a>check clamp options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
+    1. If running the <a>check clamp options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"clamp"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
@@ -1984,36 +1970,33 @@ partial interface MLGraphBuilder {
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
-    1. Let |inputs| be the first argument.
-        1. [=Assert=]: the type of |inputs| is sequence of {{MLOperand}} objects.
-        1. [=Assert=]: the type of |axis| is `unsigned long`.
-        1. [=Assert=]: the shape, i.e. {{MLOperandDescriptor/dimensions}}) of each operand in |inputs| is the same, except on the dimension given by |axis| on which they are concatenated.
-        1. [=Assert=]: the {{MLOperandDescriptor/type}} of each operand in |inputs| is the same.
-        1. If any of the following steps fail, then throw a "{{DataError}}" {{DOMException}} and stop.
-            1. If |inputs| is not an array of [=objects=], fail.
-            1. If |axis| is not a positive integer [=number=], fail.
-            1. If |axis| is greater than or equal to the <a>rank</a> of |inputs|, fail.
-            1. Let |desc| be |inputs|[0].{{MLOperand/[[descriptor]]}}.
-            1. Let |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] be `0`.
-            1. For each |index| between 0 and the <a>rank</a> of |inputs|:
-                1. If running <a>validate MLOperand</a> given |inputs|[|index|] and [=this=] returns `false`, then fail.
-                1. For each |dim| between 0 and the <a>rank</a> of |inputs|[|index|]:
-                    <div class="note">
-                        If the shape of each corresponding dimension and type of the operands, except for those of the dimension given by |axis|, is not the same, fail.
-                    </div>
-                    1. If |dim| is not equal to |axis| and if |inputs|[|index|].{{MLOperandDescriptor/dimensions}}[|dim|] is not equal to |inputs|[0].{{MLOperandDescriptor/dimensions}}[|dim|], fail.
-                    1. If |inputs|[|dim|].{{MLOperandDescriptor/type}} is not equal to |inputs|[0].{{MLOperandDescriptor/type}}.
-                    1. If |dim| is equal to |axis|, add to |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] the value of |inputs|[|index|].{{MLOperandDescriptor/dimensions}}[|dim|].
-        1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
-            1. Let |output| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |desc|.
-            1. Make a request to the underlying platform to:
-                1. Create an [=implementation-defined=] platform operator |concatImpl| for this method, given |inputs| and |axis|.
-                1. Store a reference of |concatImpl| in |output|.{{MLOperand/[[operator]]}}.
-                1. Create an [=implementation-defined=] platform operand |outputImpl| to represent output,given |output| and |concatImpl|.
-                1. Store a reference to |outputImpl| in |output|.{{MLOperand/[[operand]]}}.
-            1. Connect |inputs| as input to |concatImpl|.
-            1. Connect |output|.{{MLOperand/[[operand]]}} as output to |concatImpl|.
-        1. Return |output|.
+    1. [=Assert=]: the type of |inputs| is sequence of {{MLOperand}} objects.
+    1. [=Assert=]: the type of |axis| is `unsigned long`.
+    1. [=Assert=]: the shape, i.e. {{MLOperandDescriptor/dimensions}}) of each operand in |inputs| is the same, except on the dimension given by |axis| on which they are concatenated.
+    1. [=Assert=]: the {{MLOperandDescriptor/type}} of each operand in |inputs| is the same.
+    1. If any of the following steps fail, then throw a "{{DataError}}" {{DOMException}} and stop.
+        1. If |axis| is greater than or equal to the <a>rank</a> of |inputs|, fail.
+        1. Let |desc| be |inputs|[0].{{MLOperand/[[descriptor]]}}.
+        1. Let |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] be `0`.
+        1. For each |index| between 0 and the <a>rank</a> of |inputs|:
+            1. If running <a>validate MLOperand</a> given |inputs|[|index|] and [=this=] returns `false`, then fail.
+            1. For each |dim| between 0 and the <a>rank</a> of |inputs|[|index|]:
+                <div class="note">
+                    If the shape of each corresponding dimension and type of the operands, except for those of the dimension given by |axis|, is not the same, fail.
+                </div>
+                1. If |dim| is not equal to |axis| and if |inputs|[|index|].{{MLOperandDescriptor/dimensions}}[|dim|] is not equal to |inputs|[0].{{MLOperandDescriptor/dimensions}}[|dim|], fail.
+                1. If |inputs|[|dim|].{{MLOperandDescriptor/type}} is not equal to |inputs|[0].{{MLOperandDescriptor/type}}.
+                1. If |dim| is equal to |axis|, add to |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] the value of |inputs|[|index|].{{MLOperandDescriptor/dimensions}}[|dim|].
+    1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
+        1. Let |output| be the result of invoking the <a>create MLOperand</a> steps given [=this=] and |desc|.
+        1. Make a request to the underlying platform to:
+            1. Create an [=implementation-defined=] platform operator |concatImpl| for this method, given |inputs| and |axis|.
+            1. Store a reference of |concatImpl| in |output|.{{MLOperand/[[operator]]}}.
+            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent output,given |output| and |concatImpl|.
+            1. Store a reference to |outputImpl| in |output|.{{MLOperand/[[operand]]}}.
+        1. Connect |inputs| as input to |concatImpl|.
+        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |concatImpl|.
+    1. Return |output|.
   </div>
 </details>
 
@@ -2637,18 +2620,6 @@ partial interface MLGraphBuilder {
   </details>
 </div>
 
-<details open>
-  <summary>
-    To <dfn>check ELU options</dfn> given |options|, run the following steps:
-  </summary>
-  <div algorithm=check-elu-options class=algorithm-steps>
-    1. If |options| is not an [=object=] that [=implements=] {{MLEluOptions}}, then return `false`.
-    1. If |options|.{{MLEluOptions/alpha}} is `undefined`, set |options|.{{MLEluOptions/alpha}} to `1`.
-    1. Else if |options|.{{MLEluOptions/alpha}} is not a [=numeric type=], then return `false`.
-    1. Return `true`.
-  </div>
-</details>
-
 #### The {{MLGraphBuilder/elu(input, options)}} method #### {#api-mlgraphbuilder-elu-input-options}
 <div>
     **Arguments:**
@@ -2665,9 +2636,6 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/elu(input, options)}} method steps are:
   </summary>
   <div algorithm=elu-input-options class=algorithm-steps>
-    1. Let |input| be the first argument.
-    1. Let |options| be the second argument.
-        1. If running the <a>check ELU options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -2696,9 +2664,6 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/elu(options)}} method steps are:
   </summary>
   <div algorithm=elu-options class=algorithm-steps>
-    1. Let |options| be the first argument.
-        1. If |options| is `undefined`, let |options| be a new {{MLEluOptions}} object.
-        1. If running the <a>check ELU options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"elu"` and |options|.
     1. Return |op|.
   </div>
@@ -3228,20 +3193,6 @@ partial interface MLGraphBuilder {
          The default value is `0.5`.
 </dl>
 
-<details open>
-  <summary>
-    To <dfn>check hard-sigmoid options</dfn> given |options|, run the following steps:
-  </summary>
-  <div algorithm=check-hard-sigmoid-options class=algorithm-steps>
-    1. If |options| is not an [=object=] that [=implements=] {{MLHardSigmoidOptions}}, then return `false`.
-    1. If |options|.{{MLEluOptions/alpha}} is `undefined`, set |options|.{{MLHardSigmoidOptions/alpha}} to `0.2`.
-    1. Else if |options|.{{MLHardSigmoidOptions/alpha}} is not a [=numeric type=], then return `false`.
-    1. If |options|.{{MLHardSigmoidOptions/beta}} is `undefined`, set |options|.{{MLHardSigmoidOptions/beta}} to `0.5`.
-    1. Else if |options|.{{MLHardSigmoidOptions/beta}} is not a [=numeric type=], then return `false`.
-    1. Return `true`.
-  </div>
-</details>
-
 #### The {{MLGraphBuilder/hardSigmoid(input, options)}} method #### {#api-mlgraphbuilder-hardsigmoid-input-options}
 <div>
     **Arguments:**
@@ -3253,9 +3204,6 @@ partial interface MLGraphBuilder {
 </div>
 <div algorithm=hardsigmoid-input-options class=algorithm-steps>
     The {{MLGraphBuilder/hardSigmoid(input, options)}} method steps are:
-    1. Let |input| be the first argument.
-    1. Let |options| be the second argument.
-        1. If running the <a>check hard-sigmoid options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -3282,8 +3230,6 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/hardSigmoid(options)}} method steps are:
   </summary>
   <div algorithm=hard-sigmoid-options class=algorithm-steps>
-    1. Let |options| be the first argument.
-        1. If running the <a>check hard-sigmoid options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"hardSigmoid"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
@@ -3335,7 +3281,6 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/hardSwish(input)}} method steps are:
   </summary>
   <div algorithm=hardswish-input class=algorithm-steps>
-    1. Let |input| be the first argument.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -3517,18 +3462,6 @@ partial interface MLGraphBuilder {
          The default value is `0.01`.
 </dl>
 
-<details open>
-  <summary>
-    To <dfn>check leaky-relu options</dfn> given |options|, run the following steps:
-  </summary>
-  <div algorithm=check-leaky-relu-options class=algorithm-steps>
-    1. If |options| is not an [=object=] that [=implements=] {{MLLeakyReluOptions}}, then return `false`.
-    1. If |options|.{{MLLeakyReluOptions/alpha}} is `undefined`, set |options|.{{MLLeakyReluOptions/alpha}} to `1`.
-    1. Else if |options|.{{MLLeakyReluOptions/alpha}} is not a [=numeric type=], then return `false`.
-    1. Return `true`.
-  </div>
-</details>
-
 #### The {{MLGraphBuilder/leakyRelu(input, options)}} method #### {#api-mlgraphbuilder-leaky-relu-input-options}
 <div>
     **Arguments:**
@@ -3544,10 +3477,6 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/leakyRelu(input, options)}} method steps are:
   </summary>
   <div algorithm=leakyrelu-input-options class=algorithm-steps>
-    1. Let |input| be the first argument.
-    1. Let |options| be the second argument.
-        1. If |options| is `undefined`, let |options| be a new {{MLLeakyReluOptions}} object.
-        1. If running the <a>check leaky-relu options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -3572,12 +3501,9 @@ partial interface MLGraphBuilder {
 
 <details open>
   <summary>
-    The {{MLGraphBuilder/elu(options)}} method steps are:
+    The {{MLGraphBuilder/leakyRelu(options)}} method steps are:
   </summary>
   <div algorithm=leakyrelu-options class=algorithm-steps>
-    1. Let |options| be the first argument.
-        1. If |options| is `undefined`, let |options| be a new {{MLLeakyReluOptions}} object.
-        1. If running the <a>check leaky-relu options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"leakyRelu"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
@@ -3627,20 +3553,6 @@ partial interface MLGraphBuilder {
          The default value is `0`.
 </dl>
 
-<details open>
-  <summary>
-    To <dfn>check linear options</dfn> given |options|, run the following steps:
-  </summary>
-  <div algorithm=check-linear-options class=algorithm-steps>
-    1. If |options| is not an [=object=] that [=implements=] {{MLLinearOptions}}, then return `false`.
-    1. If |options|.{{MLEluOptions/alpha}} is `undefined`, set |options|.{{MLLinearOptions/alpha}} to `1`.
-    1. Else if |options|.{{MLLinearOptions/alpha}} is not a [=numeric type=], then return `false`.
-    1. If |options|.{{MLLinearOptions/beta}} is `undefined`, set |options|.{{MLLinearOptions/beta}} to `0`.
-    1. Else if |options|.{{MLLinearOptions/beta}} is not a [=numeric type=], then return `false`.
-    1. Return `true`.
-  </div>
-</details>
-
 #### The {{MLGraphBuilder/linear(input, options)}} method #### {#api-mlgraphbuilder-linear-input-options}
 <div>
     **Arguments:**
@@ -3648,7 +3560,7 @@ partial interface MLGraphBuilder {
         - *options*: an optional {{MLLinearOptions}}. The optional parameters of the operation.
 
     **Returns:**
-        - an {{MLOperand}}. The output tensor of the same shape as *x*.
+        - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
 <details open>
@@ -3656,9 +3568,6 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/linear(input, options)}} method steps are:
   </summary>
   <div algorithm=linear-input-options class=algorithm-steps>
-    1. Let |input| be the first argument.
-    1. Let |options| be the second argument.
-        1. If running the <a>check linear options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -3686,8 +3595,6 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/linear(options)}} method steps are:
   </summary>
   <div algorithm=linear-options class=algorithm-steps>
-    1. Let |options| be the first argument.
-        1. If running the <a>check linear options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"linear"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
@@ -4820,18 +4727,13 @@ partial interface MLGraphBuilder {
     To <dfn for="MLGraphBuilder">check resample options</dfn> given |options|, run the following steps:
   </summary>
   <div algorithm=check-resample-options class=algorithm-steps>
-    1. If |options| is `undefined`, let |options| be a new {{MLResample2dOptions}} object.
-    1. If |options|.{{MLResample2dOptions/mode}} [=map/exists=]:
-        1. If its value is not one of `"nearest-neighbor"` or `"linear"`, return `null`.
-    1. Otherwise, set |options|.{{MLResample2dOptions/mode}} to `"nearest-neighbor"`.
-    1. If |options|.{{MLResample2dOptions/scales}} [=map/exists=]:
-        1. If its size is not `2`, or if any of its values is not greater than `0`, return `null`.
-    1. Otherwise, set |options|.{{MLResample2dOptions/scales}} to `[1.0, 1.0]`.
-    1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=]: if its size is not `2`, or if any of its values is not greater than `0`, return `null`.
-    1. If |options|.{{MLResample2dOptions/axes}} [=map/exists=]:
-        1. If its value is not one of `[0, 1], [1, 2], [2, 3]`, return `null`.
-    1. Otherwise, set |options|.{{MLResample2dOptions/axes}} to `[2, 3]`.
-    1. Return |options|.
+    1. If |options|.{{MLResample2dOptions/mode}} [=map/exists=], and if its value is not one of `"nearest-neighbor"` or `"linear"`, return `false`.
+    1. If |options|.{{MLResample2dOptions/scales}} does not [=map/exist=], set it to to `[1.0, 1.0]`.
+    1. Otherwise, if any of its values is not greater than `0`, return `false`.
+    1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], and if its size is not `2`, or if any of its values is not greater than `0`, return `false`.
+    1. If |options|.{{MLResample2dOptions/axes}} does not [=map/exists=], set it to `[2, 3]`.
+    1. Otherwise, if its value is not one of `[0, 1], [1, 2], [2, 3]`, return `false`.
+    1. Return `true`.
   </div>
 </details>
 
@@ -4857,8 +4759,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=resample2d class=algorithm-steps>
     1. Check if the input is a 4-dimensional tensor: if the size of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not `4`, throw a "{{DataError}}" {{DOMException}} and stop.
-    1. Let |options| be the result of running the <a>check resample options</a> steps given |options|.
-        1. If that returns `null`, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If running the <a>check resample options</a> steps given |options| returns `false`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. Let |desc| be the result of running the <a>resample output sizes</a> steps given |options|.
         1. If that throws an error, re-throw the error and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
@@ -5161,18 +5062,6 @@ partial interface MLGraphBuilder {
          The default value is `1`.
 </dl>
 
-<details open>
-  <summary>
-    To <dfn>check softplus options</dfn> given |options|, run the following steps:
-  </summary>
-  <div algorithm=check-softplus-options class=algorithm-steps>
-    1. If |options| is not an [=object=], then return `false`.
-    1. If |options|.{{MLSoftplusOptions/steepness}} is `undefined`, set |options|.{{MLSoftplusOptions/steepness}} to `1`.
-    1. Else if |options|.{{MLSoftplusOptions/steepness}} is not a [=numeric type=], then return `false`.
-    1. Return `true`.
-  </div>
-</details>
-
 #### The {{MLGraphBuilder/softplus(input, options)}} method #### {#api-mlgraphbuilder-softplus-input-options}
 <div>
     **Arguments:**
@@ -5188,9 +5077,6 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/softplus(input, options)}} method steps are:
   </summary>
   <div algorithm=softplus-input-options class=algorithm-steps>
-    1. Let |input| be the first argument.
-    1. Let |options| be the second argument.
-        1. If running the <a>check softplus options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -5218,8 +5104,6 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/softplus(options)}} method steps are:
   </summary>
   <div algorithm=softplus-options class=algorithm-steps>
-    1. Let |options| be the first argument.
-        1. If running the <a>check softplus options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"softplus"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.

--- a/index.bs
+++ b/index.bs
@@ -1730,7 +1730,7 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
-    1. If |value| is not a [=number=], then then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |value| is not a [=number=], then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |type| is `undefined`, let |type| be `"float32"`.
     1. Otherwise, if |type| is not one of {{MLOperandType}}, then  throw a "{{TypeError}}" {{DOMException}} and stop.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
@@ -1895,7 +1895,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. If |options| is not an [=object=] that [=implements=] {{MLClampOptions}}, then return `false`.
-    1. If |options|.{{MLClampOptions/minValue}} and |options|.{{MLClampOptions/maxValue}} are not a [=numeric type=], then then return `false`.
+    1. If |options|.{{MLClampOptions/minValue}} and |options|.{{MLClampOptions/maxValue}} are not a [=numeric type=], then return `false`.
     1. If |options|.{{MLClampOptions/minValue}} is greater than |options|.{{MLClampOptions/maxValue}}, then return `false`.
     1. Return `true`.
   </div>
@@ -2141,7 +2141,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/conv2d(input, filter, options)}} steps are:
   </summary>
   <div algorithm=conv2d class=algorithm-steps>
-    1. If |input| or |filter| is not an instance of {{MLOperand}}, then then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |input| or |filter| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. Let |input_size| be the size of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Let |filter_size| be the size of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. If |input_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
@@ -2163,7 +2163,7 @@ partial interface MLGraphBuilder {
     1.
     1. If |options|.{{MLConv2dOptions/inputLayout}} is `undefined`, set it to `"nchw"`.
     1. If |options|.{{MLConv2dOptions/filterLayout}} is `undefined`, set it to `"oihw"`.
-    1. If |options|.{{MLConv2dOptions/bias}} [=map/exists=] and it is not an instance of {{MLOperand}}, then then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLConv2dOptions/bias}} [=map/exists=] and it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If the length of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConv2dOptions/activation}} [=map/exists=] and it is not an instance of {{MLActivation}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. Let |output_shape| be the result of calculating output dimensions based on input, filter, dilation, padding and stride, taking into account |options|.{{MLConv2dOptions/inputLayout}}.
@@ -2319,11 +2319,11 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/convTranspose2d(input, filter, options)}} steps are:
   </summary>
   <div algorithm=convtranspose2d class=algorithm-steps>
-    1. If |input| or |filter| is not an instance of {{MLOperand}}, then then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |input| or |filter| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. Let |input_size| be the size of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Let |filter_size| be the size of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-    1. If |input_size| is not `4`, then then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |filter_size| is not `4`, then then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If |input_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If |filter_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLConvTranspose2dOptions/padding}} is `undefined`, set it to `[0, 0, 0, 0]`.
     1. If |options|.{{MLConvTranspose2dOptions/strides}} is `undefined`, set it to `[1, 1]`.
@@ -2335,8 +2335,8 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLConvTranspose2dOptions/groups}} is `undefined`, set it to `1`.
     1. If |options|.{{MLConvTranspose2dOptions/inputLayout}} is `undefined`, set it to `"nchw"`.
     1. If |options|.{{MLConvTranspose2dOptions/filterLayout}} is `undefined`, set it to `"iohw"`.
-    1. If |options|.{{MLConvTranspose2dOptions/bias}} [=map/exists=] and it is not an instance of {{MLOperand}}, then then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLConvTranspose2dOptions/activation}} [=map/exists=] and it is not an instance of {{MLActivation}}, then then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLConvTranspose2dOptions/bias}} [=map/exists=] and it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLConvTranspose2dOptions/activation}} [=map/exists=] and it is not an instance of {{MLActivation}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. Let |output_shape| be the result of calculating output dimensions based on |input|, |filter|, |options|.{{MLConvTranspose2dOptions/dilations}}, |options|.{{MLConvTranspose2dOptions/padding}} and |options|.{{MLConvTranspose2dOptions/strides}}, taking into account |options|.{{MLConvTranspose2dOptions/inputLayout}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
@@ -2629,7 +2629,7 @@ partial interface MLGraphBuilder {
   <div algorithm=check-elu-options class=algorithm-steps>
     1. If |options| is not an [=object=] that [=implements=] {{MLEluOptions}}, then return `false`.
     1. If |options|.{{MLEluOptions/alpha}} is `undefined`, set |options|.{{MLEluOptions/alpha}} to `1`.
-    1. Else if |options|.{{MLEluOptions/alpha}} is not a [=numeric type=], then then return `false`.
+    1. Else if |options|.{{MLEluOptions/alpha}} is not a [=numeric type=], then return `false`.
     1. Return `true`.
   </div>
 </details>
@@ -3220,9 +3220,9 @@ partial interface MLGraphBuilder {
   <div algorithm=check-hard-sigmoid-options class=algorithm-steps>
     1. If |options| is not an [=object=] that [=implements=] {{MLHardSigmoidOptions}}, then return `false`.
     1. If |options|.{{MLEluOptions/alpha}} is `undefined`, set |options|.{{MLHardSigmoidOptions/alpha}} to `0.2`.
-    1. Else if |options|.{{MLHardSigmoidOptions/alpha}} is not a [=numeric type=], then then return `false`.
+    1. Else if |options|.{{MLHardSigmoidOptions/alpha}} is not a [=numeric type=], then return `false`.
     1. If |options|.{{MLHardSigmoidOptions/beta}} is `undefined`, set |options|.{{MLHardSigmoidOptions/beta}} to `0.5`.
-    1. Else if |options|.{{MLHardSigmoidOptions/beta}} is not a [=numeric type=], then then return `false`.
+    1. Else if |options|.{{MLHardSigmoidOptions/beta}} is not a [=numeric type=], then return `false`.
     1. Return `true`.
   </div>
 </details>
@@ -3509,7 +3509,7 @@ partial interface MLGraphBuilder {
   <div algorithm=check-leaky-relu-options class=algorithm-steps>
     1. If |options| is not an [=object=] that [=implements=] {{MLLeakyReluOptions}}, then return `false`.
     1. If |options|.{{MLLeakyReluOptions/alpha}} is `undefined`, set |options|.{{MLLeakyReluOptions/alpha}} to `1`.
-    1. Else if |options|.{{MLLeakyReluOptions/alpha}} is not a [=numeric type=], then then return `false`.
+    1. Else if |options|.{{MLLeakyReluOptions/alpha}} is not a [=numeric type=], then return `false`.
     1. Return `true`.
   </div>
 </details>
@@ -3619,9 +3619,9 @@ partial interface MLGraphBuilder {
   <div algorithm=check-linear-options class=algorithm-steps>
     1. If |options| is not an [=object=] that [=implements=] {{MLLinearOptions}}, then return `false`.
     1. If |options|.{{MLEluOptions/alpha}} is `undefined`, set |options|.{{MLLinearOptions/alpha}} to `1`.
-    1. Else if |options|.{{MLLinearOptions/alpha}} is not a [=numeric type=], then then return `false`.
+    1. Else if |options|.{{MLLinearOptions/alpha}} is not a [=numeric type=], then return `false`.
     1. If |options|.{{MLLinearOptions/beta}} is `undefined`, set |options|.{{MLLinearOptions/beta}} to `0`.
-    1. Else if |options|.{{MLLinearOptions/beta}} is not a [=numeric type=], then then return `false`.
+    1. Else if |options|.{{MLLinearOptions/beta}} is not a [=numeric type=], then return `false`.
     1. Return `true`.
   </div>
 </details>
@@ -5146,7 +5146,7 @@ partial interface MLGraphBuilder {
   <div algorithm=check-softplus-options class=algorithm-steps>
     1. If |options| is not an [=object=], then return `false`.
     1. If |options|.{{MLSoftplusOptions/steepness}} is `undefined`, set |options|.{{MLSoftplusOptions/steepness}} to `1`.
-    1. Else if |options|.{{MLSoftplusOptions/steepness}} is not a [=numeric type=], then then return `false`.
+    1. Else if |options|.{{MLSoftplusOptions/steepness}} is not a [=numeric type=], then return `false`.
     1. Return `true`.
   </div>
 </details>

--- a/index.bs
+++ b/index.bs
@@ -2144,21 +2144,31 @@ partial interface MLGraphBuilder {
     1. If |input| or |filter| is not an instance of {{MLOperand}}, then then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. Let |input_size| be the size of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Let |filter_size| be the size of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-    1. If |input_size| is not `4`, then then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |filter_size| is not `4`, then then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If |input_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If |filter_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If the type of |input| and |filter| is not the same, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLConv2dOptions/padding}} is `undefined`, set it to `[0, 0, 0, 0]`.
+    1. Else if |options|.{{MLConv2dOptions/padding}}.length is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConv2dOptions/strides}} is `undefined`, set it to `[1, 1]`.
-    1. Else if |options|.{{MLConv2dOptions/strides}}.size() is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. Else if |options|.{{MLConv2dOptions/strides}}.length is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConv2dOptions/dilations}} is `undefined`, set it to `[1, 1]`.
+    1. Else if |options|.{{MLConv2dOptions/dilations}}.length is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConv2dOptions/autoPad}} is `undefined`, set it to `"explicit"`.
     1. If |options|.{{MLConv2dOptions/groups}} is `undefined`, set it to `1`.
+    1. Else if |options|.{{MLConv2dOptions/groups}} is 0, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If |input_size| / |options|.{{MLConv2dOptions/groups}} is not equal to |filter_size|, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. Else if |input_size| % |options|.{{MLConv2dOptions/groups}} is not 0, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1.
     1. If |options|.{{MLConv2dOptions/inputLayout}} is `undefined`, set it to `"nchw"`.
     1. If |options|.{{MLConv2dOptions/filterLayout}} is `undefined`, set it to `"oihw"`.
     1. If |options|.{{MLConv2dOptions/bias}} [=map/exists=] and it is not an instance of {{MLOperand}}, then then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLConv2dOptions/activation}} [=map/exists=] and it is not an instance of {{MLActivation}}, then then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If the length of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLConv2dOptions/activation}} [=map/exists=] and it is not an instance of {{MLActivation}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. Let |output_shape| be the result of calculating output dimensions based on input, filter, dilation, padding and stride, taking into account |options|.{{MLConv2dOptions/inputLayout}}.
+    1. If the shape of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not the same as |output_shape|, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |output_shape|.
@@ -2317,7 +2327,7 @@ partial interface MLGraphBuilder {
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLConvTranspose2dOptions/padding}} is `undefined`, set it to `[0, 0, 0, 0]`.
     1. If |options|.{{MLConvTranspose2dOptions/strides}} is `undefined`, set it to `[1, 1]`.
-    1. Else if |options|.{{MLConv2dOptions/strides}}.size() is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. Else if |options|.{{MLConv2dOptions/strides}}.length is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/dilations}} is `undefined`, set it to `[1, 1]`.
     1. If |options|.{{MLConvTranspose2dOptions/outputPadding}} is `undefined`, set it to `[0, 0]`.

--- a/index.bs
+++ b/index.bs
@@ -4115,7 +4115,6 @@ partial interface MLGraphBuilder {
     1. If |shapeA|[0] is not equal to |shapeB|[|sizeB| - 2], then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
     1. If |sizeB| is 1 and |sizeA| is not, then append 1 to |shapeB| to become [ |shapeB| | 1 ] and let |sizeB| be 2.
     1. If |shapeA|[|sizeA| - 1] is not equal to |shapeB|[0], then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-    1. If |shapeA| is not equal to |shapeB|, then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
     1. Let |shape| be an array whose size |size| is the maximum of |sizeA| and |sizeB|.
     1. [=map/For each=] |index| in [=the range=] 0 to |size|, exclusive:
        1. Set |shape|[|index|] to the maximum of |shapeA|[|index|] and |shapeB|[|index|].

--- a/index.bs
+++ b/index.bs
@@ -1212,7 +1212,6 @@ partial interface MLContext {
     1. Return {{undefined}}.
   </div>
 </details>
-</div>
 
 <details open algorithm>
   <summary>
@@ -1372,7 +1371,6 @@ partial interface MLContext {
             1. [=Resolve=] |promise| with |result|.
   </div>
 </details>
-</div>
 
 #### Examples #### {#api-mlcontext-async-execution-examples}
 <div class="example">
@@ -1471,7 +1469,6 @@ partial interface MLCommandEncoder {
     </div>
   </div>
 </details>
-</div>
 
 ### Dispatch Execution Commands ### {#api-mlcommandencoder-dispatch-commands}
 Record the {{MLGraph}} execution with the inputs {{MLNamedGPUResources}} and outputs {{MLNamedGPUResources}}.
@@ -1519,7 +1516,6 @@ partial interface MLCommandEncoder {
     1. Return {{undefined}}.
   </div>
 </details>
-</div>
 
 ### Generate GPU Command Buffer ### {#api-mlcommandencoder-generate-gpu-command-buffer}
 Complete the recording of ML workload and return a WebGPU-compatible {{GPUCommandBuffer}} containing the recorded workload.
@@ -1550,7 +1546,6 @@ partial interface MLCommandEncoder {
     1. Return a {{GPUCommandBuffer}} containing the recorded workload.
   </div>
 </details>
-</div>
 
 ## The MLGraphBuilder interface ## {#api-mlgraphbuilder}
 
@@ -1630,7 +1625,6 @@ Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGr
     1. Set {{MLGraphBuilder/[[context]]}} to |context|.
   </div>
 </details>
-</div>
 
 ### The {{MLGraphBuilder/input()}} method  ### {#api-mlgraphbuilder-input}
 Create a named {{MLOperand}} based on a descriptor, that can be used as an input.
@@ -1666,7 +1660,6 @@ Create a named {{MLOperand}} based on a descriptor, that can be used as an input
     1. Return |operand|.
   </div>
 </details>
-</div>
 
 ### The build() method ### {#api-mlgraphbuilder-build}
 Build a composed graph up to a given output operand into a computational graph, asynchronously or synchronously.
@@ -1687,7 +1680,6 @@ Build a composed graph up to a given output operand into a computational graph, 
         1. If that [=exception/throws=], re-[=exception/throw=] the error.
   </div>
 </details>
-</div>
 
 #### The {{MLGraphBuilder/buildSync(outputs)}} method #### {#api-mlgraphbuilder-buildsync-outputs}
 
@@ -1724,7 +1716,6 @@ Build a composed graph up to a given output operand into a computational graph, 
     1. Return |graph|.
   </div>
 </details>
-</div>
 
 ### The constant() method  ### {#api-mlgraphbuilder-constant-method}
 Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
@@ -1759,7 +1750,6 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
     1. Return |operand|.
   </div>
 </details>
-</div>
 
 #### The {{MLGraphBuilder/constant(value, type)}} method  #### {#api-mlgraphbuilder-constant-value-type}
 
@@ -1795,7 +1785,6 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
     1. Return |operand|.
   </div>
 </details>
-</div>
 
 ### The batchNormalization() method ### {#api-mlgraphbuilder-batchnorm}
 Normalize the tensor values of input features across the batch dimension using [[Batch-Normalization]]. For each input feature, the mean and variance values of that feature supplied in this calculation as parameters are previously computed across the batch dimension of the input during the model training phase of this operation.
@@ -1868,7 +1857,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 <div class="note">
   <details open>
@@ -1974,7 +1962,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 #### The {{MLGraphBuilder/clamp(options)}} method #### {#api-mlgraphbuilder-clamp-options}
 <div>
@@ -1998,7 +1985,6 @@ partial interface MLGraphBuilder {
     1. Return |op|.
   </div>
 </details>
-</div>
 
 ### The concat() method ### {#api-mlgraphbuilder-concat}
 Concatenates the input tensors along a given axis.
@@ -2057,7 +2043,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 ### The conv2d() method ### {#api-mlgraphbuilder-conv2d}
 Compute a 2-D convolution given 4-D input and filter tensors
@@ -2226,7 +2211,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 ### The convTranspose2d() method ### {#api-mlgraphbuilder-convtranspose2d}
 Compute a 2-D transposed convolution given 4-D input and filter tensors
@@ -2406,7 +2390,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 ### Element-wise binary operations ### {#api-mlgraphbuilder-binary}
 Compute the element-wise binary addition, subtraction, multiplication, division, power, maximum and minimum of the two input tensors.
@@ -2472,7 +2455,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 <details open algorithm>
 
@@ -2489,7 +2471,6 @@ partial interface MLGraphBuilder {
         </div>
   </div>
 </details>
-</div>
 
 <details open>
   <summary>
@@ -2604,7 +2585,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 <details open>
   <summary>
@@ -2739,7 +2719,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 #### The {{MLGraphBuilder/elu(options)}} method #### {#api-mlgraphbuilder-elu-options}
 <div>
@@ -2761,7 +2740,6 @@ partial interface MLGraphBuilder {
     1. Return |op|.
   </div>
 </details>
-</div>
 
 ### The gemm() method ### {#api-mlgraphbuilder-gemm}
 Calculate the [general matrix multiplication of the Basic Linear Algebra Subprograms](https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3). The calculation follows the expression `alpha * A * B + beta * C`, where `A` is a 2-D tensor with shape [M, K] or [K, M], `B` is a 2-D tensor with shape [K, N] or [N, K], and `C` is broadcastable to the shape [M, N]. `A` and `B` may optionally be transposed prior to the calculation.
@@ -2844,7 +2822,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 <div class="note">
 <details open>
@@ -2976,7 +2953,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 <div class="note">
 <details open>
@@ -3129,7 +3105,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 <div class="note">
 <details open>
@@ -3307,7 +3282,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 #### The {{MLGraphBuilder/hardSigmoid(options)}} method #### {#api-mlgraphbuilder-hardsigmoid-options}
 <div>
@@ -3329,7 +3303,6 @@ partial interface MLGraphBuilder {
     1. Return |op|.
   </div>
 </details>
-</div>
 
 ### The hardSwish() method ### {#api-mlgraphbuilder-hard-swish}
 Computes the nonlinear function `y = x * max(0, min(6, (x + 3))) / 6` that is introduced by [[MobileNetV3]] on the input tensor element-wise.
@@ -3389,7 +3362,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 #### The {{MLGraphBuilder/hardSwish()}} method #### {#api-mlgraphbuilder-hardswish}
 <div>
@@ -3482,7 +3454,6 @@ The {{MLInstanceNormalizationOptions}} members are:
     1. Return |output|.
   </div>
 </details>
-</div>
 
 <div class="note">
 <details open>
@@ -3587,7 +3558,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 #### The {{MLGraphBuilder/leakyRelu(options)}} method #### {#api-mlgraphbuilder-leaky-relu-options}
 <div>
@@ -3609,7 +3579,6 @@ partial interface MLGraphBuilder {
     1. Return |op|.
   </div>
 </details>
-</div>
 
 ### The linear() method ### {#api-mlgraphbuilder-linear}
 Calculate a linear function `y = alpha * x + beta` on the input tensor.
@@ -3682,7 +3651,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 #### The {{MLGraphBuilder/linear(options)}} method #### {#api-mlgraphbuilder-linear-options}
 <div>
@@ -3704,7 +3672,6 @@ partial interface MLGraphBuilder {
     1. Return |op|.
   </div>
 </details>
-</div>
 
 ### The lstm() method ### {#api-mlgraphbuilder-lstm}
 Long Short-Term Memory [[LSTM]] recurrent network uses an input, output, forget, and cell gate to compute the output state that rolls into the output across the temporal sequence of the network.
@@ -3851,7 +3818,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 <div class="note">
 <details open>
@@ -4031,7 +3997,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 <div class="note">
 <details open>
@@ -4215,7 +4180,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 ### The pad() method ### {#api-mlgraphbuilder-pad}
 Inflate the tensor with constant or mirrored values on the edges.
@@ -4302,7 +4266,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 <div class="example">
 <details open>
@@ -4498,7 +4461,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 <details open>
   <summary>
@@ -4566,7 +4528,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 <div class="note">
   <details open>
@@ -4651,7 +4612,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 <details open>
   <summary>
@@ -4780,7 +4740,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 #### The {{MLGraphBuilder/relu()}} method #### {#api-mlgraphbuilder-relu}
 <div>
@@ -4801,7 +4760,6 @@ partial interface MLGraphBuilder {
     1. Return |op|.
   </div>
 </details>
-</div>
 
 ### The resample2d() method ### {#api-mlgraphbuilder-resample2d-method}
 Resample the tensor values from the source to the destination spatial dimensions according to the scaling factors.
@@ -4871,7 +4829,6 @@ partial interface MLGraphBuilder {
     1. Return `true`.
   </div>
 </details>
-</div>
 
 <details open algorithm>
 
@@ -4889,7 +4846,6 @@ partial interface MLGraphBuilder {
     1. Return |desc|.
   </div>
 </details>
-</div>
 
 <details open algorithm>
 
@@ -4913,7 +4869,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 ### The reshape() method ### {#api-mlgraphbuilder-reshape-method}
 Alter the shape of a tensor to a new shape. Reshape does not copy or change the content of the tensor. It just changes the tensor's logical dimensions for the subsequent operations.
@@ -4968,7 +4923,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 ### The sigmoid() method ### {#api-mlgraphbuilder-sigmoid-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Sigmoid_function">sigmoid function</a> of the input tensor. The calculation follows the expression `1 / (exp(-x) + 1)`.
@@ -5025,7 +4979,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 #### The {{MLGraphBuilder/sigmoid()}} method #### {#api-mlgraphbuilder-sigmoid}
 <div>
@@ -5046,7 +4999,6 @@ partial interface MLGraphBuilder {
     1. Return |op|.
   </div>
 </details>
-</div>
 
 ### The slice() method ### {#api-mlgraphbuilder-slice}
 Produce a slice of the input tensor.
@@ -5085,7 +5037,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 ### The softmax() method ### {#api-mlgraphbuilder-softmax-method}
 Compute the [softmax](https://en.wikipedia.org/wiki/Softmax_function) values of
@@ -5147,7 +5098,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 #### The {{MLGraphBuilder/softmax()}} method #### {#api-mlgraphbuilder-softmax}
 <div>
@@ -5168,7 +5118,6 @@ partial interface MLGraphBuilder {
     1. Return |op|.
   </div>
 </details>
-</div>
 
 ### The softplus() method ### {#api-mlgraphbuilder-softplus-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)#Softplus">softplus function</a> of the input tensor. The calculation follows the expression `ln(1 + exp(steepness * x)) / steepness`.
@@ -5238,7 +5187,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 #### The {{MLGraphBuilder/softplus(options)}} method #### {#api-mlgraphbuilder-softplus-options}
 <div>
@@ -5260,7 +5208,6 @@ partial interface MLGraphBuilder {
     1. Return |op|.
   </div>
 </details>
-</div>
 
 ### The softsign() method ### {#api-mlgraphbuilder-softsign-method}
 Compute the <a href="https://pytorch.org/docs/stable/generated/torch.nn.Softsign.html">softsign function</a> of the input tensor. The calculation follows the expression `x / (1 + |x|)`.
@@ -5313,7 +5260,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 #### The {{MLGraphBuilder/softsign()}} method #### {#api-mlgraphbuilder-softsign}
 <div>
@@ -5334,7 +5280,6 @@ partial interface MLGraphBuilder {
     1. Return |op|.
   </div>
 </details>
-</div>
 
 ### The split() method ### {#api-mlgraphbuilder-split}
 Split the input tensor into a number of sub tensors along the given axis.
@@ -5389,7 +5334,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 <div class="note">
 <details open>
@@ -5471,7 +5415,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 ### The tanh() method ### {#api-mlgraphbuilder-tanh-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Hyperbolic_functions">hyperbolic tangent function</a> of the input tensor. The calculation follows the expression `(exp(2 * x) - 1) / (exp(2 * x) + 1)`.
@@ -5526,7 +5469,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 #### The {{MLGraphBuilder/tanh()}} method #### {#api-mlgraphbuilder-tanh}
 <div>
@@ -5547,7 +5489,6 @@ partial interface MLGraphBuilder {
     1. Return |op|.
   </div>
 </details>
-</div>
 
 ### The transpose() method ### {#api-mlgraphbuilder-transpose}
 Permute the dimensions of the input tensor according to the *permutation* argument.
@@ -5602,7 +5543,6 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
-</div>
 
 Examples {#examples}
 =====================

--- a/index.bs
+++ b/index.bs
@@ -4040,13 +4040,14 @@ partial interface MLGraphBuilder {
         - If both *a* and *b* are 1-dimensional, the operation is a vector dot-product, which produces a scalar output.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
     To <dfn dfn-for=MLGraphBuilder>calculate matmul output sizes</dfn>, given |a| and |b| run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. Let |shapeA| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeA| the [=list/size=] of |shapeA|.
-    1. Let |shapeB| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeB| the [=list/size=] of |shapeB|.
+    1. Let |shapeB| be |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeB| the [=list/size=] of |shapeB|.
     1. If |sizeA| and |sizeB| is `1`, return `«  1  »`.
     1. If | sizeA| is `1` and |sizeB| is not, then insert `1` in the front of |shapeA| to become [ 1 | |shapeA| ] and let |sizeA| be `2`.
     1. If | sizeB| is `1` and |sizeA| is not, then insert `1` in the front of |shapeB| to become [ 1 | |shapeB| ] and let |sizeB| be `2`.
@@ -4056,6 +4057,7 @@ partial interface MLGraphBuilder {
     1. Return |shape|.
   </div>
 </details>
+</div>
 
 <details open>
   <summary>

--- a/index.bs
+++ b/index.bs
@@ -1653,26 +1653,26 @@ Build a composed graph up to a given output operand into a computational graph, 
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
-    1. If |outputs| is not an instance of {{MLNamedOperands}}, then throw an "{{TypeError}}" {{DOMException}} and stop.
+    1. If |outputs| is not an instance of {{MLNamedOperands}} or otherwise if empty, then throw an "{{TypeError}}" {{DOMException}} and stop.
     1. For each |element| in |outputs|:
-        1. If |element|.key is not a [=string=], then throw an "{{TypeError}}" {{DOMException}} and stop.
+        1. If |element|.key is not a [=string=] or otherwise if empty, then throw an "{{TypeError}}" {{DOMException}} and stop.
         1. If |element|.value is not an instance of {{MLOperand}}, then throw an "{{TypeError}}" {{DOMException}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |graph| be a new {{MLGraph}}:
             1. Set |graph|.{{MLGraph/[[context]]}} to [=this=].{{MLGraphBuilder/[[context]]}}.
-            1. Set |graph|.{{MLGraph/[[outputDescriptors]]}} to |outputs|.
         1. Make a request to the underlying platform to:
             1. Connect |graph| to a new [=implementation-defined=] graph implementation |graphImpl| given |graph|.
             1. Store a reference to |graphImpl| in |graph|.{{MLGraph/[[implementation]]}}.
         1. Make a request to the underlying platform to initialize the graph:
             1. For each |operand| in |outputs|:
+                1. If running the <a>validate MLOperand</a> given |operand| and [=this=] returns `false`, then throw a "{{TypeError}}" {{DOMException}} and stop.
                 1. If |operand| was created as an input by the underlying platform:
-                    1. Add |operand| to |graph|.{{MLGraph/[[inputDescriptors]]}}.
-                    1. Initialize the weights of |operand|.
+                    1. If |operand|.{{MLOperand/[[name]]}}] is not unique for |graphImpl|, then throw a "{{TypeError}}" {{DOMException}} and stop.
+                    1. Add |operand|.{{MLOperand/[[descriptor]]}} to |graph|.{{MLGraph/[[inputDescriptors]]}}[|operand|.{{MLOperand/[[name]]}}].
                 1. If |operand| was created as a constant by the underlying platform:
-                    1. Preprocess and optimize the tensor data of |operand|.
-                1. Update |graphImpl| with |operand|.{{MLOperand/[[operand]]}}.
-                1. Update |graphImpl| with |operand|.{{MLOperand/[[operator]]}}.
+                    1. Implementations MAY preprocess and optimize the tensor data of |operand| for the underlying platform.
+                1. Register |operand|.{{MLOperand/[[operand]]}} in |graphImpl| as graph output.
+                1. Register |operand|.{{MLOperand/[[operator]]}} to |graphImpl|.
     1. Return |graph|.
   </div>
 </details>
@@ -1995,7 +1995,7 @@ partial interface MLGraphBuilder {
             1. Let |desc| be |inputs|[0].{{MLOperand/[[descriptor]]}}.
             1. Let |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] be `0`.
             1. For each |index| between 0 and the <a>rank</a> of |inputs|:
-                1. If running <a>validate MLOperand</a> given |inputs|[|index|] and [=this=]  returns `false`, then fail.
+                1. If running <a>validate MLOperand</a> given |inputs|[|index|] and [=this=] returns `false`, then fail.
                 1. For each |dim| between 0 and the <a>rank</a> of |inputs|[|index|]:
                     <div class="note">
                         If the shape of each corresponding dimension and type of the operands, except for those of the dimension given by |axis|, is not the same, fail.

--- a/index.bs
+++ b/index.bs
@@ -1764,11 +1764,11 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLBatchNormalizationOptions>
     : <dfn>scale</dfn>
     ::
-        An {{MLOperand}}. Specifies the 1-D tensor of the scaling values whose length is equal to the size of the input dimension denoted by {{MLBatchNormalizationOptions/axis}}.
+        An {{MLOperand}}. Specifies the 1-D tensor of the scaling values whose is equal to the size of the input dimension denoted by {{MLBatchNormalizationOptions/axis}}.
 
     : <dfn>bias</dfn>
     ::
-        An {{MLOperand}}. Specifies the 1-D tensor of the bias values whose length is equal to the size of the input dimension denoted by {{MLBatchNormalizationOptions/axis}}.
+        An {{MLOperand}}. Specifies the 1-D tensor of the bias values whose [=list/size=] is equal to the size of the input dimension denoted by {{MLBatchNormalizationOptions/axis}}.
 
     : <dfn>axis</dfn>
     ::
@@ -1786,8 +1786,8 @@ partial interface MLGraphBuilder {
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input N-D tensor.
-        - *mean*: an {{MLOperand}}. Specifies the 1-D tensor of the mean values of the input features across the batch whose length is equal to the size of the input dimension denoted by  {{MLBatchNormalizationOptions/axis}}.
-        - *variance*: an {{MLOperand}}. The 1-D tensor of the variance values of the input features across the batch whose length is equal to the size of the input dimension denoted by {{MLBatchNormalizationOptions/axis}}.
+        - *mean*: an {{MLOperand}}. Specifies the 1-D tensor of the mean values of the input features across the batch. Its [=list/size=] is equal to the size of the input dimension denoted by  {{MLBatchNormalizationOptions/axis}}.
+        - *variance*: an {{MLOperand}}. The 1-D tensor of the variance values of the input features across the batch whose [=list/size=] is equal to the size of the input dimension denoted by {{MLBatchNormalizationOptions/axis}}.
         - *options*: an optional {{MLBatchNormalizationOptions}}. Specifies the optional parameters of the operation.
 
     **Returns:** an {{MLOperand}}. The batch-normalized N-D tensor of the same shape as *input*.
@@ -1800,9 +1800,12 @@ partial interface MLGraphBuilder {
   <div algorithm=batchnorm class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |mean| and |variance| is {{MLOperand}}.
     1. If |options|.axis is not a number between 0 and the [=rank=] of |input|, then [=exception/throw=] a {{TypeError}}.
-    1. If |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} from which the dimension represented by |options|.axis is removed, then [=exception/throw=] a {{TypeError}}.
+    1. If the [=list/size=] of |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
+    1. If the [=list/size=] of |variance|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLBatchNormalizationOptions/scale}} [=map/exists=] and its [=list/size=] is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLBatchNormalizationOptions/bias}} [=map/exists=] and its [=list/size=] is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|, that may use the same underlying data as |input|.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |input|.{{MLOperand/[[descriptor]]}}, that may use the same underlying data as |input|.
         1. Make a request to the underlying platform to initialize the batch normalization:
             1. Create an [=implementation-defined=] platform operator |batchNormImpl| for this method, given |input|, |mean|, |variance| and |options|.
             1. If |options|.activation [=map/exists=],register it as activation to |batchNormImpl|.
@@ -3310,11 +3313,11 @@ The {{MLInstanceNormalizationOptions}} members are:
 <dl dfn-type=dict-member dfn-for=MLInstanceNormalizationOptions>
     : <dfn>scale</dfn>
     ::
-        An {{MLOperand}}. Specifies he 1-D tensor of the scaling values whose length is equal to the number of channels, i.e. the size of the feature dimension of the input. For example, for an |input| tensor with `nchw` layout, the length is the value of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1].
+        An {{MLOperand}}. Specifies he 1-D tensor of the scaling values whose [=list/size=] is equal to the number of channels, i.e. the size of the feature dimension of the input. For example, for an |input| tensor with `nchw` layout, the [=list/size=] is the value of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1].
 
     : <dfn>bias</dfn>
     ::
-        An {{MLOperand}}. Specifies the 1-D tensor of the bias values whose length is equal to the size of the feature dimension of the input. For example, for an |input| tensor with `nchw` layout, the length is the value of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1].
+        An {{MLOperand}}. Specifies the 1-D tensor of the bias values whose [=list/size=] is equal to the size of the feature dimension of the input. For example, for an |input| tensor with `nchw` layout, the len[=list/size=]gth is the value of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1].
 
     : <dfn>epsilon</dfn>
     ::

--- a/index.bs
+++ b/index.bs
@@ -1807,10 +1807,16 @@ partial interface MLGraphBuilder {
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |mean| and |variance| is {{MLOperand}}.
     1. If |options|.axis is not in [=the range=] 0 to the [=rank=] of |input|, exclusive, then [=exception/throw=] a {{TypeError}}.
-    1. If the [=list/size=] of |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
-    1. If the [=list/size=] of |variance|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
-    1. If |options|.{{MLBatchNormalizationOptions/scale}} [=map/exists=] and its [=list/size=] is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
-    1. If |options|.{{MLBatchNormalizationOptions/bias}} [=map/exists=] and its [=list/size=] is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
+    1. If the [=list/size=] of |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}}.
+    1. If |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not equal to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
+    1. If the [=list/size=] of |variance|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}}.
+    1. If |variance|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not equal to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLBatchNormalizationOptions/scale}} [=map/exists=]:
+        1. If its [=list/size=] is not 1, then [=exception/throw=] a {{TypeError}}.
+        1. If |options|.{{MLBatchNormalizationOptions/scale}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not equal to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLBatchNormalizationOptions/bias}} [=map/exists=]:
+        1. If its [=list/size=] is not 1, then [=exception/throw=] a {{TypeError}}.
+        1. If |options|.{{MLBatchNormalizationOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not equal to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |input|.{{MLOperand/[[descriptor]]}}, that may use the same underlying data as |input|.
         1. Make a request to the underlying platform to initialize the batch normalization:

--- a/index.bs
+++ b/index.bs
@@ -4330,6 +4330,8 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: |op| is one of "averagePool2d", "l2Pool2d", "maxPool2d".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |options|.{{MLPool2dOptions/windowDimensions}} [=map/exists=] and its [=list/size=] is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Otherwise, set |options|.{{MLPool2dOptions/windowDimensions}} to the height and width dimensions of the shape of |input|.
     1. If |options|.{{MLPool2dOptions/outputSizes}} [=map/exists=], or if |options|.{{MLPool2dOptions/padding}} does not [=map/exist=], set |options|.{{MLPool2dOptions/padding}} to `« 0, 0, 0, 0 »`.
     1. If the len[=list/size=]gth of |options|.{{MLPool2dOptions/padding}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLPool2dOptions/strides}} does not [=map/exist=], set |options|.{{MLPool2dOptions/strides}} to `« 1, 1 »`.

--- a/index.bs
+++ b/index.bs
@@ -996,7 +996,6 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
     To <dfn>check dimensions</dfn> given |dimensions| and |type|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. If |dimensions| is not an array of positive numbers, return `false`;
     1. If the [=list/size=] of |dimensions| is 0, return `false`.
     1. If the [=list/size=] of |dimensions| is too large to be supported by the implementation, return `false`.
     1. If any element of |dimensions| is not a positive number, or it is too large to be supported by the implementation given |type|, return `false`.
@@ -1734,8 +1733,6 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
-    1. If |value| is not a [=number=], then [=exception/throw=] a {{TypeError}}.
-    1. Otherwise, if |type| is not one of {{MLOperandType}}, then  [=exception/throw=] a {{TypeError}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
         1. Set |descriptor|.{{MLOperandDescriptor/type}} to |type|.
         1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to `undefined`.
@@ -1809,7 +1806,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |mean| and |variance| is {{MLOperand}}.
-    1. If |options|.axis is not a number in [=the range=] 0 to the [=rank=] of |input|, exclusive, then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.axis is not in [=the range=] 0 to the [=rank=] of |input|, exclusive, then [=exception/throw=] a {{TypeError}}.
     1. If the [=list/size=] of |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
     1. If the [=list/size=] of |variance|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLBatchNormalizationOptions/scale}} [=map/exists=] and its [=list/size=] is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
@@ -1885,6 +1882,7 @@ partial interface MLGraphBuilder {
       }
     }
   </pre>
+</details>
 </div>
 
 <details open algorithm>
@@ -2905,9 +2903,7 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLGruOptions/initialHiddenState}} [=map/exists=].
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |options|.{{MLGruOptions/direction}} is not one of {{MLRecurrentNetworkDirection}}, then [=exception/throw=] a {{TypeError}}.
-    1. If |options|.{{MLGruOptions/layout}} is not one of {{MLGruWeightLayout}}, then [=exception/throw=] a {{TypeError}}.
-    1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of {{MLActivation}} objects with size `2`, then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and its [=list/size=] is not 2, then [=exception/throw=] a {{TypeError}}.
     1. If |steps| is not equal to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0], then [=exception/throw=] a {{TypeError}}.
     1. Let |output| be an empty sequence of {{MLOperand}} objects.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -3054,8 +3050,7 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLGruOptions/recurrentBias}} [=map/exists=]:
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not equal to 3 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |options|.{{MLGruOptions/layout}} is not one of {{MLGruWeightLayout}}, then [=exception/throw=] a {{TypeError}}.
-    1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of {{MLActivation}} objects with size `2`, then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and its [=list/size=] is not 2, then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |input|.{{MLOperandDescriptor/dimensions}}[0], |hiddenSize| ].
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
@@ -3348,7 +3343,6 @@ partial interface MLGraphBuilder {
     1. Return |op|.
  </div>
 </details>
-</div>
 
 ### The instanceNormalization() method ### {#api-mlgraphbuilder-instancenorm}
 Normalize the input features using [[Instance-Normalization]]. Unlike [[#api-mlgraphbuilder-batchnorm]] where the mean and variance values used in the calculation are previously computed across the batch dimension during the model training phase, the mean and variance values used in the calculation of an instance normalization are computed internally on the fly per input feature.
@@ -3407,7 +3401,6 @@ The {{MLInstanceNormalizationOptions}} members are:
     1. If the [=rank=] of |options|.{{MLInstanceNormalizationOptions/scale}} is not equal to the [=list/size=] of the channel dimension of |input|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=Assert=]: the type of |options|.{{MLInstanceNormalizationOptions/bias}} is  {{MLOperand}}.
     1. If the [=rank=] of |options|.{{MLInstanceNormalizationOptions/bias}} is not equal to the [=list/size=] of the channel dimension of |input|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. Otherwise if |options|.{{MLInstanceNormalizationOptions/layout}} is not one of {{MLInputOperandLayout}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
@@ -3724,7 +3717,6 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>lstm(|input|, |weight|, |recurrentWeight|, |steps|, |hiddenSize|, |options|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. If |options|.{{MLLstmOptions/direction}} is not one of {{MLRecurrentNetworkDirection}}, then [=exception/throw=] a {{TypeError}}.
     1. Let |numDirections| be `1` if |options|.{{MLLstmOptions/direction}} is `"forward"`, or otherwise let it be `2`.
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
         <div class="note">
@@ -3759,9 +3751,8 @@ partial interface MLGraphBuilder {
         1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |numDirections|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to |batchSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[2] is not |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |options|.{{MLLstmOptions/layout}} is not one of {{MLLstmWeightLayout}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLLstmOptions/activations}} [=map/exists=]:
-        1. If it is not an array of size `3`, then [=exception/throw=] a {{TypeError}}.
+        1. If its [=list/size=] is not 3, then [=exception/throw=] a {{TypeError}}.
         1. [=Assert=]: the type of its elements is {{MLActivation}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |desc| a new {{MLOperandDescriptor}}.
@@ -3942,9 +3933,8 @@ partial interface MLGraphBuilder {
         1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `1`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLstmCellOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not 3 * |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |options|.{{MLLstmCellOptions/layout}} is not one of {{MLLstmWeightLayout}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLLstmCellOptions/activations}} [=map/exists=]:
-        1. If it is not an array of size `3`, then [=exception/throw=] a {{TypeError}}.
+        1. If its [=list/size=] is not 3, then [=exception/throw=] a {{TypeError}}.
         1. [=Assert=]: the type of its elements is {{MLActivation}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |batchSize|, |hiddenSize| ].
@@ -4221,7 +4211,6 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If |options|.{{MLPadOptions/mode}} is not one of {{MLPaddingMode}}, then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of invoking the <a>calculate padding output sizes</a> steps given |input|, |beginningPadding| and |endingPadding|.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -4790,7 +4779,6 @@ partial interface MLGraphBuilder {
     To <dfn for="MLGraphBuilder">check resample options</dfn> given |options|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. If |options|.{{MLResample2dOptions/mode}} [=map/exists=], and if its value is not one of `"nearest-neighbor"` or `"linear"`, return `false`.
     1. If |options|.{{MLResample2dOptions/scales}} does not [=map/exist=], set it to to `« 1.0, 1.0 »`.
     1. Otherwise, if any of its values is not greater than `0`, return `false`.
     1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], and if its size is not `2`, or if any of its values is not greater than `0`, return `false`.
@@ -5289,7 +5277,6 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If |splits| is not a non-zero {{unsigned long}} or a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}}.
     1. If |splits| is an {{unsigned long}}, and |input|.{{MLOperandDescriptor/dimensions}}[|options|.{{MLSplitOptions/axis}}] % |splits| is not 0, then [=exception/throw=] a {{TypeError}}.
     1. If |splits| is a sequence of {{unsigned long}}, and the sum of its elements is not equal to |input|.{{MLOperandDescriptor/dimensions}}[|options|.{{MLSplitOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.

--- a/index.bs
+++ b/index.bs
@@ -1846,7 +1846,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=batchnorm class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |mean| and |variance| is {{MLOperand}}.
-    1. If |options|.axis is not a number between 0 and the [=rank=] of |input|, then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.axis is not a number in [=the range=] 0 to the [=rank=] of |input|, exclusive, then [=exception/throw=] a {{TypeError}}.
     1. If the [=list/size=] of |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
     1. If the [=list/size=] of |variance|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLBatchNormalizationOptions/scale}} [=map/exists=] and its [=list/size=] is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
@@ -2022,9 +2022,9 @@ partial interface MLGraphBuilder {
         1. Let |desc| be |inputs|[0].{{MLOperand/[[descriptor]]}}.
         1. If |axis| is greater than or equal to the [=rank=] of |desc|, fail.
         1. Let |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] be `0`.
-        1. [=map/For each=] |index| between 0 and the [=rank=] of |inputs|:
+        1. [=map/For each=] |index| in [=the range=] 0 to the [=rank=] of |inputs|, exclusive:
             1. If <a>validating MLOperand</a> given |inputs|[|index|] and [=this=] returns `false`, then fail.
-            1. [=map/For each=] |dim| between 0 and the [=rank=] of |inputs|[|index|].{{MLOperandDescriptor/dimensions}}:
+            1. [=map/For each=] |dim| in [=the range=] 0 to the [=rank=] of |inputs|[|index|].{{MLOperandDescriptor/dimensions}}, exclusive:
                 <div class="note">
                     If the shape of each corresponding dimension and type of the operands, except for those of the dimension given by |axis|, is not the same, fail.
                 </div>
@@ -4100,7 +4100,7 @@ partial interface MLGraphBuilder {
     1. If | sizeA| is `1` and |sizeB| is not, then insert `1` in the front of |shapeA| to become [ 1 | |shapeA| ] and let |sizeA| be `2`.
     1. If | sizeB| is `1` and |sizeA| is not, then insert `1` in the front of |shapeB| to become [ 1 | |shapeB| ] and let |sizeB| be `2`.
     1. Let |shape| be an array whose size |size| is the maximum of |sizeA| and |sizeB|.
-    1. [=map/For each=] |index| between 0 and |size|:
+    1. [=map/For each=] |index| in [=the range=] 0 to |size|, exclusive:
        1. Set |shape|[|index|] to the maximum of |shapeA|[|index|] and |shapeB|[|index|].
     1. Return |shape|.
   </div>
@@ -4185,7 +4185,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. Let |shape| be a copy of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-    1. For |index| between `0` and the [=rank=] of |shape|:
+    1. For |index| in [=the range=] 0 to the [=rank=] of |shape|, exclusive:
         1. Add to |shape|[|index|] the value of |beginningPadding|[|index|].
         1. Add to |shape|[|index|] the value of |endingPadding|[|index|].
     1. Return |shape|.
@@ -4759,7 +4759,7 @@ partial interface MLGraphBuilder {
   <div algorithm=resample-output-sizes class=algorithm-steps>
     1. Let |desc| be an {{MLOperandDescriptor}} initialized to |input|.{{MLOperand/[[descriptor]]}}.
     1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], then set |desc|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} to |options|.{{MLResample2dOptions/sizes}} and return |desc|.
-    1. For |index| between `0` and the [=rank=] of |desc|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}:
+    1. For |index| in [=the range=] 0 to the [=rank=] of |desc|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, exclusive:
         1. Let |inputSize| be the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|index|].
         1. Let |outputSize| be |inputSize| multiplied by |options|.{{MLResample2dOptions/scales}}.
             1. If that fails or |outputSize| is not a positive [=number=], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -5309,7 +5309,7 @@ partial interface MLGraphBuilder {
         1. Let |dimensions| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. Let |axesLength| be the [=list/size=] of |options|.{{MLSqueezeOptions/axes}}.
         1. If |axesLength| is not smaller than the <a>rank</a> of |dimensions|,
-        1. For |index| between 0 and |axesLength|:
+        1. For |index| in [=the range=] 0 to |axesLength|, exclusive:
             1. Let |oneDimIndex| be |options|.{{MLSqueezeOptions/axes}}[|index|].
             1. If |dimensions|[|oneDimIndex|] is not `1`, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -5437,7 +5437,7 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLTransposeOptions/permutation}} does not [=map/exist=], let |options|.{{MLTransposeOptions/permutation}} be the reversed sequence of all indices for |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Otherwise if |options|.{{MLTransposeOptions/permutation}} [=map/exists=]:
         1. If the [=rank=] of |options|.{{MLTransposeOptions/permutation}} is not the same as the [=rank=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a {{TypeError}}.
-        1. If the values in |options|.{{MLTransposeOptions/permutation}} are not between `0` and the [=rank=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} minus `1`, then [=exception/throw=] a {{TypeError}}.
+        1. If the values in |options|.{{MLTransposeOptions/permutation}} are not in [=the range=] 0 and the [=rank=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} exclusive, then [=exception/throw=] a {{TypeError}}.
         1. If the values in |options|.{{MLTransposeOptions/permutation}} contain duplicate value, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.

--- a/index.bs
+++ b/index.bs
@@ -1059,7 +1059,7 @@ The {{MLActivation}} objects (including the ones passed as input to methods) are
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |builder| is {{MLGraphBuilder}}.
-    1. If |name| is empty, then [=exception/throw=] a "{{TypeError}}" and abort these steps.
+    1. If |name| is empty, then [=exception/throw=] a "{{TypeError}}".
     1. Let |activation| be a new [=object=].
     1. Set |activation|.{{MLActivation/[[builder]]}} to |builder|.
     1. Set |activation|.{{MLActivation/[[name]]}} to |name|.
@@ -1586,7 +1586,7 @@ Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGr
   </summary>
   <div class=algorithm-steps>
     1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, then [=exception/throw=] a "{{SecurityError}}" {{DOMException}}.
-    1. If <a>validating MLContext</a> given |context| returns false, then [=exception/throw=] a "{{TypeError}}" and abort these steps.
+    1. If <a>validating MLContext</a> given |context| returns false, then [=exception/throw=] a "{{TypeError}}".
     1. Set {{MLGraphBuilder/[[context]]}} to |context|.
   </div>
 </details>
@@ -4217,6 +4217,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
+    1. If the [=list/size=] of |beginningPadding| and |endingPadding| is not equal to the [=rank=] of |input|, then then [=exception/throw=] a "{{TypeError}}".
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of invoking the <a>calculate padding output sizes</a> steps given |input|, |beginningPadding| and |endingPadding|.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -4786,7 +4787,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. If |options|.{{MLResample2dOptions/scales}} does not [=map/exist=], set it to to `« 1.0, 1.0 »`.
-    1. Otherwise, if any of its values is not greater than 0, return false.
+    1. Otherwise, if any of its values is not greater than 0, or if its [=list/size=] is not 2, return false.
     1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], and if its size is not 2, or if any of its values is not greater than 0, return false.
     1. If |options|.{{MLResample2dOptions/axes}} does not [=map/exists=], set it to `« 2, 3 »`.
     1. Otherwise, if its value is not one of `« 0, 1», « 1, 2», « 2, 3 »`, return false.
@@ -4802,11 +4803,9 @@ partial interface MLGraphBuilder {
   <div class=algorithm-steps>
     1. Let |desc| be an {{MLOperandDescriptor}} initialized to |input|.{{MLOperand/[[descriptor]]}}.
     1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], then set |desc|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} to |options|.{{MLResample2dOptions/sizes}} and return |desc|.
-    1. For |index| in [=the range=] 0 to the [=rank=] of |desc|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, exclusive:
+    1. For |index| in [=the range=] 0 to the [=list/size=] of |options|.{{MLResample2dOptions/axes}}, exclusive:
         1. Let |inputSize| be the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|index|].
-        1. Let |outputSize| be |inputSize| multiplied by |options|.{{MLResample2dOptions/scales}}.
-            1. If that fails or |outputSize| is not a positive [=number=], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. Set |desc|.{{MLOperandDescriptor/dimensions}}[|index|] to |outputSize|.
+        1. Set |desc|.{{MLOperandDescriptor/dimensions}}[|index|] to |inputSize| multiplied by |options|.{{MLResample2dOptions/scales}}.
     1. Return |desc|.
   </div>
 </details>
@@ -4817,7 +4816,7 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>resample2d(|input|, |options|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. Check if the input is a 4-dimensional tensor: if the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If running the <a>check resample options</a> steps given |options| returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| be the result of running the <a>resample output sizes</a> steps given |options|.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.

--- a/index.bs
+++ b/index.bs
@@ -810,8 +810,7 @@ Its <a>default allowlist</a> is <code>'self'</code>.
 
 ### The {{ML/createContext()}} method ### {#api-ml-createcontext}
 
-<div algorithm>
-<details open>
+<details open algorithm>
 <summary>
     To <dfn>create a context</dfn> given |options|, run these steps:
 </summary>
@@ -828,10 +827,8 @@ Its <a>default allowlist</a> is <code>'self'</code>.
     1. Return |context|.
 </div>
 </details>
-</div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
 <summary>
     The <dfn method for=ML>createContext(|options|)</dfn> steps are:
 </summary>
@@ -844,10 +841,8 @@ Its <a>default allowlist</a> is <code>'self'</code>.
     1. [=Resolve=] |promise| with |context|.
 </div>
 </details>
-</div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
 <summary>
     The <dfn method for=ML>createContext(|gpuDevice|)</dfn> method steps are:
 </summary>
@@ -860,12 +855,10 @@ Its <a>default allowlist</a> is <code>'self'</code>.
     1. [=Resolve=] |promise| with |context|.
 </div>
 </details>
-</div>
 
 ### The {{ML/createContextSync()}} method ### {#api-ml-createcontextsync}
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
     The <dfn method for=ML>createContextSync(|options|)</dfn> method steps are:
   </summary>
@@ -876,10 +869,8 @@ Its <a>default allowlist</a> is <code>'self'</code>.
     1. Return |context|.
   </div>
 </details>
-</div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
     The <dfn method for=ML>createContextSync(|gpuDevice|)</dfn> method steps are:
   </summary>
@@ -890,7 +881,6 @@ Its <a>default allowlist</a> is <code>'self'</code>.
     1. Return |context|.
   </div>
 </details>
-</div>
 
 ## The MLGraph interface ## {#api-mlgraph}
 The {{MLGraph}} interface represents a compiled computational graph. A compiled graph once constructed is immutable and cannot be subsequently changed.
@@ -946,7 +936,7 @@ dictionary MLOperandDescriptor {
 };
 </script>
 
-<details open>
+<details open algorithm>
   <summary>
     The <dfn for="MLOperandDescriptor">byte length</dfn> of an {{MLOperandDescriptor}} |desc| is the value returned by the following steps:
   </summary>
@@ -1007,7 +997,7 @@ Since the {{MLOperand/[[builder]]}} object is bound by the {{MLGraphBuilder/cons
 #### Creating {{MLOperand}} #### {#api-mloperand-create}
 The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, internally using the following algorithms.
 
-<details open>
+<details open algorithm>
   <summary>
     To <dfn>create an MLOperand</dfn> given |builder| and |desc|, run the following steps:
   </summary>
@@ -1021,7 +1011,7 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
   </div>
 </details>
 
-<details open>
+<details open algorithm>
   <summary>
     To <dfn>copy an MLOperand</dfn> given |operand|, run the following steps:
   </summary>
@@ -1035,7 +1025,7 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
   </div>
 </details>
 
-<details open>
+<details open algorithm>
   <summary>
     To <dfn>check dimensions</dfn> given |dimensions| and |type|, run the following steps:
   </summary>
@@ -1048,7 +1038,7 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
   </div>
 </details>
 
-<details open>
+<details open algorithm>
   <summary>
     To <dfn for="MLOperand">validate MLOperand</dfn> given |operand| and |builder|, run the following steps:
   </summary>
@@ -1098,7 +1088,7 @@ These activations function types are used to create other operations. One such u
 The {{MLActivation}} objects (including the ones passed as input to methods) are created by the methods of {{MLGraphBuilder}} and are identified by their name. The |options| dictionary is defined by those methods. The actual creation of the activation function e.g. a [[#api-mlgraphbuilder-sigmoid-method]] or [[#api-mlgraphbuilder-relu-method]] can then be deferred until when the rest of the graph is ready to connect with it such as during the construction of [[#api-mlgraphbuilder-conv2d]] for example.
 </div>
 
-<details open>
+<details open algorithm>
   <summary>
     To <dfn>create an MLActivation</dfn> given |builder|, |name|, |options| and |init-steps|, run the following steps:
   </summary>
@@ -1175,7 +1165,8 @@ When the {{[[contextType]]}} is set to [=default-context|default=] with the {{ML
 </div>
 
 ### The {{MLContext}} validation algorithm ### {#api-mlcontext-validate}
-<details open>
+
+<details open algorithm>
   <summary>
     To <dfn>validate MLContext</dfn>, given |context|, run these steps:
   </summary>
@@ -1208,8 +1199,7 @@ partial interface MLContext {
     **Returns:** {{undefined}}.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
     The <dfn method for=MLContext>computeSync(|graph|, |inputs|, |outputs|)</dfn> method steps are:
   </summary>
@@ -1224,7 +1214,7 @@ partial interface MLContext {
 </details>
 </div>
 
-<details open>
+<details open algorithm>
   <summary>
     To <dfn>validate graph resources</dfn>, given |resources| and |descriptors|, run the following steps:
   </summary>
@@ -1238,7 +1228,7 @@ partial interface MLContext {
   </div>
 </details>
 
-<details open>
+<details open algorithm>
   <summary>
     To <dfn>validate buffer with descriptor</dfn> given |bufferView| and |descriptor|, run the following steps:
   </summary>
@@ -1249,7 +1239,7 @@ partial interface MLContext {
   </div>
 </details>
 
-<details open>
+<details open algorithm>
   <summary>
     To <dfn>execute graph</dfn>, given |graph|, |inputs| and |outputs|, run the following steps:
   </summary>
@@ -1317,7 +1307,8 @@ partial interface MLContext {
 </div>
 
 ### The {{MLNamedArrayBufferViews}} transfer algorithm ### {#mlnamedarraybufferviews-transfer-alg}
-<details open>
+
+<details open algorithm>
   <summary>
     To <dfn for="MLNamedArrayBufferViews">transfer</dfn> an {{MLNamedArrayBufferViews}} |views|:
   </summary>
@@ -1360,8 +1351,7 @@ partial interface MLContext {
     **Returns:** Promise<{{MLComputeResult}}>.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
     The <dfn method for=MLContext>compute(|graph|, |inputs|, |outputs|)</dfn> method steps are:
   </summary>
@@ -1471,10 +1461,9 @@ partial interface MLCommandEncoder {
     **Returns:** {{undefined}}.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
-    The <dfn method for=MLCommandEncoder>initializeGraph(|graph|)</dfn> method steps are:
+    The <dfn method for=MLCommandEncoder>initializeGraph(<var ignore>graph</var>)</dfn> method steps are:
   </summary>
   <div>
     <div class="note">
@@ -1502,8 +1491,7 @@ partial interface MLCommandEncoder {
     **Returns:** {{undefined}}.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
     The <dfn method for=MLCommandEncoder>dispatch(|graph|, |inputs|, |outputs|)</dfn> method steps are:
   </summary>
@@ -1549,8 +1537,7 @@ partial interface MLCommandEncoder {
     **Returns:** {{GPUCommandBuffer}}.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
     The <dfn method for=MLCommandEncoder>finish(|descriptor|)</dfn> method steps are:
   </summary>
@@ -1633,8 +1620,7 @@ Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGr
 
 ### The {{MLGraphBuilder}} constructor ### {#api-mlgraphbuilder-constructor}
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
     The [=new=] <dfn constructor for=MLGraphBuilder lt="MLGraphBuilder(context)">MLGraphBuilder(context)</dfn> constructor steps are:
   </summary>
@@ -1656,8 +1642,7 @@ Create a named {{MLOperand}} based on a descriptor, that can be used as an input
     **Returns:**: an {{MLOperand}} object.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
     The <dfn method for=MLGraphBuilder>input(|name|, |descriptor|)</dfn> method steps are:
   </summary>
@@ -1688,8 +1673,7 @@ Build a composed graph up to a given output operand into a computational graph, 
 
 #### The {{MLGraphBuilder/build(outputs)}} method #### {#api-mlgraphbuilder-build-outputs}
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
     The <dfn method for=MLGraphBuilder>build(|outputs|)</dfn> method steps are:
   </summary>
@@ -1707,8 +1691,7 @@ Build a composed graph up to a given output operand into a computational graph, 
 
 #### The {{MLGraphBuilder/buildSync(outputs)}} method #### {#api-mlgraphbuilder-buildsync-outputs}
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
     The <dfn method for=MLGraphBuilder>buildSync(|outputs|)</dfn> method steps are:
   </summary>
@@ -1754,8 +1737,7 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
     **Returns:**: an {{MLOperand}} object.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
     The <dfn method for=MLGraphBuilder>constant(|descriptor|, |bufferView|)</dfn> method steps are:
   </summary>
@@ -1788,8 +1770,7 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
     **Returns:**: an {{MLOperand}} object.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
     The <dfn method for=MLGraphBuilder>constant(|value|, |type|)</dfn> method steps are:
   </summary>
@@ -1867,8 +1848,7 @@ partial interface MLGraphBuilder {
     **Returns:** an {{MLOperand}}. The batch-normalized N-D tensor of the same shape as *input*.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
     The <dfn method for=MLGraphBuilder>batchNormalization(|input|, |mean|, |variance|, |options|)</dfn> method steps are:
   </summary>
@@ -1953,7 +1933,7 @@ partial interface MLGraphBuilder {
   </pre>
 </div>
 
-<details open>
+<details open algorithm>
   <summary>
     To <dfn>check clamp options</dfn> given |options|, run the following steps:
   </summary>
@@ -1974,8 +1954,8 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *operand*.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>clamp(|operand|, |options|)</dfn> method steps are:
   </summary>
@@ -2006,8 +1986,8 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The operator representing the clamp operation.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>clamp(|options|)</dfn> method steps are:
   </summary>
@@ -2039,8 +2019,8 @@ partial interface MLGraphBuilder {
     computed as the sum of all the input sizes of the same dimension.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>concat(|inputs|, |axis|)</dfn> method steps are:
   </summary>
@@ -2199,8 +2179,8 @@ partial interface MLGraphBuilder {
     for *"oihw"* layout, [height, width, 1, options.groups] for *"hwio"* layout, [options.groups, height, width, 1] for *"ohwi"* layout and [1, height, width, options.groups] for *"ihwo"* layout.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>conv2d(|input|, |filter|, |options|)</dfn> method steps are:
   </summary>
@@ -2376,8 +2356,8 @@ partial interface MLGraphBuilder {
     *output_size = (input_size - 1) ** *stride + (filter_size - 1) ** *dilation + 1 - beginning_padding - ending_padding + output_padding*
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>convTranspose2d(|input|, |filter|, |options|)</dfn> method steps are:
   </summary>
@@ -2467,8 +2447,8 @@ partial interface MLGraphBuilder {
         - *pow*: Compute the values of the values of the first input tensor to the power of the values of the second input tensor, element-wise.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="element-wise-binary-op">create element-wise binary operation</dfn> given |op|, |a| and |b|, run the following steps:
   </summary>
@@ -2494,8 +2474,8 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     To <dfn for="MLGraphBuilder">broadcast-shapes</dfn> given |shape1| and |shape2|, run the following steps:
   </summary>
@@ -2604,8 +2584,8 @@ partial interface MLGraphBuilder {
         - *tan*: Compute the tangent of the input tensor, element-wise.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="element-wise-unary-op">create element-wise unary operation</dfn> given |op| and |input|, run the following steps:
   </summary>
@@ -2741,8 +2721,8 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>elu(|input|, |options|)</dfn> method steps are:
   </summary>
@@ -2771,8 +2751,8 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the elu operation.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>elu(|options|)</dfn> method steps are:
   </summary>
@@ -2832,8 +2812,8 @@ partial interface MLGraphBuilder {
     **Returns:** an {{MLOperand}}. The output 2-D tensor of shape [M, N] that contains the calculated product of all the inputs.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>gemm(|a|, |b|, |options|)</dfn> method steps are:
   </summary>
@@ -2965,8 +2945,8 @@ partial interface MLGraphBuilder {
     **Returns:** a sequence of {{MLOperand}}. The first element of the sequence is a 3-D tensor of shape [num_directions, batch_size, hidden_size], the cell output from the last time step of the network. Additionally, if |options|.{{MLGruOptions/returnSequence}} is set to `true`, the second element is the 4-D output tensor of shape [steps, num_directions, batch_size, hidden_size] containing every cell outputs from each time step in the temporal sequence.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>gru(|input|, |weight|, |recurrentWeight|, |steps|, |hiddenSize|, |options|)</dfn> method steps are:
   </summary>
@@ -3117,8 +3097,8 @@ partial interface MLGraphBuilder {
     **Returns:** an {{MLOperand}}. The 2-D tensor of shape [batch_size, hidden_size], the cell output hidden state of a single time step of the recurrent network.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
      The <dfn method for=MLGraphBuilder>gruCell(|input|, |weight|, |recurrentWeight|, |hiddenState|, |hiddenSize|, |options|)</dfn> method steps are:
   </summary>
@@ -3308,8 +3288,8 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>hardSigmoid(|input|, |options|)</dfn> method steps are:
   </summary>
@@ -3338,8 +3318,8 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the hard sigmoid operation.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>hardSigmoid(|options|)</dfn> method steps are:
   </summary>
@@ -3391,8 +3371,8 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>hardSwish(|input|)</dfn> method steps are:
   </summary>
@@ -3420,10 +3400,9 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the hard-swish operation.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
-    The <dfn method for=MLGraphBuilder>hardSwish()</dfn> method steps are:
+    The <dfn method for=MLGraphBuilder id=hardswish-noargs>hardSwish()</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"hardSwish"`.
@@ -3478,8 +3457,8 @@ The {{MLInstanceNormalizationOptions}} members are:
     **Returns:** an {{MLOperand}}. The instance-normalized 4-D tensor of the same shape as *input*.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>instanceNormalization(|input|, |options|)</dfn> method steps are:
   </summary>
@@ -3590,8 +3569,8 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>leakyRelu(|input|, |options|)</dfn> method steps are:
   </summary>
@@ -3619,8 +3598,8 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the leaky relu operation.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>leakyRelu(|options|)</dfn> method steps are:
   </summary>
@@ -3685,8 +3664,8 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>linear(|input|, |options|)</dfn> method steps are:
   </summary>
@@ -3714,8 +3693,8 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the linear operation.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>linear(|options|)</dfn> method steps are:
   </summary>
@@ -3806,8 +3785,8 @@ partial interface MLGraphBuilder {
     **Returns:** a sequence of {{MLOperand}}. The first element of the sequence is a 3-D tensor of shape [num_directions, batch_size, hidden_size], the output hidden state from the last time step of the network. The second element is a 3-D tensor of shape [num_directions, batch_size, hidden_size], the output cell state from the last time step of the network. Additionally, if |options|.{{MLLstmOptions/returnSequence}} is set to true, the third element is the 4-D output tensor of shape [steps, num_directions, batch_size, hidden_size] containing every output from each time step in the temporal sequence.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>lstm(|input|, |weight|, |recurrentWeight|, |steps|, |hiddenSize|, |options|)</dfn> method steps are:
   </summary>
@@ -4010,8 +3989,8 @@ partial interface MLGraphBuilder {
     **Returns:** a sequence of {{MLOperand}}. The first element of the sequence is the output hidden state of the current time step of the recurrent network. The following element is the output cell state. Both elements are 2-D tensors of shape [batch_size, hidden_size].
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>lstmCell(|input|, |weight|, |recurrentWeight|, |hiddenState|, |cellState|, |hiddenSize|, |options|)</dfn> method steps are:
   </summary>
@@ -4197,8 +4176,7 @@ partial interface MLGraphBuilder {
         - If both *a* and *b* are 1-dimensional, the operation is a vector dot-product, which produces a scalar output.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
     To <dfn dfn-for=MLGraphBuilder>calculate matmul output sizes</dfn>, given |a| and |b| run the following steps:
   </summary>
@@ -4214,10 +4192,9 @@ partial interface MLGraphBuilder {
     1. Return |shape|.
   </div>
 </details>
-</div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>matmul(|a|, |b|)</dfn> method steps are:
   </summary>
@@ -4290,7 +4267,7 @@ partial interface MLGraphBuilder {
     *output size = beginning padding + input size + ending padding*
 </div>
 
-<details open>
+<details open algorithm>
   <summary>
     To <dfn dfn-for=MLGraphBuilder>calculate padding output sizes</dfn>, given |input|, |beginningPadding| and |endingPadding|, run the following steps:
   </summary>
@@ -4303,8 +4280,8 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>pad(|input|, |beginningPadding|, |endingPadding|, |options|)</dfn> method steps are:
   </summary>
@@ -4484,8 +4461,8 @@ partial interface MLGraphBuilder {
 
 </dl>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="pooling-op">create pooling operation</dfn> given |op|, |input| and |options|, run the following steps:
   </summary>
@@ -4566,8 +4543,8 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>prelu(|input|, |slope|)</dfn> method steps are:
   </summary>
@@ -4654,8 +4631,8 @@ partial interface MLGraphBuilder {
         - *SumSquare*: Compute the sum of the square of all the input values along the axes.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="reduce-op">create reduce operation</dfn> given |op|, |input| and |options|, run the following steps:
   </summary>
@@ -4784,8 +4761,8 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>relu(|input|)</dfn> method steps are:
   </summary>
@@ -4814,10 +4791,9 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the relu operation.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
-    The <dfn method for=MLGraphBuilder>relu()</dfn> method steps are:
+    The <dfn method for=MLGraphBuilder id=relu-noargs>relu()</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"relu"`.
@@ -4880,8 +4856,8 @@ partial interface MLGraphBuilder {
         The default value is [2, 3].
 </dl>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     To <dfn for="MLGraphBuilder">check resample options</dfn> given |options|, run the following steps:
   </summary>
@@ -4897,8 +4873,8 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     To <dfn for="MLGraphBuilder">resample output sizes</dfn> given |input| and |options|, run the following steps:
   </summary>
@@ -4915,8 +4891,8 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>resample2d(|input|, |options|)</dfn> method steps are:
   </summary>
@@ -4961,8 +4937,8 @@ partial interface MLGraphBuilder {
     tensor is specified by the *newShape* argument.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>reshape(|input|, |newShape|)</dfn> method steps are:
   </summary>
@@ -5030,8 +5006,8 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>sigmoid(|input|)</dfn> method steps are:
   </summary>
@@ -5060,10 +5036,9 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the sigmoid operation.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
-    The <dfn method for=MLGraphBuilder>sigmoid()</dfn> method steps are:
+    The <dfn method for=MLGraphBuilder id=sigmoid-noargs>sigmoid()</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"sigmoid"`.
@@ -5089,8 +5064,8 @@ partial interface MLGraphBuilder {
     **Returns:** an {{MLOperand}}. The output tensor of the same rank as the input tensor with tensor values stripped to the specified starting and ending indices in each dimension.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>slice(|input|, |starts|, |sizes|)</dfn> method steps are:
   </summary>
@@ -5152,8 +5127,8 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output 2-D tensor that contains the softmax results, of the same shape as *input*.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>softmax(|input|)</dfn> method steps are:
   </summary>
@@ -5183,10 +5158,9 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the softmax operation.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
-    The <dfn method for=MLGraphBuilder>softmax()</dfn> method steps are:
+    The <dfn method for=MLGraphBuilder id=softmax-noargs>softmax()</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given  and  `"softmax"`.
@@ -5246,8 +5220,8 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>softplus(|input|, |options|)</dfn> method steps are:
   </summary>
@@ -5275,8 +5249,8 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the softplus operation.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>softplus(|options|)</dfn> method steps are:
   </summary>
@@ -5320,8 +5294,8 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>softsign(|input|)</dfn> method steps are:
   </summary>
@@ -5350,10 +5324,9 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the softsign operation.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
-    The <dfn method for=MLGraphBuilder>softsign()</dfn> method steps are:
+    The <dfn method for=MLGraphBuilder id=softsign-noargs>softsign()</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"softsign"`.
@@ -5394,8 +5367,8 @@ partial interface MLGraphBuilder {
         The default value is `0`.
 </dl>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>split(|input|, |splits|, |options|)</dfn> method steps are:
   </summary>
@@ -5472,8 +5445,8 @@ partial interface MLGraphBuilder {
         When not specified, every shape dimensions of size 1 in the tensor are eliminated.
 </dl>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>squeeze(|input|, |options|)</dfn> method steps are:
   </summary>
@@ -5534,8 +5507,8 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
+
   <summary>
     The <dfn method for=MLGraphBuilder>tanh(|input|)</dfn> method steps are:
   </summary>
@@ -5564,10 +5537,9 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the tanh operation.
 </div>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
-    The <dfn method for=MLGraphBuilder>tanh()</div> method steps are:
+    The <dfn method for=MLGraphBuilder id=tanh-noargs>tanh()</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"tanh"`.
@@ -5607,8 +5579,7 @@ partial interface MLGraphBuilder {
         These default values cause the output to become a transposed tensor of the input. When specified, the number of values in the sequence must be the same as the [=rank=] of the input tensor, and the values in the sequence must be within the range from 0 to N-1 with no two or more same values found in the sequence.
 </dl>
 
-<div algorithm>
-<details open>
+<details open algorithm>
   <summary>
     The <dfn method for=MLGraphBuilder>transpose(|input|, |options|)</dfn> method steps are:
   </summary>

--- a/index.bs
+++ b/index.bs
@@ -1131,7 +1131,7 @@ When the {{[[contextType]]}} is set to [=default-context|default=] with the {{ML
     To <dfn lt="validate MLContext">validate MLContext</dfn>, given |context|, run these steps:
   </summary>
   <div class=algorithm-steps>
-    1. If |context|.{{[[contextType]]}} is not "[=webgpu-context|webgpu=]" or "[=default-context|default=], return `false`.
+    1. If |context|.{{[[contextType]]}} is not "[=webgpu-context|webgpu=]" or "[=default-context|default=]", return `false`.
     1. If |context|.{{[[deviceType]]}} is not "[=device-type-cpu|cpu=]" or "[=device-type-gpu|gpu=]", return `false`.
     1. If |context|.{{[[powerPreference]]}} is not "[=power-preference-default|default=]" or "[=power-preference-high-performance|high-performance=]" or "[=power-preference-low-power|low-power=]", return `false`.
     1. If the user agent cannot support |context|.{{[[contextType]]}}, |context|.{{[[deviceType]]}} and |context|.{{[[powerPreference]]}}, return `false`.
@@ -1164,7 +1164,7 @@ partial interface MLContext {
     The {{MLContext/computeSync(graph, inputs, outputs)}} method steps are:
   </summary>
   <div algorithm=mlcontext.computesync class=algorithm-steps>
-    1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=], [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=]", [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
     1. If <a>validating graph resources</a> given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns `false`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If <a>validating graph resources</a> given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns `false`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Invoke <a>execute graph</a> given |graph|, |inputs| and |outputs|.
@@ -1316,7 +1316,7 @@ partial interface MLContext {
   <div algorithm=mlcontext.compute class=algorithm-steps>
     1. Let |promise| be [=a new promise=].
     1. Return |promise| and run the following steps [=in parallel=]:
-        1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=], [=reject=] |promise| with an "{{OperationError}}" {{DOMException}}.
+        1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=]", [=reject=] |promise| with an "{{OperationError}}" {{DOMException}}.
         1. If <a>validating graph resources</a> given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns `false`, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}}.
         1. If <a>validating graph resources</a> given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns `false`, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}}.
         1. Let |transferredInputs| be the result of [=MLNamedArrayBufferViews/transfer|transferring=] {{MLNamedArrayBufferViews}} |inputs|.
@@ -1545,7 +1545,7 @@ interface MLGraphBuilder {
 </script>
 
 <div class="note">
-Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGraphBuilder/buildSync()}} methods compile the graph builder state up to the specified output operands into a compiled graph according to the type of {{MLContext}} that creates it. Since this operation can be costly in some machine configurations, the calling thread of the {{MLGraphBuilder}}.{{MLGraphBuilder/buildSync()}} method must only be a worker thread to avoid potential disruption of the user experience. When the {{[[contextType]]}} of the {{MLContext}} is set to [=default-context|default=], the compiled graph is initialized right before the {{MLGraph}} is returned. This graph initialization stage is important for optimal performance of the subsequent graph executions. See [[#api-mlcommandencoder-graph-initialization]] for more detail.
+Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGraphBuilder/buildSync()}} methods compile the graph builder state up to the specified output operands into a compiled graph according to the type of {{MLContext}} that creates it. Since this operation can be costly in some machine configurations, the calling thread of the {{MLGraphBuilder}}.{{MLGraphBuilder/buildSync()}} method must only be a worker thread to avoid potential disruption of the user experience. When the {{[[contextType]]}} of the {{MLContext}} is set to "[=default-context|default=]", the compiled graph is initialized right before the {{MLGraph}} is returned. This graph initialization stage is important for optimal performance of the subsequent graph executions. See [[#api-mlcommandencoder-graph-initialization]] for more detail.
 </div>
 
 {{MLBufferResourceView}} has the following members:
@@ -1698,7 +1698,7 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
     1. If <a>validating buffer with descriptor</a> given |bufferView| and |descriptor| returns `false`, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
-        1. Let |bytes| be the result of invoking the [[=get a copy of the bytes held by the buffer source=]] steps given |bufferView|.
+        1. Let |bytes| be the result of invoking the [=get a copy of the bytes held by the buffer source=] steps given |bufferView|.
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform operand |constantImpl| to represent a constant, given |descriptor|.
             1. Store a reference of |constantImpl| in |operand|.{{MLOperand/[[operand]]}}.
@@ -4148,7 +4148,6 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=pad class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If |beginningPadding| or |endingPadding| is not a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLPadOptions/mode}} is not one of {{MLPaddingMode}}, then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of invoking the <a>calculate padding output sizes</a> steps given |input|, |beginningPadding| and |endingPadding|.
@@ -4891,7 +4890,6 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=slice class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If |starts| or |sizes| is not a sequence of {{long}}, then [=exception/throw=] a {{TypeError}}.
     1. If |sizes|.size is 0, then [=exception/throw=] a {{TypeError}}.
     1. If the [=list/size=] of |starts| and |sizes| is not equal to the <a>rank</a> of |input|, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -5388,7 +5386,6 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |options|.{{MLTransposeOptions/permutation}} does not [=map/exist=], let |options|.{{MLTransposeOptions/permutation}} be the reversed sequence of all indices for |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Otherwise if |options|.{{MLTransposeOptions/permutation}} [=map/exists=]:
-        1. If |options|.{{MLTransposeOptions/permutation}} is not a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}}.
         1. If the [=rank=] of |options|.{{MLTransposeOptions/permutation}} is not the same as the [=rank=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a {{TypeError}}.
         1. If the values in |options|.{{MLTransposeOptions/permutation}} are not between `0` and the [=rank=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} minus `1`, then [=exception/throw=] a {{TypeError}}.
         1. If the values in |options|.{{MLTransposeOptions/permutation}} contain duplicate value, then [=exception/throw=] a {{TypeError}}.

--- a/index.bs
+++ b/index.bs
@@ -1005,7 +1005,7 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |operand|.{{MLOperand/[[builder]]}} is {{MLGraphBuilder}}.
-    1. If |builder| [=map/exists=]] and is not equal to |operand|.{{MLOperand/[[builder]]}}, return `false`.
+    1. If |builder| is not equal to |operand|.{{MLOperand/[[builder]]}}, return `false`.
     1. Let |desc| be |operand|.{{MLOperand/[[descriptor]]}}.
     1. If |desc|.{{MLOperandDescriptor/dimensions}} [=map/exists=] and invoking <a>check dimensions</a> given |desc|.{{MLOperandDescriptor/dimensions}} and |desc|.{{MLOperandDescriptor/type}} returns `false`, then return `false`.
     1. Return `true`.
@@ -1799,7 +1799,6 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=batchnorm class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |mean| and |variance| is {{MLOperand}}.
-    1. [=Assert=]: the type of |mean| is
     1. If |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} from which the dimension represented by |options|.axis is removed, then  [=exception/throw=] a {{TypeError}} and abort these steps.
     1. If |options|.axis is not a number between 0 and the rank of |input|, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. If |input| is a 4-D tensor of the *"nchw"* layout, set |options|.axis to 1.
@@ -2507,7 +2506,6 @@ partial interface MLGraphBuilder {
   <div algorithm=unary class=algorithm-steps>
     1. [=Assert=]: |op| is one of "abs", "ceil", "cos", "exp", "floor", "log", "neg", "sin", "tan".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. Let |kind| be `"output"`.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
@@ -2616,7 +2614,7 @@ partial interface MLGraphBuilder {
             - *alpha*: a {{float}} scalar multiplier, default to 1.
 
     **Returns:**
-        - an {{MLOperand}}. The output tensor of the same shape as *x*.
+        - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
 <details open>
@@ -3162,7 +3160,7 @@ partial interface MLGraphBuilder {
          The default value is `0.2`.
     : <dfn>beta</dfn>
     ::
-         A {{float}} point scalar addition.
+         A {{float}} scalar addition.
          The default value is `0.5`.
 </dl>
 
@@ -3175,8 +3173,13 @@ partial interface MLGraphBuilder {
     **Returns:**
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
-<div algorithm=hardsigmoid-input-options class=algorithm-steps>
+
+<details open>
+  <summary>
     The {{MLGraphBuilder/hardSigmoid(input, options)}} method steps are:
+  </summary>
+  <div algorithm=hardsigmoid-input-options class=algorithm-steps>
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
@@ -3187,7 +3190,8 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-</div>
+  </div>
+</details>
 
 #### The {{MLGraphBuilder/hardSigmoid(options)}} method #### {#api-mlgraphbuilder-hardsigmoid-options}
 <div>
@@ -4324,14 +4328,14 @@ partial interface MLGraphBuilder {
   <div algorithm=create-pooling-operation class=algorithm-steps>
     1. [=Assert=]: |op| is one of "averagePool2d", "l2Pool2d", "maxPool2d".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If the length of of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If the length of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLPool2dOptions/outputSizes}} [=map/exists=], or if |options|.{{MLPool2dOptions/padding}} does not [=map/exist=], set |options|.{{MLPool2dOptions/padding}} to `« 0, 0, 0, 0 »`.
-    1. If the length of of |padding|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If the length of |padding|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLPool2dOptions/strides}} does not [=map/exist=], set |options|.{{MLPool2dOptions/strides}} to `« 1, 1 »`.
-    1. If the length of of |options|.{{MLPool2dOptions/strides}} is not 2, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If the length of |options|.{{MLPool2dOptions/strides}} is not 2, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If any value in |options|.{{MLPool2dOptions/strides}} is not greater than 0, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLPool2dOptions/dilations}} does not [=map/exist=], set |options|.{{MLPool2dOptions/dilations}} to `« 1, 1 »`.
-    1. If the length of of |options|.{{MLPool2dOptions/dilations}} is not 2, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If the length of |options|.{{MLPool2dOptions/dilations}} is not 2, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If any value in |options|.{{MLPool2dOptions/dilations}} is not greater than 0, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLPool2dOptions/autoPad}} is not `"explicit"`, set |options|.{{MLPool2dOptions/padding}} to `« 0, 0, 0, 0 »`.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
@@ -4389,7 +4393,7 @@ partial interface MLGraphBuilder {
         - *slope*: an {{MLOperand}}. The slope tensor. Its shape is either the same as, or unidirectionally broadcastable to the shape of input tensor *input* according to [[!numpy-broadcasting-rule]].
 
     **Returns:**
-        - an {{MLOperand}}. The output tensor of the same shape as *x*.
+        - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
 <details open>

--- a/index.bs
+++ b/index.bs
@@ -5645,6 +5645,8 @@ Benjamin Poulain for their contributions to the API specification.
 
 Thanks to Sangwhan Moon and the W3C Technical Architecture Group for review of this specification for web architecture fit, design consistency and developer ergonomics.
 
+Thanks to Zoltan Kis for adding algorithms and making navigating this specification a delightful experience. Thanks to Joshua Bell for aligning the specification with modern editorial conventions. Thanks to Ningxin Hu, Lisha Guo, Shiyi Zou, Mingming Xu, Junwei Fu, Bruce Dai and Bin Miao for careful review and comments.
+
 Thanks to W3C Privacy Interest Group for privacy and security review and feedback.
 
 Thanks to Alex Gough and the Chrome Security team for security review and questions.

--- a/index.bs
+++ b/index.bs
@@ -1801,8 +1801,6 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |input|, |mean| and |variance| is {{MLOperand}}.
     1. If |options|.axis is not a number between 0 and the [=rank=] of |input|, then [=exception/throw=] a {{TypeError}}.
     1. If |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} from which the dimension represented by |options|.axis is removed, then [=exception/throw=] a {{TypeError}}.
-    1. If |input| is a 4-D tensor of the *"nchw"* layout, set |options|.axis to 1.
-    1. If |input| is a 4-D tensor of the *"nhwc"* layout, set |options|.axis to 3.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|, that may use the same underlying data as |input|.
         1. Make a request to the underlying platform to initialize the batch normalization:

--- a/index.bs
+++ b/index.bs
@@ -1049,7 +1049,7 @@ These activations function types are used to create other operations. One such u
 
 #### Creating {{MLActivation}} #### {#api-mlactivation-create}
 <div class="note">
-The {{MLActivation}} objects (including the ones passed as input to methods) are created by the methods of {{MLGraphBuilder}} and are identified by their name. The |options| dictionary is defined by those methods. The actual creation of the activation function e.g. a [[#api-mlgraphbuilder-sigmoid]] or [[#api-mlgraphbuilder-relu]] can then be deferred until when the rest of the graph is ready to connect with it such as during the construction of [[#api-mlgraphbuilder-conv2d]] for example.
+The {{MLActivation}} objects (including the ones passed as input to methods) are created by the methods of {{MLGraphBuilder}} and are identified by their name. The |options| dictionary is defined by those methods. The actual creation of the activation function e.g. a [[#api-mlgraphbuilder-sigmoid-method]] or [[#api-mlgraphbuilder-relu-method]] can then be deferred until when the rest of the graph is ready to connect with it such as during the construction of [[#api-mlgraphbuilder-conv2d]] for example.
 </div>
 
 <details open>
@@ -3337,7 +3337,7 @@ partial interface MLGraphBuilder {
   <summary>
     The {{MLGraphBuilder/hardSwish()}} method steps are:
   </summary>
-  <div algorithm=hard-swish class=algorithm-steps>
+  <div algorithm=hardswish class=algorithm-steps>
     1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"hardSwish"`.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.

--- a/index.bs
+++ b/index.bs
@@ -1790,7 +1790,7 @@ partial interface MLGraphBuilder {
         - *variance*: an {{MLOperand}}. The 1-D tensor of the variance values of the input features across the batch whose length is equal to the size of the input dimension denoted by {{MLBatchNormalizationOptions/axis}}.
         - *options*: an optional {{MLBatchNormalizationOptions}}. Specifies the optional parameters of the operation.
 
-    **Returns:** an {{MLOperand}}. The batch-normalized N-D tensor of the same shape as the input tensor.
+    **Returns:** an {{MLOperand}}. The batch-normalized N-D tensor of the same shape as *input*.
 </div>
 
 <details open>
@@ -2422,41 +2422,41 @@ partial interface MLGraphBuilder {
 
 <details open>
   <summary>
-    The element-wise binary operation algorithms invoke the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation =] steps as follows.
+    The element-wise binary operation algorithms invoke the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] steps as follows.
   </summary>
   <div class=algorithm-steps>
     The {{MLGraphBuilder/add(a, b)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation =] given "add", |a| and |b|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "add", |a| and |b|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/sub(a, b)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation =] given "sub", |a| and |b|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "sub", |a| and |b|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/mul(a, b)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation =] given "mul", |a| and |b|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "mul", |a| and |b|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/div(a, b)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation =] given "div", |a| and |b|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "div", |a| and |b|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/max(a, b)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation =] given "max", |a| and |b|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "max", |a| and |b|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/min(a, b)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation =] given "min", |a| and |b|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "min", |a| and |b|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/pow(a, b)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation =] given "pow", |a| and |b|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "pow", |a| and |b|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 </div>
@@ -2522,51 +2522,51 @@ partial interface MLGraphBuilder {
 
 <details open>
   <summary>
-    The element-wise unary operation algorithms invoke the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation =] steps as follows.
+    The element-wise unary operation algorithms invoke the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] steps as follows.
   </summary>
   <div class=algorithm-steps>
     The {{MLGraphBuilder/abs(input)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation =] given "abs" and |input|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "abs" and |input|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/ceil(input)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation =] given "ceil" and |input|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "ceil" and |input|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/cos(input)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation =] given "cos" and |input|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "cos" and |input|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/exp(input)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation =] given "exp" and |input|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "exp" and |input|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/floor(input)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation =] given "floor" and |input|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "floor" and |input|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/log(input)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation =] given "log" and |input|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "log" and |input|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/neg(input)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation =] given "neg" and |input|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "neg" and |input|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/sin(input)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation =] given "sin" and |input|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "sin" and |input|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/tan(input)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation =] given "tan" and |input|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "tan" and |input|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
   </div>
@@ -3333,7 +3333,7 @@ The {{MLInstanceNormalizationOptions}} members are:
         - *input*: an {{MLOperand}}. The input 4-D tensor.
         - *options*: an optional {{MLInstanceNormalizationOptions}}. The optional parameters of the operation.
 
-    **Returns:** an {{MLOperand}}. The instance-normalized 4-D tensor of the same shape as the input tensor.
+    **Returns:** an {{MLOperand}}. The instance-normalized 4-D tensor of the same shape as *input*.
 </div>
 
 <details open>
@@ -4359,21 +4359,21 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=averagePool2d class=algorithm-steps>
     The {{MLGraphBuilder/averagePool2d(input, options)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/pooling-op | create pooling operation =] given `"averagePool2d"`, |input| and |options|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/pooling-op | create pooling operation=] given `"averagePool2d"`, |input| and |options|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
   </div>
 
   <div algorithm=l2Pool2d class=algorithm-steps>
     The {{MLGraphBuilder/l2Pool2d(input, options)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/pooling-op | create pooling operation =] given `"l2Pool2d"`, |input| and |options|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/pooling-op | create pooling operation=] given `"l2Pool2d"`, |input| and |options|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
   </div>
 
   <div algorithm=maxPool2d class=algorithm-steps>
     The {{MLGraphBuilder/maxPool2d(input, options)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/pooling-op | create pooling operation =] given `"maxPool2d"`, |input| and |options|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/pooling-op | create pooling operation=] given `"maxPool2d"`, |input| and |options|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
   </div>
@@ -4507,52 +4507,52 @@ partial interface MLGraphBuilder {
     The following reduce algorithms are supported.
   </summary>
     The {{MLGraphBuilder/reduceL1(input, options)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation =] given "reduceL1", |input| and |options|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceL1", |input| and |options|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceL2(input, options)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation =] given "reduceL2", |input| and |options|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceL2", |input| and |options|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceLogSum(input, options)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation =] given "reduceLogSum", |input| and |options|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceLogSum", |input| and |options|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceLogSumExp(input, options)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation =] given "reduceLogSumExp", |input| and |options|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceLogSumExp", |input| and |options|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceMax(input, options)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation =] given "reduceMax", |input| and |options|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceMax", |input| and |options|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceMean(input, options)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation =] given "reduceMean", |input| and |options|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceMean", |input| and |options|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceMin(input, options)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation =] given "reduceMin", |input| and |options|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceMin", |input| and |options|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceProduct(input, options)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation =] given "reduceProduct", |input| and |options|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceProduct", |input| and |options|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceSum(input, options)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation =] given "reduceSum", |input| and |options|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceSum", |input| and |options|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 
     The {{MLGraphBuilder/reduceSumSquare(input, options)}} steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation =] given "reduceSumSquare", |input| and |options|.
+        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceSumSquare", |input| and |options|.
             1. If that throws an error, then re-throw the error and stop.
         1. Return |output|.
 </details>
@@ -4587,7 +4587,7 @@ partial interface MLGraphBuilder {
         - *input*: an {{MLOperand}}. The input tensor.
 
     **Returns:**
-        - an {{MLOperand}}. The output tensor of the same shape as *x*.
+        - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
 <details open>
@@ -4940,7 +4940,7 @@ partial interface MLGraphBuilder {
         - *input*: an {{MLOperand}}. The input 2-D tensor.
 
     **Returns:**
-        - an {{MLOperand}}. The output 2-D tensor that contains the softmax results, of the same shape as the input tensor.
+        - an {{MLOperand}}. The output 2-D tensor that contains the softmax results, of the same shape as *input*.
 </div>
 
 <details open>
@@ -5029,7 +5029,7 @@ partial interface MLGraphBuilder {
         - *options*: an optional {{MLSoftplusOptions}}. The optional parameters of the operation.
 
     **Returns:**
-        - an {{MLOperand}}. The output tensor of the same shape as *x*.
+        - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
 <details open>
@@ -5099,7 +5099,7 @@ partial interface MLGraphBuilder {
         - *input*: an {{MLOperand}}. The input tensor.
 
     **Returns:**
-        - an {{MLOperand}}. The output tensor of the same shape as *x*.
+        - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
 <details open>
@@ -5300,7 +5300,7 @@ partial interface MLGraphBuilder {
         - *input*: an {{MLOperand}}. The input tensor.
 
     **Returns:**
-        - an {{MLOperand}}. The output tensor of the same shape as *x*.
+        - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
 <details open>

--- a/index.bs
+++ b/index.bs
@@ -995,9 +995,11 @@ interface MLOperand {};
   </dl>
 </div>
 
+<div algorithm>
 To get the <dfn for="MLOperand">rank</dfn> of an {{MLOperand}} |operand|, run the following steps:
-<div algorithm=rank class=algorithm-steps>
+<div class=algorithm-steps>
     1. Return the [=list/size=] of |operand|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+</div>
 </div>
 
 Since the {{MLOperand/[[builder]]}} object is bound by the {{MLGraphBuilder/constructor()}} constructor to an {{MLContext}} object, an {{MLOperand}} is also always bound to the same {{MLContext}} object.
@@ -1206,11 +1208,12 @@ partial interface MLContext {
     **Returns:** {{undefined}}.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLContext/computeSync(graph, inputs, outputs)}} method steps are:
+    The <dfn method for=MLContext>computeSync(|graph|, |inputs|, |outputs|)</dfn> method steps are:
   </summary>
-  <div algorithm=mlcontext.computesync class=algorithm-steps>
+  <div class=algorithm-steps>
     1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=]", [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
     1. If <a>validating graph resources</a> given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns `false`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If <a>validating graph resources</a> given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns `false`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -1219,6 +1222,7 @@ partial interface MLContext {
     1. Return {{undefined}}.
   </div>
 </details>
+</div>
 
 <details open>
   <summary>
@@ -1356,11 +1360,12 @@ partial interface MLContext {
     **Returns:** Promise<{{MLComputeResult}}>.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLContext/compute(graph, inputs, outputs)}} method steps are:
+    The <dfn method for=MLContext>compute(|graph|, |inputs|, |outputs|)</dfn> method steps are:
   </summary>
-  <div algorithm=mlcontext.compute class=algorithm-steps>
+  <div class=algorithm-steps>
     1. Let |promise| be [=a new promise=].
     1. Return |promise| and run the following steps [=in parallel=]:
         1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=]", [=reject=] |promise| with an "{{OperationError}}" {{DOMException}}.
@@ -1377,6 +1382,7 @@ partial interface MLContext {
             1. [=Resolve=] |promise| with |result|.
   </div>
 </details>
+</div>
 
 #### Examples #### {#api-mlcontext-async-execution-examples}
 <div class="example">
@@ -1465,16 +1471,18 @@ partial interface MLCommandEncoder {
     **Returns:** {{undefined}}.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLCommandEncoder/initializeGraph(graph)}} steps are:
+    The <dfn method for=MLCommandEncoder>initializeGraph(|graph|)</dfn> method steps are:
   </summary>
-  <div algorithm=mlcommandencoder.initializegraph>
+  <div>
     <div class="note">
-        Graph initialization stage typically involves a process known as "weight preprocessing" where all the constant inputs to the graph are preprocessed and cached at the operating system level for subsequent graph execution calls. The initializing inputs are typically the constant weight data specified through the {{MLGraphBuilder/constant(descriptor, bufferView)|MLGraphBuilder/constant()}} method as constant operands during graph construction time.
+        Graph initialization stage typically involves a process known as "weight preprocessing" where all the constant inputs to the graph are preprocessed and cached at the operating system level for subsequent graph execution calls. The initializing inputs are typically the constant weight data specified through the {{MLGraphBuilder/constant(descriptor, bufferView)|MLGraphBuilder/constant(value, type)}} method as constant operands during graph construction time.
     </div>
   </div>
 </details>
+</div>
 
 ### Dispatch Execution Commands ### {#api-mlcommandencoder-dispatch-commands}
 Record the {{MLGraph}} execution with the inputs {{MLNamedGPUResources}} and outputs {{MLNamedGPUResources}}.
@@ -1494,11 +1502,12 @@ partial interface MLCommandEncoder {
     **Returns:** {{undefined}}.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLCommandEncoder/dispatch(graph, inputs, outputs)}} steps are:
+    The <dfn method for=MLCommandEncoder>dispatch(|graph|, |inputs|, |outputs|)</dfn> method steps are:
   </summary>
-  <div algorithm=mlcommandencoder.dispatch class=algorithm-steps>
+  <div class=algorithm-steps>
     1. If any of the following requirements are unmet, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         <div class=validusage>
             1. [=map/For each=] |key| &rarr; |value| of |inputs|:
@@ -1522,6 +1531,7 @@ partial interface MLCommandEncoder {
     1. Return {{undefined}}.
   </div>
 </details>
+</div>
 
 ### Generate GPU Command Buffer ### {#api-mlcommandencoder-generate-gpu-command-buffer}
 Complete the recording of ML workload and return a WebGPU-compatible {{GPUCommandBuffer}} containing the recorded workload.
@@ -1539,11 +1549,12 @@ partial interface MLCommandEncoder {
     **Returns:** {{GPUCommandBuffer}}.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLCommandEncoder/finish(descriptor)}} method steps are:
+    The <dfn method for=MLCommandEncoder>finish(|descriptor|)</dfn> method steps are:
   </summary>
-  <div algorithm=mlcommandencoder.finish class=algorithm-steps>
+  <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Make a request to the underlying platform to complete the recording of the ML workload, given |descriptor|.
             <div class="note">
@@ -1552,6 +1563,7 @@ partial interface MLCommandEncoder {
     1. Return a {{GPUCommandBuffer}} containing the recorded workload.
   </div>
 </details>
+</div>
 
 ## The MLGraphBuilder interface ## {#api-mlgraphbuilder}
 
@@ -1620,9 +1632,11 @@ Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGr
 </div>
 
 ### The {{MLGraphBuilder}} constructor ### {#api-mlgraphbuilder-constructor}
+
+<div algorithm>
 <details open>
   <summary>
-    The [=new=] {{MLGraphBuilder(context)}} constructor steps are:
+    The [=new=] <dfn constructor for=MLGraphBuilder lt="MLGraphBuilder(context)">MLGraphBuilder(context)</dfn> constructor steps are:
   </summary>
   <div class=algorithm-steps>
     1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, then [=exception/throw=] a "{{SecurityError}}" {{DOMException}}.
@@ -1630,6 +1644,7 @@ Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGr
     1. Set {{MLGraphBuilder/[[context]]}} to |context|.
   </div>
 </details>
+</div>
 
 ### The {{MLGraphBuilder/input()}} method  ### {#api-mlgraphbuilder-input}
 Create a named {{MLOperand}} based on a descriptor, that can be used as an input.
@@ -1641,11 +1656,12 @@ Create a named {{MLOperand}} based on a descriptor, that can be used as an input
     **Returns:**: an {{MLOperand}} object.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/input(name, descriptor)}} steps are:
+    The <dfn method for=MLGraphBuilder>input(|name|, |descriptor|)</dfn> method steps are:
   </summary>
-  <div algorithm=input class=algorithm-steps>
+  <div class=algorithm-steps>
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
@@ -1665,16 +1681,19 @@ Create a named {{MLOperand}} based on a descriptor, that can be used as an input
     1. Return |operand|.
   </div>
 </details>
+</div>
 
 ### The build() method ### {#api-mlgraphbuilder-build}
 Build a composed graph up to a given output operand into a computational graph, asynchronously or synchronously.
 
 #### The {{MLGraphBuilder/build(outputs)}} method #### {#api-mlgraphbuilder-build-outputs}
+
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/build(outputs)}} steps are:
+    The <dfn method for=MLGraphBuilder>build(|outputs|)</dfn> method steps are:
   </summary>
-  <div algorithm=build-outputs class=algorithm-steps>
+  <div class=algorithm-steps>
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
@@ -1684,13 +1703,16 @@ Build a composed graph up to a given output operand into a computational graph, 
         1. If that [=exception/throws=], re-[=exception/throw=] the error.
   </div>
 </details>
+</div>
 
 #### The {{MLGraphBuilder/buildSync(outputs)}} method #### {#api-mlgraphbuilder-buildsync-outputs}
+
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/buildSync(outputs)}} steps are:
+    The <dfn method for=MLGraphBuilder>buildSync(|outputs|)</dfn> method steps are:
   </summary>
-  <div algorithm=buildsync-outputs class=algorithm-steps>
+  <div class=algorithm-steps>
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
@@ -1719,6 +1741,7 @@ Build a composed graph up to a given output operand into a computational graph, 
     1. Return |graph|.
   </div>
 </details>
+</div>
 
 ### The constant() method  ### {#api-mlgraphbuilder-constant-method}
 Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
@@ -1731,11 +1754,12 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
     **Returns:**: an {{MLOperand}} object.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/constant(descriptor, bufferView)}} steps are:
+    The <dfn method for=MLGraphBuilder>constant(|descriptor|, |bufferView|)</dfn> method steps are:
   </summary>
-  <div algorithm=constant class=algorithm-steps>
+  <div class=algorithm-steps>
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
@@ -1753,6 +1777,7 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
     1. Return |operand|.
   </div>
 </details>
+</div>
 
 #### The {{MLGraphBuilder/constant(value, type)}} method  #### {#api-mlgraphbuilder-constant-value-type}
 
@@ -1763,11 +1788,12 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
     **Returns:**: an {{MLOperand}} object.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/constant(value, type)}} steps are:
+    The <dfn method for=MLGraphBuilder>constant(|value|, |type|)</dfn> method steps are:
   </summary>
-  <div algorithm=constant-value-type class=algorithm-steps>
+  <div class=algorithm-steps>
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
@@ -1788,6 +1814,7 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
     1. Return |operand|.
   </div>
 </details>
+</div>
 
 ### The batchNormalization() method ### {#api-mlgraphbuilder-batchnorm}
 Normalize the tensor values of input features across the batch dimension using [[Batch-Normalization]]. For each input feature, the mean and variance values of that feature supplied in this calculation as parameters are previously computed across the batch dimension of the input during the model training phase of this operation.
@@ -1840,11 +1867,12 @@ partial interface MLGraphBuilder {
     **Returns:** an {{MLOperand}}. The batch-normalized N-D tensor of the same shape as *input*.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/batchNormalization(input, mean, variance, options)}} method steps are:
+    The <dfn method for=MLGraphBuilder>batchNormalization(|input|, |mean|, |variance|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=batchnorm class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |mean| and |variance| is {{MLOperand}}.
     1. If |options|.axis is not a number in [=the range=] 0 to the [=rank=] of |input|, exclusive, then [=exception/throw=] a {{TypeError}}.
     1. If the [=list/size=] of |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
@@ -1860,6 +1888,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 <div class="note">
   <details open>
@@ -1945,11 +1974,12 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *operand*.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/clamp(operand, options)}} method steps are:
+    The <dfn method for=MLGraphBuilder>clamp(|operand|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=clamp class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |operand| is {{MLOperand}}.
     1. If running the <a>check clamp options</a> steps given |options| returns `false`, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -1964,6 +1994,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 #### The {{MLGraphBuilder/clamp(options)}} method #### {#api-mlgraphbuilder-clamp-options}
 <div>
@@ -1975,17 +2006,19 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The operator representing the clamp operation.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/clamp(options)}} method steps are:
+    The <dfn method for=MLGraphBuilder>clamp(|options|)</dfn> method steps are:
   </summary>
-  <div algorithm=clamp-options class=algorithm-steps>
+  <div class=algorithm-steps>
     1. If running the <a>check clamp options</a> steps given |options| returns `false`, then [=exception/throw=] a {{TypeError}}.
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=],  `"clamp"` and |options|.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
+</div>
 
 ### The concat() method ### {#api-mlgraphbuilder-concat}
 Concatenates the input tensors along a given axis.
@@ -2006,11 +2039,12 @@ partial interface MLGraphBuilder {
     computed as the sum of all the input sizes of the same dimension.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/concat(inputs, axis)}} steps are:
+    The <dfn method for=MLGraphBuilder>concat(|inputs|, |axis|)</dfn> method steps are:
   </summary>
-  <div algorithm=concat class=algorithm-steps>
+  <div class=algorithm-steps>
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
@@ -2043,6 +2077,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 ### The conv2d() method ### {#api-mlgraphbuilder-conv2d}
 Compute a 2-D convolution given 4-D input and filter tensors
@@ -2164,11 +2199,12 @@ partial interface MLGraphBuilder {
     for *"oihw"* layout, [height, width, 1, options.groups] for *"hwio"* layout, [options.groups, height, width, 1] for *"ohwi"* layout and [1, height, width, options.groups] for *"ihwo"* layout.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/conv2d(input, filter, options)}} steps are:
+    The <dfn method for=MLGraphBuilder>conv2d(|input|, |filter|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=conv2d class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| and |filter| is {{MLOperand}}.
     1. Let |input_size| be the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Let |filter_size| be the [=list/size=] of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
@@ -2210,6 +2246,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 ### The convTranspose2d() method ### {#api-mlgraphbuilder-convtranspose2d}
 Compute a 2-D transposed convolution given 4-D input and filter tensors
@@ -2339,11 +2376,12 @@ partial interface MLGraphBuilder {
     *output_size = (input_size - 1) ** *stride + (filter_size - 1) ** *dilation + 1 - beginning_padding - ending_padding + output_padding*
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/convTranspose2d(input, filter, options)}} steps are:
+    The <dfn method for=MLGraphBuilder>convTranspose2d(|input|, |filter|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=convtranspose2d class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| and |filter| is {{MLOperand}}.
     1. Let |input_size| be the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Let |filter_size| be the [=list/size=] of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
@@ -2388,6 +2426,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 ### Element-wise binary operations ### {#api-mlgraphbuilder-binary}
 Compute the element-wise binary addition, subtraction, multiplication, division, power, maximum and minimum of the two input tensors.
@@ -2428,11 +2467,12 @@ partial interface MLGraphBuilder {
         - *pow*: Compute the values of the values of the first input tensor to the power of the values of the second input tensor, element-wise.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="element-wise-binary-op">create element-wise binary operation</dfn> given |op|, |a| and |b|, run the following steps:
   </summary>
-  <div algorithm=binary class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "add", "sub", "mul", "div", "max", "min", "pow".
     1. [=Assert=]: the type of |a| and |b| is {{MLOperand}}.
     1. If |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not equal to |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -2452,12 +2492,14 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
+<div algorithm>
 <details open>
   <summary>
     To <dfn for="MLGraphBuilder">broadcast-shapes</dfn> given |shape1| and |shape2|, run the following steps:
   </summary>
-  <div algorithm=broadcast-shape class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: The type of |shape1| and |shape2| is `sequence of unsigned long`.
     1. Let |output| be the result of invoking the [=implementation-defined=] shape broadcast on |shape1| and |shape2|.
             1. If that fails, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -2467,46 +2509,61 @@ partial interface MLGraphBuilder {
         </div>
   </div>
 </details>
+</div>
 
 <details open>
   <summary>
     The element-wise binary operation algorithms invoke the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] steps as follows.
   </summary>
   <div class=algorithm-steps>
-    The {{MLGraphBuilder/add(a, b)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>add(|a|, |b|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "add", |a| and |b|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/sub(a, b)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>sub(|a|, |b|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "sub", |a| and |b|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/mul(a, b)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>mul(|a|, |b|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "mul", |a| and |b|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/div(a, b)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>div(|a|, |b|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "div", |a| and |b|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/max(a, b)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>max(|a|, |b|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "max", |a| and |b|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/min(a, b)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>min(|a|, |b|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "min", |a| and |b|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/pow(a, b)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>pow(|a|, |b|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "pow", |a| and |b|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 </div>
 </details>
 
@@ -2547,11 +2604,12 @@ partial interface MLGraphBuilder {
         - *tan*: Compute the tangent of the input tensor, element-wise.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="element-wise-unary-op">create element-wise unary operation</dfn> given |op| and |input|, run the following steps:
   </summary>
-  <div algorithm=unary class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "abs", "ceil", "cos", "exp", "floor", "log", "neg", "sin", "tan".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -2566,56 +2624,75 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 <details open>
   <summary>
     The element-wise unary operation algorithms invoke the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] steps as follows.
   </summary>
   <div class=algorithm-steps>
-    The {{MLGraphBuilder/abs(input)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>abs(|input|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "abs" and |input|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/ceil(input)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>ceil(|input|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "ceil" and |input|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/cos(input)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>cos(|input|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "cos" and |input|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/exp(input)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>exp(|input|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "exp" and |input|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/floor(input)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>floor(|input|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "floor" and |input|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/log(input)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>log(|input|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "log" and |input|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/neg(input)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>neg(|input|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "neg" and |input|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/sin(input)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>sin(|input|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "sin" and |input|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/tan(input)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>tan(|input|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "tan" and |input|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
   </div>
 </details>
 
@@ -2664,11 +2741,12 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/elu(input, options)}} method steps are:
+    The <dfn method for=MLGraphBuilder>elu(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=elu-input-options class=algorithm-steps>
+  <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
@@ -2681,6 +2759,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 #### The {{MLGraphBuilder/elu(options)}} method #### {#api-mlgraphbuilder-elu-options}
 <div>
@@ -2692,15 +2771,17 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the elu operation.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/elu(options)}} method steps are:
+    The <dfn method for=MLGraphBuilder>elu(|options|)</dfn> method steps are:
   </summary>
-  <div algorithm=elu-options class=algorithm-steps>
+  <div class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=], `"elu"` and |options|.
     1. Return |op|.
   </div>
 </details>
+</div>
 
 ### The gemm() method ### {#api-mlgraphbuilder-gemm}
 Calculate the [general matrix multiplication of the Basic Linear Algebra Subprograms](https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3). The calculation follows the expression `alpha * A * B + beta * C`, where `A` is a 2-D tensor with shape [M, K] or [K, M], `B` is a 2-D tensor with shape [K, N] or [N, K], and `C` is broadcastable to the shape [M, N]. `A` and `B` may optionally be transposed prior to the calculation.
@@ -2751,11 +2832,12 @@ partial interface MLGraphBuilder {
     **Returns:** an {{MLOperand}}. The output 2-D tensor of shape [M, N] that contains the calculated product of all the inputs.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/gemm(a, b, options)}} steps are:
+    The <dfn method for=MLGraphBuilder>gemm(|a|, |b|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=gemm class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |a| and |b| is {{MLOperand}}.
     1. Let |shapeA| be |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeA| the [=list/size=] of |shapeA|.
     1. Let |shapeB| be |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |sizeB| the [=list/size=] of |shapeB|.
@@ -2782,6 +2864,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 <div class="note">
 <details open>
@@ -2882,11 +2965,12 @@ partial interface MLGraphBuilder {
     **Returns:** a sequence of {{MLOperand}}. The first element of the sequence is a 3-D tensor of shape [num_directions, batch_size, hidden_size], the cell output from the last time step of the network. Additionally, if |options|.{{MLGruOptions/returnSequence}} is set to `true`, the second element is the 4-D output tensor of shape [steps, num_directions, batch_size, hidden_size] containing every cell outputs from each time step in the temporal sequence.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/gru(input, weight, recurrentWeight, steps, hiddenSize, options)}} steps are:
+    The <dfn method for=MLGraphBuilder>gru(|input|, |weight|, |recurrentWeight|, |steps|, |hiddenSize|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=gru class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
     1. If the [=rank=] of |input| or |weight| is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If the [=rank=] of |weight| or |recurrentWeight| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -2912,6 +2996,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 <div class="note">
 <details open>
@@ -3032,11 +3117,12 @@ partial interface MLGraphBuilder {
     **Returns:** an {{MLOperand}}. The 2-D tensor of shape [batch_size, hidden_size], the cell output hidden state of a single time step of the recurrent network.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-     The {{MLGraphBuilder/gruCell(input, weight, recurrentWeight, hiddenState, hiddenSize, options)}} steps are:
+     The <dfn method for=MLGraphBuilder>gruCell(|input|, |weight|, |recurrentWeight|, |hiddenState|, |hiddenSize|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=grucell class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
     1. If the [=rank=] of |input| or |weight| is not `3`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If the [=rank=] of |weight| or |recurrentWeight| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -3063,6 +3149,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 <div class="note">
 <details open>
@@ -3221,11 +3308,12 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/hardSigmoid(input, options)}} method steps are:
+    The <dfn method for=MLGraphBuilder>hardSigmoid(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=hardsigmoid-input-options class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
@@ -3239,6 +3327,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 #### The {{MLGraphBuilder/hardSigmoid(options)}} method #### {#api-mlgraphbuilder-hardsigmoid-options}
 <div>
@@ -3249,16 +3338,18 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the hard sigmoid operation.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/hardSigmoid(options)}} method steps are:
+    The <dfn method for=MLGraphBuilder>hardSigmoid(|options|)</dfn> method steps are:
   </summary>
-  <div algorithm=hard-sigmoid-options class=algorithm-steps>
+  <div class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=], `"hardSigmoid"` and |options|.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
+</div>
 
 ### The hardSwish() method ### {#api-mlgraphbuilder-hard-swish}
 Computes the nonlinear function `y = x * max(0, min(6, (x + 3))) / 6` that is introduced by [[MobileNetV3]] on the input tensor element-wise.
@@ -3300,11 +3391,12 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/hardSwish(input)}} method steps are:
+    The <dfn method for=MLGraphBuilder>hardSwish(|input|)</dfn> method steps are:
   </summary>
-  <div algorithm=hardswish-input class=algorithm-steps>
+  <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
@@ -3317,6 +3409,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 #### The {{MLGraphBuilder/hardSwish()}} method #### {#api-mlgraphbuilder-hardswish}
 <div>
@@ -3327,16 +3420,18 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the hard-swish operation.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/hardSwish()}} method steps are:
+    The <dfn method for=MLGraphBuilder>hardSwish()</dfn> method steps are:
   </summary>
-  <div algorithm=hardswish class=algorithm-steps>
+  <div class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"hardSwish"`.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
  </div>
 </details>
+</div>
 
 ### The instanceNormalization() method ### {#api-mlgraphbuilder-instancenorm}
 Normalize the input features using [[Instance-Normalization]]. Unlike [[#api-mlgraphbuilder-batchnorm]] where the mean and variance values used in the calculation are previously computed across the batch dimension during the model training phase, the mean and variance values used in the calculation of an instance normalization are computed internally on the fly per input feature.
@@ -3383,11 +3478,12 @@ The {{MLInstanceNormalizationOptions}} members are:
     **Returns:** an {{MLOperand}}. The instance-normalized 4-D tensor of the same shape as *input*.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/instanceNormalization(input, options)}} steps are:
+    The <dfn method for=MLGraphBuilder>instanceNormalization(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=instancenorm class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If the [=rank=] of |input| is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=Assert=]:  the type of |options|.{{MLInstanceNormalizationOptions/scale}} is {{MLOperand}}.
@@ -3407,6 +3503,7 @@ The {{MLInstanceNormalizationOptions}} members are:
     1. Return |output|.
   </div>
 </details>
+</div>
 
 <div class="note">
 <details open>
@@ -3493,11 +3590,12 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/leakyRelu(input, options)}} method steps are:
+    The <dfn method for=MLGraphBuilder>leakyRelu(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=leakyrelu-input-options class=algorithm-steps>
+  <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
@@ -3510,6 +3608,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 #### The {{MLGraphBuilder/leakyRelu(options)}} method #### {#api-mlgraphbuilder-leaky-relu-options}
 <div>
@@ -3520,16 +3619,18 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the leaky relu operation.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/leakyRelu(options)}} method steps are:
+    The <dfn method for=MLGraphBuilder>leakyRelu(|options|)</dfn> method steps are:
   </summary>
-  <div algorithm=leakyrelu-options class=algorithm-steps>
+  <div class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=], `"leakyRelu"` and |options|.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
+</div>
 
 ### The linear() method ### {#api-mlgraphbuilder-linear}
 Calculate a linear function `y = alpha * x + beta` on the input tensor.
@@ -3584,11 +3685,12 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/linear(input, options)}} method steps are:
+    The <dfn method for=MLGraphBuilder>linear(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=linear-input-options class=algorithm-steps>
+  <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
@@ -3601,6 +3703,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 #### The {{MLGraphBuilder/linear(options)}} method #### {#api-mlgraphbuilder-linear-options}
 <div>
@@ -3611,16 +3714,18 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the linear operation.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/linear(options)}} method steps are:
+    The <dfn method for=MLGraphBuilder>linear(|options|)</dfn> method steps are:
   </summary>
-  <div algorithm=linear-options class=algorithm-steps>
+  <div class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=],  `"linear"` and |options|.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
+</div>
 
 ### The lstm() method ### {#api-mlgraphbuilder-lstm}
 Long Short-Term Memory [[LSTM]] recurrent network uses an input, output, forget, and cell gate to compute the output state that rolls into the output across the temporal sequence of the network.
@@ -3701,11 +3806,12 @@ partial interface MLGraphBuilder {
     **Returns:** a sequence of {{MLOperand}}. The first element of the sequence is a 3-D tensor of shape [num_directions, batch_size, hidden_size], the output hidden state from the last time step of the network. The second element is a 3-D tensor of shape [num_directions, batch_size, hidden_size], the output cell state from the last time step of the network. Additionally, if |options|.{{MLLstmOptions/returnSequence}} is set to true, the third element is the 4-D output tensor of shape [steps, num_directions, batch_size, hidden_size] containing every output from each time step in the temporal sequence.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/lstm(input, weight, recurrentWeight, steps, hiddenSize, options)}} steps are:
+    The <dfn method for=MLGraphBuilder>lstm(|input|, |weight|, |recurrentWeight|, |steps|, |hiddenSize|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=lstm class=algorithm-steps>
+  <div class=algorithm-steps>
     1. If |options|.{{MLLstmOptions/direction}} is not one of {{MLRecurrentNetworkDirection}}, then [=exception/throw=] a {{TypeError}}.
     1. Let |num_directions| be `1` if |options|.{{MLLstmOptions/direction}} is `"forward"`, or otherwise let it be `2`.
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
@@ -3766,6 +3872,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 <div class="note">
 <details open>
@@ -3903,11 +4010,12 @@ partial interface MLGraphBuilder {
     **Returns:** a sequence of {{MLOperand}}. The first element of the sequence is the output hidden state of the current time step of the recurrent network. The following element is the output cell state. Both elements are 2-D tensors of shape [batch_size, hidden_size].
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/lstmCell(input, weight, recurrentWeight, hiddenState, cellState, hiddenSize, options)}} steps are:
+    The <dfn method for=MLGraphBuilder>lstmCell(|input|, |weight|, |recurrentWeight|, |hiddenState|, |cellState|, |hiddenSize|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=lstmcell class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input|, |weight|, |recurrentWeight|, |hiddenState| and |cellState| is {{MLOperand}}.
     1. If the [=rank=] of |input|, |weight|, |recurrentWeight|, |hiddenState| or |cellState| is not `2`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |batch_size| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0].
@@ -3944,6 +4052,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 <div class="note">
 <details open>
@@ -4107,11 +4216,12 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/matmul(a, b)}} steps are:
+    The <dfn method for=MLGraphBuilder>matmul(|a|, |b|)</dfn> method steps are:
   </summary>
-  <div algorithm=matmul class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |a| and |b| is {{MLOperand}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of invoking the <a>calculate matmul output sizes</a> steps given |a| and |b|.
@@ -4128,6 +4238,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 ### The pad() method ### {#api-mlgraphbuilder-pad}
 Inflate the tensor with constant or mirrored values on the edges.
@@ -4192,11 +4303,12 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/pad(input, beginningPadding, endingPadding, options)}} steps are:
+    The <dfn method for=MLGraphBuilder>pad(|input|, |beginningPadding|, |endingPadding|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=pad class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |options|.{{MLPadOptions/mode}} is not one of {{MLPaddingMode}}, then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
@@ -4213,6 +4325,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 <div class="example">
 <details open>
@@ -4371,11 +4484,12 @@ partial interface MLGraphBuilder {
 
 </dl>
 
+<div algorithm>
 <details open>
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="pooling-op">create pooling operation</dfn> given |op|, |input| and |options|, run the following steps:
   </summary>
-  <div algorithm=create-pooling-operation class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "averagePool2d", "l2Pool2d", "maxPool2d".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -4407,27 +4521,28 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 <details open>
   <summary>
     The following pooling algorithms are supported.
   </summary>
-  <div algorithm=averagePool2d class=algorithm-steps>
-    The {{MLGraphBuilder/averagePool2d(input, options)}} steps are:
+  <div algorithm class=algorithm-steps>
+    The <dfn method for=MLGraphBuilder>averagePool2d(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/pooling-op | create pooling operation=] given `"averagePool2d"`, |input| and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
   </div>
 
-  <div algorithm=l2Pool2d class=algorithm-steps>
-    The {{MLGraphBuilder/l2Pool2d(input, options)}} steps are:
+  <div algorithm class=algorithm-steps>
+    The <dfn method for=MLGraphBuilder>l2Pool2d(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/pooling-op | create pooling operation=] given `"l2Pool2d"`, |input| and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
   </div>
 
-  <div algorithm=maxPool2d class=algorithm-steps>
-    The {{MLGraphBuilder/maxPool2d(input, options)}} steps are:
+  <div algorithm class=algorithm-steps>
+    The <dfn method for=MLGraphBuilder>maxPool2d(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/pooling-op | create pooling operation=] given `"maxPool2d"`, |input| and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
@@ -4451,11 +4566,12 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/prelu(input, slope)}} steps are:
+    The <dfn method for=MLGraphBuilder>prelu(|input|, |slope|)</dfn> method steps are:
   </summary>
-  <div algorithm=prelu-input-slope class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| and |slope| is {{MLOperand}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
     1. Set |descriptor|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
@@ -4473,6 +4589,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 <div class="note">
   <details open>
@@ -4537,11 +4654,12 @@ partial interface MLGraphBuilder {
         - *SumSquare*: Compute the sum of the square of all the input values along the axes.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="reduce-op">create reduce operation</dfn> given |op|, |input| and |options|, run the following steps:
   </summary>
-  <div algorithm=reduce class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "reduceL1", "reduceL2", "reduceLogSum", "reduceLogSumExp", "reduceMax", "reduceMean", "reduceMin", "reduceProduct", "reduceSum", "reduceSumSquare".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -4556,60 +4674,81 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 <details open>
   <summary>
     The following reduce algorithms are supported.
   </summary>
-    The {{MLGraphBuilder/reduceL1(input, options)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>reduceL1(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceL1", |input| and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/reduceL2(input, options)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>reduceL2(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceL2", |input| and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/reduceLogSum(input, options)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>reduceLogSum(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceLogSum", |input| and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/reduceLogSumExp(input, options)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>reduceLogSumExp(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceLogSumExp", |input| and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/reduceMax(input, options)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>reduceMax(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceMax", |input| and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/reduceMean(input, options)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>reduceMean(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceMean", |input| and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/reduceMin(input, options)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>reduceMin(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceMin", |input| and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/reduceProduct(input, options)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>reduceProduct(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceProduct", |input| and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/reduceSum(input, options)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>reduceSum(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceSum", |input| and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 
-    The {{MLGraphBuilder/reduceSumSquare(input, options)}} steps are:
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>reduceSumSquare(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceSumSquare", |input| and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
 </details>
 
 ### The relu() method ### {#api-mlgraphbuilder-relu-method}
@@ -4645,11 +4784,12 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/relu(input)}} steps are:
+    The <dfn method for=MLGraphBuilder>relu(|input|)</dfn> method steps are:
   </summary>
-  <div algorithm=relu-input class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
@@ -4663,6 +4803,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 #### The {{MLGraphBuilder/relu()}} method #### {#api-mlgraphbuilder-relu}
 <div>
@@ -4673,16 +4814,18 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the relu operation.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/relu()}} method steps are:
+    The <dfn method for=MLGraphBuilder>relu()</dfn> method steps are:
   </summary>
-  <div algorithm=relu class=algorithm-steps>
+  <div class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"relu"`.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
+</div>
 
 ### The resample2d() method ### {#api-mlgraphbuilder-resample2d-method}
 Resample the tensor values from the source to the destination spatial dimensions according to the scaling factors.
@@ -4737,11 +4880,12 @@ partial interface MLGraphBuilder {
         The default value is [2, 3].
 </dl>
 
+<div algorithm>
 <details open>
   <summary>
     To <dfn for="MLGraphBuilder">check resample options</dfn> given |options|, run the following steps:
   </summary>
-  <div algorithm=check-resample-options class=algorithm-steps>
+  <div class=algorithm-steps>
     1. If |options|.{{MLResample2dOptions/mode}} [=map/exists=], and if its value is not one of `"nearest-neighbor"` or `"linear"`, return `false`.
     1. If |options|.{{MLResample2dOptions/scales}} does not [=map/exist=], set it to to `« 1.0, 1.0 »`.
     1. Otherwise, if any of its values is not greater than `0`, return `false`.
@@ -4751,12 +4895,14 @@ partial interface MLGraphBuilder {
     1. Return `true`.
   </div>
 </details>
+</div>
 
+<div algorithm>
 <details open>
   <summary>
     To <dfn for="MLGraphBuilder">resample output sizes</dfn> given |input| and |options|, run the following steps:
   </summary>
-  <div algorithm=resample-output-sizes class=algorithm-steps>
+  <div class=algorithm-steps>
     1. Let |desc| be an {{MLOperandDescriptor}} initialized to |input|.{{MLOperand/[[descriptor]]}}.
     1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], then set |desc|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} to |options|.{{MLResample2dOptions/sizes}} and return |desc|.
     1. For |index| in [=the range=] 0 to the [=rank=] of |desc|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, exclusive:
@@ -4767,12 +4913,14 @@ partial interface MLGraphBuilder {
     1. Return |desc|.
   </div>
 </details>
+</div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/resample2d(input, options)}} steps are:
+    The <dfn method for=MLGraphBuilder>resample2d(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=resample2d class=algorithm-steps>
+  <div class=algorithm-steps>
     1. Check if the input is a 4-dimensional tensor: if the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not `4`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If running the <a>check resample options</a> steps given |options| returns `false`, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| be the result of running the <a>resample output sizes</a> steps given |options|.
@@ -4789,6 +4937,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 ### The reshape() method ### {#api-mlgraphbuilder-reshape-method}
 Alter the shape of a tensor to a new shape. Reshape does not copy or change the content of the tensor. It just changes the tensor's logical dimensions for the subsequent operations.
@@ -4812,11 +4961,12 @@ partial interface MLGraphBuilder {
     tensor is specified by the *newShape* argument.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/reshape(input, newShape)}} steps are:
+    The <dfn method for=MLGraphBuilder>reshape(|input|, |newShape|)</dfn> method steps are:
   </summary>
-  <div algorithm=reshape class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. Let |outputShape| be an empty array of {{unsigned long}}.
     1. If |newShape| is a scalar [=number=], set |outputShape| to `«  1  »`.
@@ -4842,6 +4992,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 ### The sigmoid() method ### {#api-mlgraphbuilder-sigmoid-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Sigmoid_function">sigmoid function</a> of the input tensor. The calculation follows the expression `1 / (exp(-x) + 1)`.
@@ -4879,11 +5030,12 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/sigmoid(input)}} steps are:
+    The <dfn method for=MLGraphBuilder>sigmoid(|input|)</dfn> method steps are:
   </summary>
-  <div algorithm=sigmoid-input class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
@@ -4897,6 +5049,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 #### The {{MLGraphBuilder/sigmoid()}} method #### {#api-mlgraphbuilder-sigmoid}
 <div>
@@ -4907,16 +5060,18 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the sigmoid operation.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/sigmoid()}} method steps are:
+    The <dfn method for=MLGraphBuilder>sigmoid()</dfn> method steps are:
   </summary>
-  <div algorithm=sigmoid class=algorithm-steps>
+  <div class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"sigmoid"`.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
+</div>
 
 ### The slice() method ### {#api-mlgraphbuilder-slice}
 Produce a slice of the input tensor.
@@ -4934,11 +5089,12 @@ partial interface MLGraphBuilder {
     **Returns:** an {{MLOperand}}. The output tensor of the same rank as the input tensor with tensor values stripped to the specified starting and ending indices in each dimension.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/slice(input, starts, sizes)}} steps are:
+    The <dfn method for=MLGraphBuilder>slice(|input|, |starts|, |sizes|)</dfn> method steps are:
   </summary>
-  <div algorithm=slice class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |sizes|.size is 0, then [=exception/throw=] a {{TypeError}}.
     1. If the [=list/size=] of |starts| and |sizes| is not equal to the <a>rank</a> of |input|, then [=exception/throw=] a {{TypeError}}.
@@ -4954,6 +5110,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 ### The softmax() method ### {#api-mlgraphbuilder-softmax-method}
 Compute the [softmax](https://en.wikipedia.org/wiki/Softmax_function) values of
@@ -4995,11 +5152,12 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output 2-D tensor that contains the softmax results, of the same shape as *input*.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/softmax(input)}} steps are:
+    The <dfn method for=MLGraphBuilder>softmax(|input|)</dfn> method steps are:
   </summary>
-  <div algorithm=softmax-input class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -5014,6 +5172,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 #### The {{MLGraphBuilder/softmax()}} method #### {#api-mlgraphbuilder-softmax}
 <div>
@@ -5023,16 +5182,19 @@ partial interface MLGraphBuilder {
     **Returns:**
         - an {{MLActivation}}. The activation function representing the softmax operation.
 </div>
+
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/softmax()}} method steps are:
+    The <dfn method for=MLGraphBuilder>softmax()</dfn> method steps are:
   </summary>
-  <div algorithm=softmax class=algorithm-steps>
+  <div class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given  and  `"softmax"`.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
+</div>
 
 ### The softplus() method ### {#api-mlgraphbuilder-softplus-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)#Softplus">softplus function</a> of the input tensor. The calculation follows the expression `ln(1 + exp(steepness * x)) / steepness`.
@@ -5084,11 +5246,12 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/softplus(input, options)}} method steps are:
+    The <dfn method for=MLGraphBuilder>softplus(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=softplus-input-options class=algorithm-steps>
+  <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
@@ -5101,6 +5264,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 #### The {{MLGraphBuilder/softplus(options)}} method #### {#api-mlgraphbuilder-softplus-options}
 <div>
@@ -5111,16 +5275,18 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the softplus operation.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/softplus(options)}} method steps are:
+    The <dfn method for=MLGraphBuilder>softplus(|options|)</dfn> method steps are:
   </summary>
-  <div algorithm=softplus-options class=algorithm-steps>
+  <div class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=], `"softplus"` and |options|.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
+</div>
 
 ### The softsign() method ### {#api-mlgraphbuilder-softsign-method}
 Compute the <a href="https://pytorch.org/docs/stable/generated/torch.nn.Softsign.html">softsign function</a> of the input tensor. The calculation follows the expression `x / (1 + |x|)`.
@@ -5154,11 +5320,12 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/softsign(input)}} steps are:
+    The <dfn method for=MLGraphBuilder>softsign(|input|)</dfn> method steps are:
   </summary>
-  <div algorithm=softsign-input class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
@@ -5172,6 +5339,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 #### The {{MLGraphBuilder/softsign()}} method #### {#api-mlgraphbuilder-softsign}
 <div>
@@ -5181,16 +5349,19 @@ partial interface MLGraphBuilder {
     **Returns:**
         - an {{MLActivation}}. The activation function representing the softsign operation.
 </div>
+
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/softsign()}} method steps are:
+    The <dfn method for=MLGraphBuilder>softsign()</dfn> method steps are:
   </summary>
-  <div algorithm=softsign class=algorithm-steps>
+  <div class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"softsign"`.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
+</div>
 
 ### The split() method ### {#api-mlgraphbuilder-split}
 Split the input tensor into a number of sub tensors along the given axis.
@@ -5223,11 +5394,12 @@ partial interface MLGraphBuilder {
         The default value is `0`.
 </dl>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/split(input, splits, options)}} steps are:
+    The <dfn method for=MLGraphBuilder>split(|input|, |splits|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=split class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |splits| is not a non-zero {{unsigned long}} or a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}}.
     1. If |splits| is an {{unsigned long}}, and |input|.{{MLOperandDescriptor/dimensions}}[|options|.{{MLSplitOptions/axis}}] % |splits| is not 0, then [=exception/throw=] a {{TypeError}}.
@@ -5244,6 +5416,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 <div class="note">
 <details open>
@@ -5299,11 +5472,12 @@ partial interface MLGraphBuilder {
         When not specified, every shape dimensions of size 1 in the tensor are eliminated.
 </dl>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/squeeze(input, options)}} steps are:
+    The <dfn method for=MLGraphBuilder>squeeze(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=squeeze class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |options|.{{MLSqueezeOptions/axes}} [=map/exists=], then:
         1. Let |dimensions| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
@@ -5324,6 +5498,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 ### The tanh() method ### {#api-mlgraphbuilder-tanh-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Hyperbolic_functions">hyperbolic tangent function</a> of the input tensor. The calculation follows the expression `(exp(2 * x) - 1) / (exp(2 * x) + 1)`.
@@ -5359,11 +5534,12 @@ partial interface MLGraphBuilder {
         - an {{MLOperand}}. The output tensor of the same shape as *input*.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/tanh(input)}} steps are:
+    The <dfn method for=MLGraphBuilder>tanh(|input|)</dfn> method steps are:
   </summary>
-  <div algorithm=tanh-input class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
@@ -5377,6 +5553,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 #### The {{MLGraphBuilder/tanh()}} method #### {#api-mlgraphbuilder-tanh}
 <div>
@@ -5387,16 +5564,18 @@ partial interface MLGraphBuilder {
         - an {{MLActivation}}. The activation function representing the tanh operation.
 </div>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/tanh()}} method steps are:
+    The <dfn method for=MLGraphBuilder>tanh()</div> method steps are:
   </summary>
-  <div algorithm=tanh class=algorithm-steps>
+  <div class=algorithm-steps>
     1. Let |op| be the result of <a>creating an MLActivation</a> given [=this=] and `"tanh"`.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
   </div>
 </details>
+</div>
 
 ### The transpose() method ### {#api-mlgraphbuilder-transpose}
 Permute the dimensions of the input tensor according to the *permutation* argument.
@@ -5428,11 +5607,12 @@ partial interface MLGraphBuilder {
         These default values cause the output to become a transposed tensor of the input. When specified, the number of values in the sequence must be the same as the [=rank=] of the input tensor, and the values in the sequence must be within the range from 0 to N-1 with no two or more same values found in the sequence.
 </dl>
 
+<div algorithm>
 <details open>
   <summary>
-    The {{MLGraphBuilder/transpose(input, options)}} steps are:
+    The <dfn method for=MLGraphBuilder>transpose(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div algorithm=transpose class=algorithm-steps>
+  <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |options|.{{MLTransposeOptions/permutation}} does not [=map/exist=], let |options|.{{MLTransposeOptions/permutation}} be the reversed sequence of all indices for |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Otherwise if |options|.{{MLTransposeOptions/permutation}} [=map/exists=]:
@@ -5451,6 +5631,7 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+</div>
 
 Examples {#examples}
 =====================

--- a/index.bs
+++ b/index.bs
@@ -2141,7 +2141,7 @@ partial interface MLGraphBuilder {
     1. Else if |input_size| % |options|.{{MLConv2dOptions/groups}} is not 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConv2dOptions/bias}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConv2dOptions/bias}} is {{MLOperand}}.
-    1. If the length of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}}.
+    1. If the [=list/size=] of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/activation}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConv2dOptions/activation}} is {{MLActivation}}.
@@ -2319,7 +2319,7 @@ partial interface MLGraphBuilder {
     1. Else if |input_size| % |options|.{{MLConvTranspose2dOptions/groups}} is not 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConvTranspose2dOptions/bias}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConvTranspose2dOptions/bias}} is {{MLOperand}}.
-    1. If the length of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}}.
+    1. If the [=list/size=] of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/activation}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConvTranspose2dOptions/activation}} is {{MLActivation}}.
@@ -4329,14 +4329,17 @@ partial interface MLGraphBuilder {
   <div algorithm=create-pooling-operation class=algorithm-steps>
     1. [=Assert=]: |op| is one of "averagePool2d", "l2Pool2d", "maxPool2d".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If the length of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLPool2dOptions/outputSizes}} [=map/exists=], or if |options|.{{MLPool2dOptions/padding}} does not [=map/exist=], set |options|.{{MLPool2dOptions/padding}} to `« 0, 0, 0, 0 »`.
-    1. If the length of |padding|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the len[=list/size=]gth of |options|.{{MLPool2dOptions/padding}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLPool2dOptions/strides}} does not [=map/exist=], set |options|.{{MLPool2dOptions/strides}} to `« 1, 1 »`.
-    1. If the length of |options|.{{MLPool2dOptions/strides}} is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=list/size=] of |options|.{{MLPool2dOptions/strides}} is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any value in |options|.{{MLPool2dOptions/strides}} is not greater than 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |options|.{{MLPool2dOptions/outputSizes}} [=map/exists=]:
+        1. If the [=list/size=] of |options|.{{MLPool2dOptions/outputSizes}} is not `2`, then [=exception/throw=] a {{TypeError}}.
+        1. If the elements of |options|.{{MLPool2dOptions/outputSizes}} are not smaller than the elements at the same dimension (index) for |options|.{{MLPool2dOptions/strides}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLPool2dOptions/dilations}} does not [=map/exist=], set |options|.{{MLPool2dOptions/dilations}} to `« 1, 1 »`.
-    1. If the length of |options|.{{MLPool2dOptions/dilations}} is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=list/size=] of |options|.{{MLPool2dOptions/dilations}} is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any value in |options|.{{MLPool2dOptions/dilations}} is not greater than 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLPool2dOptions/autoPad}} is not `"explicit"`, set |options|.{{MLPool2dOptions/padding}} to `« 0, 0, 0, 0 »`.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
@@ -4950,7 +4953,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=softmax-input class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If the length of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
@@ -5161,7 +5164,7 @@ partial interface MLGraphBuilder {
         - *splits*: an {{unsigned long}} or a sequence of {{unsigned long}}. If an {{unsigned long}}, it specifies the number of output tensors along the axis. The number must evenly divide the dimension size of *input* along *options.axis*. If a sequence of {{unsigned long}}, it specifies the sizes of each output tensor along the *options.axis*. The sum of sizes must equal to the dimension size of *input* along *options.axis*.
         - *options*: an optional {{MLSplitOptions}}. The optional parameters of the operation.
 
-    **Returns:** a sequence of {{MLOperand}}. The splitted output tensors. If *splits* is an {{unsigned long}}, the length of the output sequence equals to *splits*. The shape of each output tensor is the same as *input* except the dimension size of *axis* equals to the quotient of dividing the dimension size of *input* along *axis* by *splits*. If *splits* is a sequence of {{unsigned long}}, the length of the output sequence equals to the length of *splits*. The shape of the i-th output tensor is the same as as *input* except along *axis* where the dimension size is *splits[i]*.
+    **Returns:** a sequence of {{MLOperand}}. The splitted output tensors. If *splits* is an {{unsigned long}}, the [=list/size=] of the output sequence equals to *splits*. The shape of each output tensor is the same as *input* except the dimension size of *axis* equals to the quotient of dividing the dimension size of *input* along *axis* by *splits*. If *splits* is a sequence of {{unsigned long}}, the [=list/size=] of the output sequence equals to the [=list/size=] of *splits*. The shape of the i-th output tensor is the same as as *input* except along *axis* where the dimension size is *splits[i]*.
 </div>
 
 {{MLSplitOptions}} has the following members:

--- a/index.bs
+++ b/index.bs
@@ -809,41 +809,88 @@ string "<code><dfn data-lt="webnn-feature">webnn</dfn></code>".
 Its <a>default allowlist</a> is <code>'self'</code>.
 
 ### The {{ML/createContext()}} method ### {#api-ml-createcontext}
+
+<div algorithm>
 <details open>
 <summary>
-    The {{ML/createContext(options)}} method steps are:
+    To <dfn>create a context</dfn> given |options|, run these steps:
 </summary>
-<div algorithm=createcontext class=algorithm-steps>
+<div class=algorithm-steps>
+    1. Let |context| be a new {{MLContext}} object.
+    1. If |options| is a {{GPUDevice}} object,
+        1. Set |context|.{{[[contextType]]}} to "[=webgpu-context|webgpu=]".
+        1. Set |context|.{{[[deviceType]]}} to "[=device-type-gpu|gpu=]".
+        1. Set |context|.{{[[powerPreference]]}} to "[=power-preference-default|default=]".
+    1. Otherwise,
+        1. Set |context|.{{[[contextType]]}} to "[=default-context|default=]".
+        1. If |options|["{{deviceType}}"] [=map/exists=], then set |context|.{{[[deviceType]]}} to |options|["{{deviceType}}"]. Otherwise, set |context|.{{[[deviceType]]}} to "[=device-type-cpu|cpu=]".
+        1. If |options|["{{powerPreference}}"] [=map/exists=], then set |context|.{{[[powerPreference]]}} to |options|["{{powerPreference}}"]. Otherwise, set |context|.{{[[powerPreference]]}} to "[=power-preference-default|default=]".
+    1. Return |context|.
+</div>
+</details>
+</div>
+
+<div algorithm>
+<details open>
+<summary>
+    The <dfn method for=ML>createContext(|options|)</dfn> steps are:
+</summary>
+<div class=algorithm-steps>
     1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, return [=a new promise=] [=rejected=] with a "{{SecurityError}}" {{DOMException}}.
     1. Let |promise| be [=a new promise=].
     1. Return |promise| and run the following steps [=in parallel=].
-    1. Run the <dfn>create context</dfn> steps given |options|:
-        1. Let |context| be a new {{MLContext}} object.
-        1. If |options| is a {{GPUDevice}} object,
-            1. Set |context|.{{[[contextType]]}} to "[=webgpu-context|webgpu=]".
-            1. Set |context|.{{[[deviceType]]}} to "[=device-type-gpu|gpu=]".
-            1. Set |context|.{{[[powerPreference]]}} to "[=power-preference-default|default=]".
-        1. Otherwise,
-            1. Set |context|.{{[[contextType]]}} to "[=default-context|default=]".
-            1. If |options|["{{deviceType}}"] [=map/exists=], then set |context|.{{[[deviceType]]}} to |options|["{{deviceType}}"]. Otherwise, set |context|.{{[[deviceType]]}} to "[=device-type-cpu|cpu=]".
-            1. If |options|["{{powerPreference}}"] [=map/exists=], then set |context|.{{[[powerPreference]]}} to |options|["{{powerPreference}}"]. Otherwise, set |context|.{{[[powerPreference]]}} to "[=power-preference-default|default=]".
+    1. Let |context| be the result of [=creating a context=] given |options|.
     1. If <a>validating MLContext</a> given |context| returns `false`, [=reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}}.
     1. [=Resolve=] |promise| with |context|.
 </div>
 </details>
+</div>
+
+<div algorithm>
+<details open>
+<summary>
+    The <dfn method for=ML>createContext(|gpuDevice|)</dfn> method steps are:
+</summary>
+<div class=algorithm-steps>
+    1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, return [=a new promise=] [=rejected=] with a "{{SecurityError}}" {{DOMException}}.
+    1. Let |promise| be [=a new promise=].
+    1. Return |promise| and run the following steps [=in parallel=].
+    1. Let |context| be the result of [=creating a context=] given |gpuDevice|.
+    1. If <a>validating MLContext</a> given |context| returns `false`, [=reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}}.
+    1. [=Resolve=] |promise| with |context|.
+</div>
+</details>
+</div>
 
 ### The {{ML/createContextSync()}} method ### {#api-ml-createcontextsync}
+
+<div algorithm>
 <details open>
   <summary>
-    The {{ML/createContextSync(options)}} method steps are:
+    The <dfn method for=ML>createContextSync(|options|)</dfn> method steps are:
   </summary>
-  <div algorithm=createcontextsync class=algorithm-steps>
+  <div class=algorithm-steps>
     1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, then [=exception/throw=] a "{{SecurityError}}" {{DOMException}}.
-    1. Let |context| be the result of running the <a>create context</a> steps given |options|.
+    1. Let |context| be the result [=creating a context=] |options|.
     1. If <a>validating MLContext</a> given |context| return `false`, then [=exception/throw=] a "{{NotSupportedError}}" {{DOMException}}.
     1. Return |context|.
   </div>
 </details>
+</div>
+
+<div algorithm>
+<details open>
+  <summary>
+    The <dfn method for=ML>createContextSync(|gpuDevice|)</dfn> method steps are:
+  </summary>
+  <div class=algorithm-steps>
+    1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, then [=exception/throw=] a "{{SecurityError}}" {{DOMException}}.
+    1. Let |context| be the result [=creating a context=] with |gpuDevice|.
+    1. If <a>validating MLContext</a> given |context| return `false`, then [=exception/throw=] a "{{NotSupportedError}}" {{DOMException}}.
+    1. Return |context|.
+  </div>
+</details>
+</div>
 
 ## The MLGraph interface ## {#api-mlgraph}
 The {{MLGraph}} interface represents a compiled computational graph. A compiled graph once constructed is immutable and cannot be subsequently changed.

--- a/index.bs
+++ b/index.bs
@@ -2160,15 +2160,14 @@ partial interface MLGraphBuilder {
     1. Else if |options|.{{MLConv2dOptions/groups}} is 0, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |input_size| / |options|.{{MLConv2dOptions/groups}} is not equal to |filter_size|, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. Else if |input_size| % |options|.{{MLConv2dOptions/groups}} is not 0, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1.
     1. If |options|.{{MLConv2dOptions/inputLayout}} is `undefined`, set it to `"nchw"`.
     1. If |options|.{{MLConv2dOptions/filterLayout}} is `undefined`, set it to `"oihw"`.
     1. If |options|.{{MLConv2dOptions/bias}} [=map/exists=] and it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If the length of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLConv2dOptions/activation}} [=map/exists=] and it is not an instance of {{MLActivation}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. Let |output_shape| be the result of calculating output dimensions based on input, filter, dilation, padding and stride, taking into account |options|.{{MLConv2dOptions/inputLayout}}.
-    1. If the shape of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not the same as |output_shape|, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLConv2dOptions/activation}} [=map/exists=] and it is not an instance of {{MLActivation}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. Let |output_shape| be the result of invoking the underlying implementation for calculating output dimensions, given |options|.
+    1. If |output_shape| is not the same as the shape of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |output_shape|.
@@ -2324,20 +2323,32 @@ partial interface MLGraphBuilder {
     1. Let |filter_size| be the size of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. If |input_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |filter_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. If the type of |input| and |filter| is not the same, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLConvTranspose2dOptions/padding}} is `undefined`, set it to `[0, 0, 0, 0]`.
+    1. Else if |options|.{{MLConvTranspose2dOptions/padding}}.length is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/strides}} is `undefined`, set it to `[1, 1]`.
-    1. Else if |options|.{{MLConv2dOptions/strides}}.length is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. Else if |options|.{{MLConvTranspose2dOptions/strides}}.length is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/dilations}} is `undefined`, set it to `[1, 1]`.
+    1. Else if |options|.{{MLConvTranspose2dOptions/dilations}}.length is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/outputPadding}} is `undefined`, set it to `[0, 0]`.
+    1. Else if |options|.{{MLConvTranspose2dOptions/outputPadding}}.length is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLConvTranspose2dOptions/outputSizes}} [=map/exists=]:
+        1. If |options|.{{MLConvTranspose2dOptions/outputSizes}}.length is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+        1. If the elements of |options|.{{MLConvTranspose2dOptions/outputSizes}} are not smaller than the elements at the same dimension (index) for |options|.{{MLConvTranspose2dOptions/strides}}, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/autoPad}} is `undefined`, set it to `"explicit"`.
     1. If |options|.{{MLConvTranspose2dOptions/groups}} is `undefined`, set it to `1`.
+    1. If |input_size| / |options|.{{MLConvTranspose2dOptions/groups}} is not equal to |filter_size|, then throw a "{{DataError}}" {{DOMException}} and stop.
+    1. Else if |input_size| % |options|.{{MLConvTranspose2dOptions/groups}} is not 0, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/inputLayout}} is `undefined`, set it to `"nchw"`.
     1. If |options|.{{MLConvTranspose2dOptions/filterLayout}} is `undefined`, set it to `"iohw"`.
     1. If |options|.{{MLConvTranspose2dOptions/bias}} [=map/exists=] and it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If the length of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/activation}} [=map/exists=] and it is not an instance of {{MLActivation}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. Let |output_shape| be the result of calculating output dimensions based on |input|, |filter|, |options|.{{MLConvTranspose2dOptions/dilations}}, |options|.{{MLConvTranspose2dOptions/padding}} and |options|.{{MLConvTranspose2dOptions/strides}}, taking into account |options|.{{MLConvTranspose2dOptions/inputLayout}}.
+    1. Let |output_shape| be the result of invoking the underlying implementation for calculating output dimensions, given |options|.
+    1. If |output_shape| is not the same as the shape of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |output_shape|.
@@ -2356,8 +2367,7 @@ partial interface MLGraphBuilder {
 </details>
 
 ### Element-wise binary operations ### {#api-mlgraphbuilder-binary}
-Compute the element-wise binary addition, subtraction, multiplication, division,
-maximum and minimum of the two input tensors.
+Compute the element-wise binary addition, subtraction, multiplication, division, power, maximum and minimum of the two input tensors.
 
 The element-wise binary operations will be broadcasted according to
 [[!numpy-broadcasting-rule]]. The rank of the output tensor is the maximum
@@ -2404,7 +2414,7 @@ partial interface MLGraphBuilder {
     1. If |a| or |b| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not equal to |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
-    1. Set |descriptor|.{{MLOperandDescriptor/dimensions}}.{{MLOperandDescriptor/type}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
+    1. Set |descriptor|.{{MLOperandDescriptor/type}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. Let |descriptor|.{{MLOperandDescriptor/dimensions}} be the result of running the [=MLGraphBuilder/broadcast-shapes=] steps given |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. If that throws an error, re-throw the error and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
@@ -4520,7 +4530,7 @@ partial interface MLGraphBuilder {
   <div algorithm=prelu-input-slope class=algorithm-steps>
     1. If |input| or |slope| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
-    1. Set |descriptor|.{{MLOperandDescriptor/dimensions}}.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
+    1. Set |descriptor|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. Let |descriptor|.{{MLOperandDescriptor/dimensions}} be the result of running the [=MLGraphBuilder/broadcast-shapes=] steps given |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |slope|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. If that throws an error, re-throw the error and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
@@ -4893,7 +4903,7 @@ partial interface MLGraphBuilder {
         1. If the size of |newShape| is `0`, set |outputShape| to `[ 1 ]` (reshaping to scalar).
         1. If |newShape| contains more than one `null` value, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If any value in |newShape| is `0`, then throw a "{{DataError}}" {{DOMException}} and stop.
-        1. Let |inputElementCount| be  the product of all elements in |inputs|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+        1. Let |inputElementCount| be the product of all elements in |inputs|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. If |newShape| contains a `null` value, set that value to |inputElementCount| divided by the product of all other values in |newShape|.
             1. If that value is too large for {{unsigned long}}, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If product of all values in |newShape| is not equal to |inputElementCount|, then throw a "{{DataError}}" {{DOMException}} and stop.

--- a/index.bs
+++ b/index.bs
@@ -1980,7 +1980,7 @@ partial interface MLGraphBuilder {
     </div>
     1. [=Assert=]: the type of |inputs| is sequence of {{MLOperand}} objects.
     1. [=Assert=]: the type of |axis| is `unsigned long`.
-    1. [=Assert=]: the shape, i.e. {{MLOperandDescriptor/dimensions}}) of each operand in |inputs| is the same, except on the dimension given by |axis| on which they are concatenated.
+    1. [=Assert=]: the shape, i.e. {{MLOperandDescriptor/dimensions}} of each operand in |inputs| is the same, except on the dimension given by |axis| on which they are concatenated.
     1. [=Assert=]: the {{MLOperandDescriptor/type}} of each operand in |inputs| is the same.
     1. If any of the following steps fail, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Let |desc| be |inputs|[0].{{MLOperand/[[descriptor]]}}.
@@ -2139,7 +2139,7 @@ partial interface MLGraphBuilder {
     1. Let |filterSize| be the [=list/size=] of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. If |inputSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |filterSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}}.
+    1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as {{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/padding}} does not [=map/exist=], set it to `« 0, 0, 0, 0 »`.
     1. Else if the [=list/size=] of |options|.{{MLConv2dOptions/padding}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConv2dOptions/strides}} does not [=map/exist=], set it to `« 1, 1 »`.
@@ -2315,7 +2315,7 @@ partial interface MLGraphBuilder {
     1. Let |filterSize| be the [=list/size=] of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. If |inputSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |filterSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}}.
+    1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as {{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/padding}} does not [=map/exist=], set it to `« 0, 0, 0, 0 »`.
     1. Else if the [=list/size=] of |options|.{{MLConvTranspose2dOptions/padding}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConvTranspose2dOptions/strides}} does not [=map/exist=], set it to `« 1, 1 »`.
@@ -4107,7 +4107,7 @@ partial interface MLGraphBuilder {
     1. If |sizeA| and |sizeB| is 1, return `«  1  »`.
     1. If |sizeA| is 1 and |sizeB| is not, then insert 1 in the front of |shapeA| to become [ 1 | |shapeA| ] and let |sizeA| be 2.
     1. If |shapeA|[0] is not equal to |shapeB|[|sizeB| - 2], then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-    1. If |sizeB| is 1 and |sizeA| is not, then insert 1 in the front of |shapeB| to become [ 1 | |shapeB| ] and let |sizeB| be 2.
+    1. If |sizeB| is 1 and |sizeA| is not, then append 1 to |shapeB| to become [ |shapeB| | 1 ] and let |sizeB| be 2.
     1. If |shapeA|[|sizeA| - 1] is not equal to |shapeB|[0], then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
     1. If |shapeA| is not equal to |shapeB|, then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
     1. Let |shape| be an array whose size |size| is the maximum of |sizeA| and |sizeB|.

--- a/index.bs
+++ b/index.bs
@@ -2145,7 +2145,7 @@ partial interface MLGraphBuilder {
     1. Let |filterSize| be the [=list/size=] of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. If |inputSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |filterSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as {{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
+    1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/padding}} does not [=map/exist=], set it to `« 0, 0, 0, 0 »`.
     1. Else if the [=list/size=] of |options|.{{MLConv2dOptions/padding}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConv2dOptions/strides}} does not [=map/exist=], set it to `« 1, 1 »`.
@@ -4802,10 +4802,9 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. Let |desc| be an {{MLOperandDescriptor}} initialized to |input|.{{MLOperand/[[descriptor]]}}.
-    1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], then set |desc|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} to |options|.{{MLResample2dOptions/sizes}} and return |desc|.
     1. For |index| in [=the range=] 0 to the [=list/size=] of |options|.{{MLResample2dOptions/axes}}, exclusive:
-        1. Let |inputSize| be the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|index|].
-        1. Set |desc|.{{MLOperandDescriptor/dimensions}}[|index|] to |inputSize| multiplied by |options|.{{MLResample2dOptions/scales}}.
+        1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], set |desc|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLResample2dOptions/axes}}[|index|]] to |options|.{{MLResample2dOptions/sizes}}[|index|] and return |desc|.
+        1. Otherwise, set |desc|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLResample2dOptions/axes}}[|index|]] to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|index|] multiplied by |options|.{{MLResample2dOptions/scales}}.
     1. Return |desc|.
   </div>
 </details>

--- a/index.bs
+++ b/index.bs
@@ -965,7 +965,7 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
     To <dfn>create MLOperand</dfn> given |builder| and |desc|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. If |builder| is not an instance of {{MLGraphBuilder}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |builder| is {{MLGraphBuilder}}.
     1. If |desc| is not an [=object=] that [=implements=] {{MLOperandDescriptor}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. Let |operand| be a new [=object=].
     1. Set |operand|.{{MLOperand/[[builder]]}} to |builder|.
@@ -979,7 +979,7 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
     To <dfn>copy MLOperand</dfn> given |operand|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. If |operand| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" and stop.
+    1. [=Assert=]: the type of |operand| is {{MLOperand}}.
     1. Let |result| be a new [=object=].
     1. Set |result|.{{MLOperand/[[builder]]}} to |operand|.{{MLOperand/[[builder]]}}.
     1. Set |result|.{{MLOperand/[[descriptor]]}} to |operand|.{{MLOperand/[[descriptor]]}}.
@@ -1006,7 +1006,7 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
     To <dfn for="MLOperand">validate MLOperand</dfn> given |operand| and |builder|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. If |operand|.{{MLOperand/[[builder]]}} is not an instance of {{MLGraphBuilder}}, return `false`.
+    1. [=Assert=]: the type of |operand|.{{MLOperand/[[builder]]}} is {{MLGraphBuilder}}.
     1. If |builder| is not `undefined` and is not equal to |operand|.{{MLOperand/[[builder]]}}, return `false`.
     1. Let |desc| be |operand|.{{MLOperand/[[descriptor]]}}.
     1. If |desc| is not an [=object=] that [=implements=] {{MLOperandDescriptor}}, return `false`.
@@ -1057,7 +1057,7 @@ The {{MLActivation}} objects (including the ones passed as input to methods) are
     To <dfn>create MLActivation</dfn> given |builder|, |name|, |options| and |init-steps|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. If |builder| is not an instance of {{MLGraphBuilder}}, throw a "{{TypeError}}" and abort these steps.
+    1. [=Assert=]: the type of |builder| is {{MLGraphBuilder}}.
     1. If |name| is `undefined` or `null`,  throw a "{{TypeError}}" and abort these steps.
     1. Let |activation| be a new [=object=].
     1. Set |activation|.{{MLActivation/[[builder]]}} to |builder|.
@@ -1653,10 +1653,12 @@ Build a composed graph up to a given output operand into a computational graph, 
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
-    1. If |outputs| is not an instance of {{MLNamedOperands}} or otherwise if empty, then throw an "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |outputs| is {{MLNamedOperands}}.
+    1. If |outputs| is empty, then throw an "{{TypeError}}" {{DOMException}} and stop.
     1. For each |element| in |outputs|:
-        1. If |element|.key is not a [=string=] or otherwise if empty, then throw an "{{TypeError}}" {{DOMException}} and stop.
-        1. If |element|.value is not an instance of {{MLOperand}}, then throw an "{{TypeError}}" {{DOMException}} and stop.
+        1. [=Assert=]: the type of |element|.key is [=string=].
+        1. If |element|.key is empty, then throw an "{{TypeError}}" {{DOMException}} and stop.
+        1. [=Assert=]: the type of |element|.value is {{MLOperand}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |graph| be a new {{MLGraph}}:
             1. Set |graph|.{{MLGraph/[[context]]}} to [=this=].{{MLGraphBuilder/[[context]]}}.
@@ -2141,7 +2143,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/conv2d(input, filter, options)}} steps are:
   </summary>
   <div algorithm=conv2d class=algorithm-steps>
-    1. If |input| or |filter| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| and |filter| is {{MLOperand}}.
     1. Let |input_size| be the size of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Let |filter_size| be the size of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. If |input_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
@@ -2162,10 +2164,12 @@ partial interface MLGraphBuilder {
     1. Else if |input_size| % |options|.{{MLConv2dOptions/groups}} is not 0, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConv2dOptions/inputLayout}} is `undefined`, set it to `"nchw"`.
     1. If |options|.{{MLConv2dOptions/filterLayout}} is `undefined`, set it to `"oihw"`.
-    1. If |options|.{{MLConv2dOptions/bias}} [=map/exists=] and it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLConv2dOptions/bias}} [=map/exists=]:
+        1. [=Assert=]: the type of |options|.{{MLConv2dOptions/bias}} is {{MLOperand}}.
     1. If the length of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLConv2dOptions/activation}} [=map/exists=] and it is not an instance of {{MLActivation}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLConv2dOptions/activation}} [=map/exists=]:
+        1. [=Assert=]: the type of |options|.{{MLConv2dOptions/activation}} is {{MLActivation}}.
     1. Let |output_shape| be the result of invoking the underlying implementation for calculating output dimensions, given |options|.
     1. If |output_shape| is not the same as the shape of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. Let |desc| a new {{MLOperandDescriptor}}.
@@ -2318,7 +2322,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/convTranspose2d(input, filter, options)}} steps are:
   </summary>
   <div algorithm=convtranspose2d class=algorithm-steps>
-    1. If |input| or |filter| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| and |filter| is {{MLOperand}}.
     1. Let |input_size| be the size of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Let |filter_size| be the size of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. If |input_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
@@ -2343,10 +2347,12 @@ partial interface MLGraphBuilder {
     1. Else if |input_size| % |options|.{{MLConvTranspose2dOptions/groups}} is not 0, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/inputLayout}} is `undefined`, set it to `"nchw"`.
     1. If |options|.{{MLConvTranspose2dOptions/filterLayout}} is `undefined`, set it to `"iohw"`.
-    1. If |options|.{{MLConvTranspose2dOptions/bias}} [=map/exists=] and it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLConvTranspose2dOptions/bias}} [=map/exists=]:
+        1. [=Assert=]: the type of |options|.{{MLConvTranspose2dOptions/bias}} is {{MLOperand}}.
     1. If the length of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLConvTranspose2dOptions/activation}} [=map/exists=] and it is not an instance of {{MLActivation}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLConvTranspose2dOptions/activation}} [=map/exists=]:
+        1. [=Assert=]: the type of |options|.{{MLConvTranspose2dOptions/activation}} is {{MLActivation}}.
     1. Let |output_shape| be the result of invoking the underlying implementation for calculating output dimensions, given |options|.
     1. If |output_shape| is not the same as the shape of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. Let |desc| a new {{MLOperandDescriptor}}.
@@ -2411,7 +2417,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=binary class=algorithm-steps>
     1. [=Assert=]: |op| is one of "add", "sub", "mul", "div", "max", "min", "pow".
-    1. If |a| or |b| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |a| and |b| is {{MLOperand}}.
     1. If |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not equal to |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
     1. Set |descriptor|.{{MLOperandDescriptor/type}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
@@ -2530,7 +2536,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=unary class=algorithm-steps>
     1. [=Assert=]: |op| is one of "abs", "ceil", "cos", "exp", "floor", "log", "neg", "sin", "tan".
-    1. If |input| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. Let |kind| be `"output"`.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
@@ -2753,7 +2759,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/gemm(a, b, options)}} steps are:
   </summary>
   <div algorithm=gemm class=algorithm-steps>
-    1. If |a| or |b| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |a| and |b| is {{MLOperand}}.
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLGemmOptions/alpha}} is `undefined`, set it to `1.0`.
     1. If |options|.{{MLGemmOptions/beta}} is `undefined`, set it to `1.0`.
@@ -2891,18 +2897,18 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/gru(input, weight, recurrentWeight, steps, hiddenSize, options)}} steps are:
   </summary>
   <div algorithm=gru class=algorithm-steps>
-    1. If |input|, |weight| or |recurrentWeight| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
     1. If the rank of |input| or |weight| is not `3`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If the rank of |weight| or |recurrentWeight| is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLGruOptions/bias}} [=map/exists=].
-        1. If it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+        1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLGruOptions/recurrentBias}} [=map/exists=].
-        1. If it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+        1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLGruOptions/initialHiddenState}} [=map/exists=].
-        1. If it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+        1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `3`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLGruOptions/resetAfter}} is `undefined`, set it to `true`.
     1. If |options|.{{MLGruOptions/returnSequence}} is `undefined`, set it to `false`.
@@ -2910,7 +2916,7 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLGruOptions/direction}} is not one of {{MLRecurrentNetworkDirection}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options|.{{MLGruOptions/layout}} is `undefined`, set it to `"zrn"`.
     1. If |options|.{{MLGruOptions/layout}} is not one of {{MLGruWeightLayout}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of size `2`, or if any of its elements is not an instance of {{MLActivation}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of {{MLActivation}} objects with size `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |steps| is not a [=number=] or it is `0`, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. Let |output| be an empty sequence of {{MLOperand}} objects.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
@@ -3046,20 +3052,20 @@ partial interface MLGraphBuilder {
      The {{MLGraphBuilder/gruCell(input, weight, recurrentWeight, hiddenState, hiddenSize, options)}} steps are:
   </summary>
   <div algorithm=grucell class=algorithm-steps>
-    1. If |input|, |weight| or |recurrentWeight| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
     1. If the rank of |input| or |weight| is not `3`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If the rank of |weight| or |recurrentWeight| is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options| is `undefined`, let |options| be an empty [=object=].
-    1. If |options|.{{MLGruOptions/bias}} [=map/exists=].
-        1. If it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLGruOptions/bias}} [=map/exists=]:
+        1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `1`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLGruOptions/recurrentBias}} [=map/exists=].
-        1. If it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLGruOptions/recurrentBias}} [=map/exists=]:
+        1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `1`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLGruOptions/resetAfter}} is `undefined`, set it to `true`.
     1. If |options|.{{MLGruOptions/layout}} is `undefined`, set it to `"zrn"`.
     1. If |options|.{{MLGruOptions/layout}} is not one of {{MLGruWeightLayout}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of size `2`, or if any of its elements is not an instance of {{MLActivation}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of {{MLActivation}} objects with size `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |input|.{{MLOperandDescriptor/dimensions}}[0], |hiddenSize| ].
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
@@ -3414,12 +3420,12 @@ The {{MLInstanceNormalizationOptions}} members are:
     The {{MLGraphBuilder/instanceNormalization(input, options)}} steps are:
   </summary>
   <div algorithm=instancenorm class=algorithm-steps>
-    1. If |input| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If the rank of |input| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options| is `undefined`, let |options| be an empty [=object=].
-    1. If |options|.{{MLInstanceNormalizationOptions/scale}} is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]:  the type of |options|.{{MLInstanceNormalizationOptions/scale}} is {{MLOperand}}.
     1. If the rank of |options|.{{MLInstanceNormalizationOptions/scale}} is not equal to the size of the channel dimension of |input|, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLInstanceNormalizationOptions/bias}} is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |options|.{{MLInstanceNormalizationOptions/bias}} is  {{MLOperand}}.
     1. If the rank of |options|.{{MLInstanceNormalizationOptions/bias}} is not equal to the size of the channel dimension of |input|, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLInstanceNormalizationOptions/epsilon}} is `undefined`, let it be `0.00001`.
     1. If |options|.{{MLInstanceNormalizationOptions/layout}} is `undefined`, let it be `"nchw"`.
@@ -3777,35 +3783,35 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLLstmOptions/direction}} is `undefined`, set it to `"forward"`.
     1. If |options|.{{MLLstmOptions/direction}} is not one of {{MLRecurrentNetworkDirection}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. Let |num_directions| be `1` if |options|.{{MLLstmOptions/direction}} is `"forward"`, or otherwise let it be `2`.
-    1. If |input|, |weight| or |recurrentWeight| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
         <div class="note">
             The shape of |input|, |weight| or |recurrentWeight| could be also checked here.
         </div>
     1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not equal to |steps|, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. Let |batch_size| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1].
-    1. If |options|.{{MLLstmOptions/bias}} [=map/exists=].
-        1. If it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLLstmOptions/bias}} [=map/exists=]:
+        1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not 4 * |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLLstmOptions/recurrentBias}} [=map/exists=].
-        1. If it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLLstmOptions/recurrentBias}} [=map/exists=]:
+        1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not 4 * |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLLstmOptions/peepholeWeight}} [=map/exists=].
-        1. If it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLLstmOptions/peepholeWeight}} [=map/exists=]:
+        1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not 4 * |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLLstmOptions/initialHiddenState}} [=map/exists=].
-        1. If it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLLstmOptions/initialHiddenState}} [=map/exists=]:
+        1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `3`, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmOptions/initialHiddenState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmOptions/initialHiddenState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to |batch_size|, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmOptions/initialHiddenState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[2] is not |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLLstmOptions/initialCellState}} [=map/exists=].
-        1. If it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLLstmOptions/initialCellState}} [=map/exists=]:
+        1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `3`, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not |num_directions|, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1] is not equal to |batch_size|, then throw a "{{DataError}}" {{DOMException}} and stop.
@@ -3815,7 +3821,7 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLLstmOptions/layout}} is not one of {{MLLstmWeightLayout}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options|.{{MLLstmOptions/activations}} [=map/exists=]:
         1. If it is not an array of size `3`, then throw a "{{TypeError}}" {{DOMException}} and stop.
-        1. If any of its elements is not an instance of {{MLActivation}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+        1. [=Assert=]: the type of its elements is {{MLActivation}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |desc| a new {{MLOperandDescriptor}}.
         1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |nume_directions|, |batch_size|, |hiddenSize| ].
@@ -3977,27 +3983,27 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/lstmCell(input, weight, recurrentWeight, hiddenState, cellState, hiddenSize, options)}} steps are:
   </summary>
   <div algorithm=lstmcell class=algorithm-steps>
-    1. If |input|, |weight|, |recurrentWeight|, |hiddenState| or |cellState| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input|, |weight|, |recurrentWeight|, |hiddenState| and |cellState| is {{MLOperand}}.
     1. If the rank of |input|, |weight|, |recurrentWeight|, |hiddenState| or |cellState| is not `2`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. Let |batch_size| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0].
     1. If |options| is `undefined`, let |options| be an empty [=object=].
-    1. If |options|.{{MLLstmCellOptions/bias}} [=map/exists=].
-        1. If it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLLstmCellOptions/bias}} [=map/exists=]:
+        1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `1`, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmCellOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not 4 * |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLLstmCellOptions/recurrentBias}} [=map/exists=].
-        1. If it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLLstmCellOptions/recurrentBias}} [=map/exists=]:
+        1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `1`, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmCellOptions/recurrentBias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not 4 * |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLLstmCellOptions/peepholeWeight}} [=map/exists=].
-        1. If it is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLLstmCellOptions/peepholeWeight}} [=map/exists=]:
+        1. [=Assert=]: its type is {{MLOperand}}.
         1. If its rank is not `1`, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmCellOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not 3 * |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLLstmCellOptions/layout}} is `undefined`, set it to `"iofg"`.
     1. If |options|.{{MLLstmCellOptions/layout}} is not one of {{MLLstmWeightLayout}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options|.{{MLLstmCellOptions/activations}} [=map/exists=]:
         1. If it is not an array of size `3`, then throw a "{{TypeError}}" {{DOMException}} and stop.
-        1. If any of its elements is not an instance of {{MLActivation}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+        1. [=Assert=]: the type of its elements is {{MLActivation}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |batch_size|, |hiddenSize| ].
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
@@ -4181,7 +4187,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/matmul(a, b)}} steps are:
   </summary>
   <div algorithm=matmul class=algorithm-steps>
-    1. If |a| or |b| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |a| and |b| is {{MLOperand}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of invoking the <a>calculate matmul output sizes</a> given |a| and |b|.
     1. Set |desc|.{{MLOperandDescriptor/type}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
@@ -4266,7 +4272,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/pad(input, beginningPadding, endingPadding, options)}} steps are:
   </summary>
   <div algorithm=pad class=algorithm-steps>
-    1. If |input| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |beginningPadding| or |endingPadding| is not a sequence of {{unsigned long}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLPadOptions/mode}} is `undefined`, set it to `"constant"`.
@@ -4450,7 +4456,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=create-pooling-operation class=algorithm-steps>
     1. [=Assert=]: |op| is one of "averagePool2d", "l2Pool2d", "maxPool2d".
-    1. If |input| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If the length of of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options| is `undefined`, let |options| be a new {{MLPool2dOptions}} object.
     1. If |options|.{{MLPool2dOptions/outputSizes}} [=map/exists=], or if |options|.{{MLPool2dOptions/padding}} is `undefined`, set |options|.{{MLPool2dOptions/padding}} to `[0, 0, 0, 0]`.
@@ -4528,7 +4534,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/prelu(input, slope)}} steps are:
   </summary>
   <div algorithm=prelu-input-slope class=algorithm-steps>
-    1. If |input| or |slope| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| and |slope| is {{MLOperand}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
     1. Set |descriptor|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. Let |descriptor|.{{MLOperandDescriptor/dimensions}} be the result of running the [=MLGraphBuilder/broadcast-shapes=] steps given |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |slope|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
@@ -4615,7 +4621,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=reduce class=algorithm-steps>
     1. [=Assert=]: |op| is one of "reduceL1", "reduceL2", "reduceLogSum", "reduceLogSumExp", "reduceMax", "reduceMean", "reduceMin", "reduceProduct", "reduceSum", "reduceSumSquare".
-    1. If |input| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |options| is `undefined`, let |options| be a new {{MLReduceOptions}} object with |options|.{{MLReduceOptions/keepDimensions}} set to `false` and |options|.{{MLReduceOptions/axes}} set to `null`.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
@@ -4723,7 +4729,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/relu(input)}} steps are:
   </summary>
   <div algorithm=relu-input class=algorithm-steps>
-    1. If |input| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -4896,7 +4902,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/reshape(input, newShape)}} steps are:
   </summary>
   <div algorithm=reshape class=algorithm-steps>
-    1. If |input| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. Let |outputShape| be an empty array of {{unsigned long}}.
     1. If |newShape| is a scalar [=number=], set |outputShape| to `[ 1 ]`.
     1. Otherwise, if |newShape| is an array of {{unsigned long}}:
@@ -4963,7 +4969,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/sigmoid(input)}} steps are:
   </summary>
   <div algorithm=sigmoid-input class=algorithm-steps>
-    1. If |input| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -5018,7 +5024,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/slice(input, starts, sizes)}} steps are:
   </summary>
   <div algorithm=slice class=algorithm-steps>
-    1. If |input| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |starts| or |sizes| is not a sequence of {{long}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
     1. If |sizes|.size is 0, then throw a "{{TypeError}}" {{DOMException}} and stop.
         <div class="note">
@@ -5082,7 +5088,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/softmax(input)}} steps are:
   </summary>
   <div algorithm=softmax-input class=algorithm-steps>
-    1. If |input| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If the length of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 2, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
@@ -5258,7 +5264,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/softsign(input)}} steps are:
   </summary>
   <div algorithm=softsign-input class=algorithm-steps>
-    1. If |input| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -5327,7 +5333,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/split(input, splits, options)}} steps are:
   </summary>
   <div algorithm=split class=algorithm-steps>
-    1. If |input| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLSplitOptions/axis}} is `undefined`, let |options|.{{MLSplitOptions/axis}} be `0`.
     1. If |splits| is not {{unsigned long}} or a sequence of {{unsigned long}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
@@ -5403,7 +5409,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/squeeze(input, options)}} steps are:
   </summary>
   <div algorithm=squeeze class=algorithm-steps>
-    1. If |input| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLSqueezeOptions/axes}} [=map/exists=], then:
         1. Let |dimensions| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
@@ -5462,7 +5468,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/tanh(input)}} steps are:
   </summary>
   <div algorithm=tanh-input class=algorithm-steps>
-    1. If |input| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -5531,7 +5537,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/transpose(input, options)}} steps are:
   </summary>
   <div algorithm=transpose class=algorithm-steps>
-    1. If |input| is not an instance of {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLTransposeOptions/permutation}} is `undefined`, let |options|.{{MLTransposeOptions/permutation}} be the reversed sequence of all indices for |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Otherwise if |options|.{{MLTransposeOptions/permutation}} [=map/exists=]:

--- a/index.bs
+++ b/index.bs
@@ -4399,7 +4399,7 @@ partial interface MLGraphBuilder {
 
     : <dfn>autoPad</dfn>
     ::
-        An {{MLAutoPad}} [=string=]].
+        An {{MLAutoPad}} [=string=].
         Specifies the automatic input padding options.
         The default value is *"explicit"*, which means that the values in the {{MLPool2dOptions/padding}} array should be used for input padding.
         When the option is set other than *"explicit"*, the values in the {{MLPool2dOptions/padding}} array are ignored.
@@ -4445,7 +4445,7 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLPool2dOptions/outputSizes}} [=map/exists=], or if |options|.{{MLPool2dOptions/padding}} is `undefined`, set |options|.{{MLPool2dOptions/padding}} to `[0, 0, 0, 0]`.
     1. If |options|.{{MLPool2dOptions/strides}} is `undefined`, set |options|.{{MLPool2dOptions/strides}} to `[1, 1]`.
     1. If |options|.{{MLPool2dOptions/dilations}} is `undefined`, set |options|.{{MLPool2dOptions/dilations}} to `[1, 1]`.
-    1. If |options|.{{MLPool2dOptions/autoPad}} is `undefined`, set |options|.{{MLPool2dOptions/autoPad}} to `"explicit`.
+    1. If |options|.{{MLPool2dOptions/autoPad}} is `undefined`, set |options|.{{MLPool2dOptions/autoPad}} to `"explicit"`.
     1. If |options|.{{MLPool2dOptions/autoPad}} is not `"explicit"`, set |options|.{{MLPool2dOptions/padding}} to `[0, 0, 0, 0]`.
     1. If |options|.{{MLPool2dOptions/layout}} is `undefined`, set |options|.{{MLPool2dOptions/layout}} to `"nchw"`.
     1. If |options|.{{MLPool2dOptions/roundingType}} is `undefined`, set |options|.{{MLPool2dOptions/roundingType}} to `"floor"`.

--- a/index.bs
+++ b/index.bs
@@ -966,7 +966,7 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |builder| is {{MLGraphBuilder}}.
-    1. If |desc| is not an [=object=] that [=implements=] {{MLOperandDescriptor}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |desc| is not an [=object=] that [=implements=] {{MLOperandDescriptor}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. Let |operand| be a new [=object=].
     1. Set |operand|.{{MLOperand/[[builder]]}} to |builder|.
     1. Set |operand|.{{MLOperand/[[descriptor]]}} to |desc|.
@@ -1607,9 +1607,9 @@ Create a named {{MLOperand}} based on a descriptor, that can be used as an input
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
     1. Let |name| be the first argument.
-        1. If |name| is `undefined` or an empty [=string=], then throw a "{{TypeError}}" {{DOMException}} and stop.
+        1. If |name| is `undefined` or an empty [=string=], then [=exception/throw=] a {{TypeError}} and stop.
     1. Let |descriptor| be the second argument.
-        1. If |descriptor| is not an an object that [=implements=] {{MLOperandDescriptor}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+        1. If |descriptor| is not an an object that [=implements=] {{MLOperandDescriptor}}, then [=exception/throw=] a {{TypeError}} and stop.
         1. [=Assert=]: If |descriptor|.{{MLOperandDescriptor/dimensions}} does not [=map/exist=], then |descriptor| defines a scalar input.
         1. If |descriptor|.{{MLOperandDescriptor/dimensions}} [=map/exists=]:
             1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return `false`, throw a "{{DataError}}" {{DOMException}} and stop.
@@ -1654,10 +1654,10 @@ Build a composed graph up to a given output operand into a computational graph, 
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
     1. [=Assert=]: the type of |outputs| is {{MLNamedOperands}}.
-    1. If |outputs| is empty, then throw an "{{TypeError}}" {{DOMException}} and stop.
+    1. If |outputs| is empty, then [=exception/throw=] a {{TypeError}} and stop.
     1. For each |element| in |outputs|:
         1. [=Assert=]: the type of |element|.key is [=string=].
-        1. If |element|.key is empty, then throw an "{{TypeError}}" {{DOMException}} and stop.
+        1. If |element|.key is empty, then [=exception/throw=] a {{TypeError}} and stop.
         1. [=Assert=]: the type of |element|.value is {{MLOperand}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |graph| be a new {{MLGraph}}:
@@ -1667,9 +1667,9 @@ Build a composed graph up to a given output operand into a computational graph, 
             1. Store a reference to |graphImpl| in |graph|.{{MLGraph/[[implementation]]}}.
         1. Make a request to the underlying platform to initialize the graph:
             1. For each |operand| in |outputs|:
-                1. If running the <a>validate MLOperand</a> given |operand| and [=this=] returns `false`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+                1. If running the <a>validate MLOperand</a> given |operand| and [=this=] returns `false`, then [=exception/throw=] a {{TypeError}} and stop.
                 1. If |operand| was created as an input by the underlying platform:
-                    1. If |operand|.{{MLOperand/[[name]]}}] is not unique for |graphImpl|, then throw a "{{TypeError}}" {{DOMException}} and stop.
+                    1. If |operand|.{{MLOperand/[[name]]}}] is not unique for |graphImpl|, then [=exception/throw=] a {{TypeError}} and stop.
                     1. Add |operand|.{{MLOperand/[[descriptor]]}} to |graph|.{{MLGraph/[[inputDescriptors]]}}[|operand|.{{MLOperand/[[name]]}}].
                 1. If |operand| was created as a constant by the underlying platform:
                     1. Implementations MAY preprocess and optimize the tensor data of |operand| for the underlying platform.
@@ -1699,11 +1699,11 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
     1. Let |descriptor| be the first argument.
-    1. If |descriptor| is not an an object that [=implements=] {{MLOperandDescriptor}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |descriptor| is not an an object that [=implements=] {{MLOperandDescriptor}}, then [=exception/throw=] a {{TypeError}} and stop.
         1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return `false`, throw a "{{DataError}}" {{DOMException}} and stop.
     1. Let |bufferView| be the second argument.
-        1. If invoking <a>validate buffer with descriptor</a> given |bufferView| and |descriptor| return `false`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+        1. If invoking <a>validate buffer with descriptor</a> given |bufferView| and |descriptor| return `false`, then [=exception/throw=] a {{TypeError}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |operand| be the result of invoking the <a>create MLOperand</a> steps with [=this=] and |descriptor|.
         1. Let |bytes| be the result of invoking [[=get a copy of the bytes held by the buffer source=]] given |bufferView|.
@@ -1732,9 +1732,8 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
-    1. If |value| is not a [=number=], then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. If |type| is `undefined`, let |type| be `"float32"`.
-    1. Otherwise, if |type| is not one of {{MLOperandType}}, then  throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |value| is not a [=number=], then [=exception/throw=] a {{TypeError}} and stop.
+    1. Otherwise, if |type| is not one of {{MLOperandType}}, then  [=exception/throw=] a {{TypeError}} and stop.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
         1. Set |descriptor|.{{MLOperandDescriptor/type}} to |type|.
         1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to `undefined`.
@@ -1808,14 +1807,14 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=batchnorm class=algorithm-steps>
     1. Let |input| be the first argument. To validate |input|, run these substeps:
-        1. If |input| is not an [=object=] that [=implements=] {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and abort these steps.
+        1. If |input| is not an [=object=] that [=implements=] {{MLOperand}}, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. Let |mean| be the second argument, representing a vector with the moving mean values for |input|. To validate |mean|, run the following substeps:
-        1. If |mean| is not an [=object=] that [=implements=] {{MLOperand}}, then throw a "{{TypeError}}" {{DOMException}} and abort these steps.
-        1. If |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} from which the dimension represented by |options|.axis is removed, then  throw a "{{TypeError}}" {{DOMException}} and abort these steps.
+        1. If |mean| is not an [=object=] that [=implements=] {{MLOperand}}, then [=exception/throw=] a {{TypeError}} and abort these steps.
+        1. If |mean|.{{MLOperand/[[descriptor]]}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not equal with |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} from which the dimension represented by |options|.axis is removed, then  [=exception/throw=] a {{TypeError}} and abort these steps.
     1. Let |variance| be the third argument, representing the moving variance values of |input|.
     1. Let |options| be the fourth argument. To validate |options|, run these substeps:
         1. If |options|.axis does not [=map/exist=], let |options|."axis" be 1.
-        1. If |options|.axis is not a number between 0 and the rank of |input|, then throw a "{{TypeError}}" {{DOMException}} and abort these steps.
+        1. If |options|.axis is not a number between 0 and the rank of |input|, then [=exception/throw=] a {{TypeError}} and abort these steps.
         1. If |input| is a 4-D tensor of the *"nchw"* layout, set |options|.axis to 1.
         1. If |input| is a 4-D tensor of the *"nhwc"* layout, set |options|.axis to 3.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
@@ -1921,7 +1920,7 @@ partial interface MLGraphBuilder {
   <div algorithm=clamp class=algorithm-steps>
     1. Let |operand| be the first argument.
     1. Let |options| be the second argument.
-        1. If running the <a>check clamp options</a> steps with |options| returns `false`, then throw a "{{TypeError}}" {{DOMException}} and abort these steps.
+        1. If running the <a>check clamp options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |operand|.
         1. Make a request to the underlying platform to:
@@ -1951,7 +1950,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=clamp-options class=algorithm-steps>
     1. Let |options| be the first argument.
-        1. If running the <a>check clamp options</a> steps with |options| returns `false`, then throw a "{{TypeError}}" {{DOMException}} and abort these steps.
+        1. If running the <a>check clamp options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"clamp"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
@@ -2148,15 +2147,15 @@ partial interface MLGraphBuilder {
     1. Let |filter_size| be the size of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. If |input_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |filter_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If the type of |input| and |filter| is not the same, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLConv2dOptions/padding}} is `undefined`, set it to `[0, 0, 0, 0]`.
     1. Else if |options|.{{MLConv2dOptions/padding}}.length is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConv2dOptions/strides}} is `undefined`, set it to `[1, 1]`.
-    1. Else if |options|.{{MLConv2dOptions/strides}}.length is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. Else if |options|.{{MLConv2dOptions/strides}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLConv2dOptions/dilations}} is `undefined`, set it to `[1, 1]`.
-    1. Else if |options|.{{MLConv2dOptions/dilations}}.length is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. Else if |options|.{{MLConv2dOptions/dilations}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLConv2dOptions/autoPad}} is `undefined`, set it to `"explicit"`.
     1. If |options|.{{MLConv2dOptions/groups}} is `undefined`, set it to `1`.
     1. Else if |options|.{{MLConv2dOptions/groups}} is 0, then throw a "{{DataError}}" {{DOMException}} and stop.
@@ -2166,8 +2165,8 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLConv2dOptions/filterLayout}} is `undefined`, set it to `"oihw"`.
     1. If |options|.{{MLConv2dOptions/bias}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConv2dOptions/bias}} is {{MLOperand}}.
-    1. If the length of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If the length of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLConv2dOptions/activation}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConv2dOptions/activation}} is {{MLActivation}}.
     1. Let |output_shape| be the result of invoking the underlying implementation for calculating output dimensions, given |options|.
@@ -2327,19 +2326,19 @@ partial interface MLGraphBuilder {
     1. Let |filter_size| be the size of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. If |input_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |filter_size| is not `4`, then throw a "{{DataError}}" {{DOMException}} and stop.
-    1. If the type of |input| and |filter| is not the same, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If the type of |input| and |filter| is not the same, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLConvTranspose2dOptions/padding}} is `undefined`, set it to `[0, 0, 0, 0]`.
     1. Else if |options|.{{MLConvTranspose2dOptions/padding}}.length is not 4, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/strides}} is `undefined`, set it to `[1, 1]`.
-    1. Else if |options|.{{MLConvTranspose2dOptions/strides}}.length is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. Else if |options|.{{MLConvTranspose2dOptions/strides}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If any element in |options|.{{MLConv2dOptions/strides}} is equal to 0, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/dilations}} is `undefined`, set it to `[1, 1]`.
-    1. Else if |options|.{{MLConvTranspose2dOptions/dilations}}.length is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. Else if |options|.{{MLConvTranspose2dOptions/dilations}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/outputPadding}} is `undefined`, set it to `[0, 0]`.
-    1. Else if |options|.{{MLConvTranspose2dOptions/outputPadding}}.length is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. Else if |options|.{{MLConvTranspose2dOptions/outputPadding}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/outputSizes}} [=map/exists=]:
-        1. If |options|.{{MLConvTranspose2dOptions/outputSizes}}.length is not `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+        1. If |options|.{{MLConvTranspose2dOptions/outputSizes}}.length is not `2`, then [=exception/throw=] a {{TypeError}} and stop.
         1. If the elements of |options|.{{MLConvTranspose2dOptions/outputSizes}} are not smaller than the elements at the same dimension (index) for |options|.{{MLConvTranspose2dOptions/strides}}, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/autoPad}} is `undefined`, set it to `"explicit"`.
     1. If |options|.{{MLConvTranspose2dOptions/groups}} is `undefined`, set it to `1`.
@@ -2349,8 +2348,8 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLConvTranspose2dOptions/filterLayout}} is `undefined`, set it to `"iohw"`.
     1. If |options|.{{MLConvTranspose2dOptions/bias}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConvTranspose2dOptions/bias}} is {{MLOperand}}.
-    1. If the length of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If the length of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLConvTranspose2dOptions/activation}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConvTranspose2dOptions/activation}} is {{MLActivation}}.
     1. Let |output_shape| be the result of invoking the underlying implementation for calculating output dimensions, given |options|.
@@ -2668,7 +2667,7 @@ partial interface MLGraphBuilder {
   <div algorithm=elu-input-options class=algorithm-steps>
     1. Let |input| be the first argument.
     1. Let |options| be the second argument.
-        1. If running the <a>check ELU options</a> steps with |options| returns `false`, then throw a "{{TypeError}}" {{DOMException}} and abort these steps.
+        1. If running the <a>check ELU options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -2699,7 +2698,7 @@ partial interface MLGraphBuilder {
   <div algorithm=elu-options class=algorithm-steps>
     1. Let |options| be the first argument.
         1. If |options| is `undefined`, let |options| be a new {{MLEluOptions}} object.
-        1. If running the <a>check ELU options</a> steps with |options| returns `false`, then throw a "{{TypeError}}" {{DOMException}} and abort these steps.
+        1. If running the <a>check ELU options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"elu"` and |options|.
     1. Return |op|.
   </div>
@@ -2913,11 +2912,11 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLGruOptions/resetAfter}} is `undefined`, set it to `true`.
     1. If |options|.{{MLGruOptions/returnSequence}} is `undefined`, set it to `false`.
     1. If |options|.{{MLGruOptions/direction}} is `undefined`, set it to `"forward"`.
-    1. If |options|.{{MLGruOptions/direction}} is not one of {{MLRecurrentNetworkDirection}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLGruOptions/direction}} is not one of {{MLRecurrentNetworkDirection}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLGruOptions/layout}} is `undefined`, set it to `"zrn"`.
-    1. If |options|.{{MLGruOptions/layout}} is not one of {{MLGruWeightLayout}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of {{MLActivation}} objects with size `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. If |steps| is not a [=number=] or it is `0`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLGruOptions/layout}} is not one of {{MLGruWeightLayout}}, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of {{MLActivation}} objects with size `2`, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If |steps| is not a [=number=] or it is `0`, then [=exception/throw=] a {{TypeError}} and stop.
     1. Let |output| be an empty sequence of {{MLOperand}} objects.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Make a request to the underlying platform to:
@@ -3064,8 +3063,8 @@ partial interface MLGraphBuilder {
         1. If its rank is not `1`, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLGruOptions/resetAfter}} is `undefined`, set it to `true`.
     1. If |options|.{{MLGruOptions/layout}} is `undefined`, set it to `"zrn"`.
-    1. If |options|.{{MLGruOptions/layout}} is not one of {{MLGruWeightLayout}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of {{MLActivation}} objects with size `2`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLGruOptions/layout}} is not one of {{MLGruWeightLayout}}, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and is not an array of {{MLActivation}} objects with size `2`, then [=exception/throw=] a {{TypeError}} and stop.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |input|.{{MLOperandDescriptor/dimensions}}[0], |hiddenSize| ].
     1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
@@ -3256,7 +3255,7 @@ partial interface MLGraphBuilder {
     The {{MLGraphBuilder/hardSigmoid(input, options)}} method steps are:
     1. Let |input| be the first argument.
     1. Let |options| be the second argument.
-        1. If running the <a>check hard-sigmoid options</a> steps with |options| returns `false`, then throw a "{{TypeError}}" {{DOMException}} and abort these steps.
+        1. If running the <a>check hard-sigmoid options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -3284,7 +3283,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=hard-sigmoid-options class=algorithm-steps>
     1. Let |options| be the first argument.
-        1. If running the <a>check hard-sigmoid options</a> steps with |options| returns `false`, then throw a "{{TypeError}}" {{DOMException}} and abort these steps.
+        1. If running the <a>check hard-sigmoid options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"hardSigmoid"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
@@ -3548,7 +3547,7 @@ partial interface MLGraphBuilder {
     1. Let |input| be the first argument.
     1. Let |options| be the second argument.
         1. If |options| is `undefined`, let |options| be a new {{MLLeakyReluOptions}} object.
-        1. If running the <a>check leaky-relu options</a> steps with |options| returns `false`, then throw a "{{TypeError}}" {{DOMException}} and abort these steps.
+        1. If running the <a>check leaky-relu options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -3578,7 +3577,7 @@ partial interface MLGraphBuilder {
   <div algorithm=leakyrelu-options class=algorithm-steps>
     1. Let |options| be the first argument.
         1. If |options| is `undefined`, let |options| be a new {{MLLeakyReluOptions}} object.
-        1. If running the <a>check leaky-relu options</a> steps with |options| returns `false`, then throw a "{{TypeError}}" {{DOMException}} and abort these steps.
+        1. If running the <a>check leaky-relu options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"leakyRelu"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
@@ -3659,7 +3658,7 @@ partial interface MLGraphBuilder {
   <div algorithm=linear-input-options class=algorithm-steps>
     1. Let |input| be the first argument.
     1. Let |options| be the second argument.
-        1. If running the <a>check linear options</a> steps with |options| returns `false`, then throw a "{{TypeError}}" {{DOMException}} and abort these steps.
+        1. If running the <a>check linear options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -3688,7 +3687,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=linear-options class=algorithm-steps>
     1. Let |options| be the first argument.
-        1. If running the <a>check linear options</a> steps with |options| returns `false`, then throw a "{{TypeError}}" {{DOMException}} and abort these steps.
+        1. If running the <a>check linear options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"linear"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
@@ -3781,7 +3780,7 @@ partial interface MLGraphBuilder {
   <div algorithm=lstm class=algorithm-steps>
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLLstmOptions/direction}} is `undefined`, set it to `"forward"`.
-    1. If |options|.{{MLLstmOptions/direction}} is not one of {{MLRecurrentNetworkDirection}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLLstmOptions/direction}} is not one of {{MLRecurrentNetworkDirection}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. Let |num_directions| be `1` if |options|.{{MLLstmOptions/direction}} is `"forward"`, or otherwise let it be `2`.
     1. [=Assert=]: the type of |input|, |weight| and |recurrentWeight| is {{MLOperand}}.
         <div class="note">
@@ -3818,9 +3817,9 @@ partial interface MLGraphBuilder {
         1. If |options|.{{MLLstmOptions/initialCellState}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[2] is not |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLLstmOptions/returnSequence}} is `undefined`, set it to `false`.
     1. If |options|.{{MLLstmOptions/layout}} is `undefined`, set it to `"iofg"`.
-    1. If |options|.{{MLLstmOptions/layout}} is not one of {{MLLstmWeightLayout}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLLstmOptions/layout}} is not one of {{MLLstmWeightLayout}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLLstmOptions/activations}} [=map/exists=]:
-        1. If it is not an array of size `3`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+        1. If it is not an array of size `3`, then [=exception/throw=] a {{TypeError}} and stop.
         1. [=Assert=]: the type of its elements is {{MLActivation}}.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |desc| a new {{MLOperandDescriptor}}.
@@ -4000,9 +3999,9 @@ partial interface MLGraphBuilder {
         1. If its rank is not `1`, then throw a "{{DataError}}" {{DOMException}} and stop.
         1. If |options|.{{MLLstmCellOptions/peepholeWeight}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[0] is not 3 * |hiddenSize|, then throw a "{{DataError}}" {{DOMException}} and stop.
     1. If |options|.{{MLLstmCellOptions/layout}} is `undefined`, set it to `"iofg"`.
-    1. If |options|.{{MLLstmCellOptions/layout}} is not one of {{MLLstmWeightLayout}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |options|.{{MLLstmCellOptions/layout}} is not one of {{MLLstmWeightLayout}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLLstmCellOptions/activations}} [=map/exists=]:
-        1. If it is not an array of size `3`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+        1. If it is not an array of size `3`, then [=exception/throw=] a {{TypeError}} and stop.
         1. [=Assert=]: the type of its elements is {{MLActivation}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |batch_size|, |hiddenSize| ].
@@ -4273,10 +4272,10 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=pad class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If |beginningPadding| or |endingPadding| is not a sequence of {{unsigned long}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |beginningPadding| or |endingPadding| is not a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLPadOptions/mode}} is `undefined`, set it to `"constant"`.
-        1. Otherwise, if |options|.{{MLPadOptions/mode}} is not one of {{MLPaddingMode}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+        1. Otherwise, if |options|.{{MLPadOptions/mode}} is not one of {{MLPaddingMode}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. If |options|.{{MLPadOptions/value}} is `undefined`, set it to `0`.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of invoking the <a>calculate padding output sizes</a> given |input|, |beginningPadding| and |endingPadding|.
@@ -5025,8 +5024,8 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=slice class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If |starts| or |sizes| is not a sequence of {{long}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
-    1. If |sizes|.size is 0, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |starts| or |sizes| is not a sequence of {{long}}, then [=exception/throw=] a {{TypeError}} and stop.
+    1. If |sizes|.size is 0, then [=exception/throw=] a {{TypeError}} and stop.
         <div class="note">
             Further validation of |starts| and |sizes| given |input| is left [=implementation-defined=].
         </div>
@@ -5191,7 +5190,7 @@ partial interface MLGraphBuilder {
   <div algorithm=softplus-input-options class=algorithm-steps>
     1. Let |input| be the first argument.
     1. Let |options| be the second argument.
-        1. If running the <a>check softplus options</a> steps with |options| returns `false`, then throw a "{{TypeError}}" {{DOMException}} and abort these steps.
+        1. If running the <a>check softplus options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -5220,7 +5219,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div algorithm=softplus-options class=algorithm-steps>
     1. Let |options| be the first argument.
-        1. If running the <a>check softplus options</a> steps with |options| returns `false`, then throw a "{{TypeError}}" {{DOMException}} and abort these steps.
+        1. If running the <a>check softplus options</a> steps with |options| returns `false`, then [=exception/throw=] a {{TypeError}} and abort these steps.
     1. Let |op| be the result of invoking the <a>create MLActivation</a> steps with `"softplus"` and |options|.
         1. If that throws an error, re-throw the error and abort these steps.
     1. Return |op|.
@@ -5336,7 +5335,7 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLSplitOptions/axis}} is `undefined`, let |options|.{{MLSplitOptions/axis}} be `0`.
-    1. If |splits| is not {{unsigned long}} or a sequence of {{unsigned long}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
+    1. If |splits| is not {{unsigned long}} or a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -5415,7 +5414,7 @@ partial interface MLGraphBuilder {
         1. Let |dimensions| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. For |index| between 0 and the size of |options|.{{MLSqueezeOptions/axes}}:
             1. Let |oneDimIndex| be |options|.{{MLSqueezeOptions/axes}}[|index|].
-            1. If |dimensions|[|oneDimIndex|] is not `1`, then throw a "{{TypeError}}" {{DOMException}} and stop.
+            1. If |dimensions|[|oneDimIndex|] is not `1`, then [=exception/throw=] a {{TypeError}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:
@@ -5541,10 +5540,10 @@ partial interface MLGraphBuilder {
     1. If |options| is `undefined`, let |options| be an empty [=object=].
     1. If |options|.{{MLTransposeOptions/permutation}} is `undefined`, let |options|.{{MLTransposeOptions/permutation}} be the reversed sequence of all indices for |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Otherwise if |options|.{{MLTransposeOptions/permutation}} [=map/exists=]:
-        1. If |options|.{{MLTransposeOptions/permutation}} is not a sequence of {{unsigned long}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
-        1. If the rank of |options|.{{MLTransposeOptions/permutation}} is not the same as the rank of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then throw a "{{TypeError}}" {{DOMException}} and stop.
-        1. If the values in |options|.{{MLTransposeOptions/permutation}} are not between `0` and the rank of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} minus `1`, then throw a "{{TypeError}}" {{DOMException}} and stop.
-        1. If the values in |options|.{{MLTransposeOptions/permutation}} contain duplicate value, then throw a "{{TypeError}}" {{DOMException}} and stop.
+        1. If |options|.{{MLTransposeOptions/permutation}} is not a sequence of {{unsigned long}}, then [=exception/throw=] a {{TypeError}} and stop.
+        1. If the rank of |options|.{{MLTransposeOptions/permutation}} is not the same as the rank of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a {{TypeError}} and stop.
+        1. If the values in |options|.{{MLTransposeOptions/permutation}} are not between `0` and the rank of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} minus `1`, then [=exception/throw=] a {{TypeError}} and stop.
+        1. If the values in |options|.{{MLTransposeOptions/permutation}} contain duplicate value, then [=exception/throw=] a {{TypeError}} and stop.
     1. If any of the following sub-steps fail, throw an "{{OperationError}}" {{DOMException}} and stop.
         1. Let |output| be the result of invoking the <a>copy MLOperand</a> steps given |input|.
         1. Make a request to the underlying platform to:


### PR DESCRIPTION
A series of changes including:
- add collapsible stylistic boxes for algorithms and other stylistic improvements
- add missing algorithms
- some white space alignments
- consistent args and variable names across the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zolkis/webnn/pull/446.html" title="Last updated on Aug 25, 2023, 8:45 AM UTC (c067b22)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/446/8e63e07...zolkis:c067b22.html" title="Last updated on Aug 25, 2023, 8:45 AM UTC (c067b22)">Diff</a>