### PR TITLE
Do not include metadata collapsible into expand/collapse all button

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -370,7 +370,7 @@ th, td {
     function toggleCE() {
         var button = document.querySelector(".collapse-expand-button");
         var tip = document.querySelector(".tooltiptext");
-        var allDetails = document.querySelectorAll('details');
+        var allDetails = document.querySelectorAll(':not(.head) > details');
 
         Array.from(allDetails).forEach(function(detail, index) {
             if (button.classList.contains("expand")) {


### PR DESCRIPTION
To avoid inconsistent behavior with other TR specs