### PR TITLE
Define the Bikeshed build to fail on warnings

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -17,7 +17,7 @@ jobs:
           GH_PAGES_BRANCH: gh-pages
           TOOLCHAIN: bikeshed
           VALIDATE_LINKS: false
-          BUILD_FAIL_ON: link-error
+          BUILD_FAIL_ON: warning
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-webmachinelearning-wg/2021Jun/0011.html
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
           W3C_BUILD_OVERRIDE: |

--- a/index.bs
+++ b/index.bs
@@ -20,6 +20,7 @@ Markup Shorthands: idl yes
 Markup Shorthands: css no
 Logo: https://webmachinelearning.github.io/webmachinelearning-logo.png
 Deadline: 2023-10-01
+Die On: warning
 Status Text: <p>
   Further implementation experience and user feedback is being gathered for the
   {{MLCommandEncoder}} interface that proposes to enable more efficient WebGPU


### PR DESCRIPTION
See https://github.com/w3c/spec-prod/blob/main/docs/options.md#build_fail_on

Fix #468


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Oct 10, 2023, 1:56 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwebmachinelearning%2Fwebnn%2Fbf301f61224cb76ff4159fa143b002a13f3a4b1c%2Findex.bs&force=1&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20webmachinelearning/webnn%23469.)._
</details>
