### PR TITLE
Add support for operations needed for well-known transformers e.g. Segment Anything, Stable Diffusion, etc.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -725,6 +725,19 @@ The following table summarizes the types of resource supported by the context cr
 API {#api}
 =====================
 
+## The navigator.ml interface ## {#api-navigator-ml}
+
+An {{ML}} object is available in the {{Window}} and {{DedicatedWorkerGlobalScope}} contexts through the {{Navigator}}
+and {{WorkerNavigator}} interfaces respectively and is exposed via `navigator.ml`.
+
+<script type=idl>
+interface mixin NavigatorML {
+  [SecureContext, SameObject] readonly attribute ML ml;
+};
+Navigator includes NavigatorML;
+WorkerNavigator includes NavigatorML;
+</script>
+
 ## {{ML}} interface ## {#api-ml}
 <script type=idl>
 enum MLDeviceType {

--- a/index.bs
+++ b/index.bs
@@ -2393,9 +2393,9 @@ partial interface MLGraphBuilder {
 </details>
 
 ### Element-wise logical operations ### {#api-mlgraphbuilder-logical}
-Compare two input tensors element-wise, if the operation requires two inputs, and return a tensor of {{boolean}} values 0 or 1 for the specified input values.
+Compare input tensors element-wise and return a uint8 tensor of values 0 or 1 for the comparisons. For single-operand operations, return the logical results of the operation. 
 
-The two input tensors will be broadcasted according to [[!numpy-broadcasting-rule]]. The [=rank=] of the output tensor is the maximum
+The input tensor will be broadcasted according to [[!numpy-broadcasting-rule]]. The [=rank=] of the output tensor is the maximum
 [=rank=] of the input tensors.
 
 <script type=idl>
@@ -2424,7 +2424,7 @@ partial interface MLGraphBuilder {
         - *greaterOrEqual*: Compare if the values of the first input tensor is greater or equal, element-wise.
         - *lesser*: Compare if the values of the first input tensor is lesser, element-wise.
         - *lesserOrEqual*: Compare if the values of the first input tensor is lesser or equal, element-wise.
-        - *not*: Invert the values of the input tensor to {{boolean}} values 0 or 1, element-wise. Specifically, when the input value is non-zero, invert it to a {{boolean}} value 0. Conversely, for a zero input value, invert it to a {{boolean}} value. 
+        - *not*: Invert the values of the input tensor to values 0 or 1, element-wise. Specifically, when the input value is non-zero, invert it to a {{boolean}} value 0. Conversely, for a zero input value, invert it to a {{boolean}} value. 
 </div>
 
 <div class="note">
@@ -2438,7 +2438,7 @@ Although operations *greaterOrEqual* and *lesserOrEqual* can each be implemented
   <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "equal", "greater", "greaterOrEqual", "lesser", "lesserOrEqual", "not".
     1. [=Assert=]: the type of |a| and |b| if available is {{MLOperand}}.
-    1. If either |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} or |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} isn't "uint8", then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If either |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} or |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} (when available) isn't "uint8", then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
     1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to "uint8".
     1. Let |descriptor|.{{MLOperandDescriptor/dimensions}} be the result of running the [=MLGraphBuilder/broadcast-shapes=] steps given |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
@@ -2856,7 +2856,7 @@ partial interface MLGraphBuilder {
     1. Let |dimCount| be zero.
     1. [=map/For each=] |size| &rarr; |value| of |shapeInput|:
         1. If |dimCount| is less than or equal to |axis| then [=continue=].
-        1. Set |shapeOutput|[|rankOutput| + |dimCount|] to |size|.
+        1. Set |shapeOutput|[|rankOutput| + |dimCount| - |axis| - 1] to |size|.
         1. Increment |dimCount| by one.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |shapeOutput|.
@@ -3761,7 +3761,6 @@ The {{MLLayerNormalizationOptions}} members are:
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If the [=rank=] of |input| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=Assert=]:  the type of |options|.{{MLLayerNormalizationOptions/scale}} is {{MLOperand}}.
     1. If the [=rank=] of |options|.{{MLLayerNormalizationOptions/scale}} is not equal to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=Assert=]: the type of |options|.{{MLLayerNormalizationOptions/bias}} is  {{MLOperand}}.

--- a/index.bs
+++ b/index.bs
@@ -6465,6 +6465,8 @@ Thanks to Kaustubha Govind and Chrome privacy reviewers for feedback and privacy
 
 Thanks to Jiewei Qian for Chromium implementation review and feedback.
 
+Thanks to Dwayne Robinson for his work investigating and providing recommendation for transformer support, and for providing reviews of operator conformance and WPT implementation.
+
 <pre class="biblio">
 {
   "Models": {

--- a/index.bs
+++ b/index.bs
@@ -1203,12 +1203,12 @@ partial interface MLContext {
 
     // Build a graph with two outputs.
     const builder = new MLGraphBuilder(context);
-    const descA = {type: 'float32', dimensions: [3, 4]};
+    const descA = {dataType: 'float32', dimensions: [3, 4]};
     const a = builder.input('a', descA);
-    const descB = {type: 'float32', dimensions: [4, 3]};
+    const descB = {dataType: 'float32', dimensions: [4, 3]};
     const bufferB = new Float32Array(sizeOfShape(descB.dimensions)).fill(0.5);
     const b = builder.constant(descB, bufferB);
-    const descC = {type: 'float32', dimensions: [3, 3]};
+    const descC = {dataType: 'float32', dimensions: [3, 3]};
     const bufferC = new Float32Array(sizeOfShape(descC.dimensions)).fill(1);
     const c = builder.constant(descC, bufferC);
     const d = builder.matmul(a, b);
@@ -1305,7 +1305,7 @@ partial interface MLContext {
     The following code showcases the asynchronous computation.
   </summary>
   <pre highlight="js">
-    const operandType = {type: 'float32', dimensions: [2, 2]};
+    const operandType = {dataType: 'float32', dimensions: [2, 2]};
     const context = await navigator.ml.createContext();
     const builder = new MLGraphBuilder(context);
     // 1. Create a computational graph 'C = 0.2 * A + B'.
@@ -1450,6 +1450,84 @@ Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGr
     1. If <a>validating MLContext</a> given |context| returns false, then [=exception/throw=] a "{{TypeError}}".
     1. Set {{MLGraphBuilder/[[context]]}} to |context|.
   </div>
+</details>
+
+### argMin/Max ### {#api-mlgraphbuilder-argminmax}
+Return the index location of the minium or maxmium values of all the input values along the axes.
+
+<script type=idl>
+dictionary MLArgMinMaxOptions {
+  sequence<unsigned long> axes = null;
+  boolean keepDimensions = false;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand argMin(MLOperand input, optional MLArgMinMaxOptions options = {});
+  MLOperand argMax(MLOperand input, optional MLArgMinMaxOptions options = {});
+};
+</script>
+
+{{MLArgMinMaxOptions}} has the following members:
+<dl dfn-type=dict-member dfn-for=MLArgMinMaxOptions>
+    : <dfn>axes</dfn>
+    ::
+        A sequence of {{unsigned long}}. The dimensions to reduce. The values in the sequence must be in the range [0, N-1] where N is the [=rank=] of the input tensor. If not present, all dimensions are reduced.
+
+    : <dfn>keepDimensions</dfn>
+    ::
+        A {{boolean}}. If true, retains reduced dimensions with [=list/size=] 1. The default value is false.
+</dl>
+
+<div>
+    **Arguments:**
+        - *input*: an {{MLOperand}}. The input N-D tensor.
+        - *options*: an optional {{MLArgMinMaxOptions}}. The optional parameters of the operation.
+
+    **Returns:** an {{MLOperand}}. The N-D tensor of the reduced shape. The values must be of type "uint32" in the range [0, N-1] where N is the corresponding size of each of the input dimensions specified by options.axes.
+</div>
+
+<details open algorithm>
+  <summary>
+    To <dfn for="MLGraphBuilder" data-lt="argminmax-op">create argMin/argMax operation</dfn> given |op|, |input| and |options|, run the following steps:
+  </summary>
+  <div class=algorithm-steps>
+    1. [=Assert=]: |op| is one of "argMin", "argMax".
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
+    1. If |options|.{{MLArgMinMaxOptions/axes}} [=map/exists=], if any of its elements is not in [=the range=] 0 to the [=rank=] of |input|, exclusive, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Let |outputShape| be the result of invoking the underlying implementation for calculating reduction output dimensions, given |options|.
+    1. Let |desc| be a new {{MLOperandDescriptor}}.
+    1. Set |desc|.{{MLOperandDescriptor/dataType}} to "uint32".
+    1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |outputShape|.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
+        1. Make a request to the underlying platform to:
+            1. Let |opImpl| be an [=implementation-defined=] platform operator for the |op| argMin or argMax operation, given |options|.
+            1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
+            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Store a reference to |outputImpl| in |output|.{{MLOperand/[[operand]]}}.
+        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
+        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+    1. Return |output|.
+  </div>
+</details>
+
+<details open>
+  <summary>
+    The following argMin/argMax algorithms are supported.
+  </summary>
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>argMin(|input|, |options|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/argminmax-op | create argMin/argMax operation=] given "argMin", |input| and |options|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
+
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>argMax(|input|, |options|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/argminmax-op | create argMin/argMax operation=] given "argMax", |input| and |options|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 </details>
 
 ### batchNormalization ### {#api-mlgraphbuilder-batchnorm}
@@ -2902,13 +2980,13 @@ partial interface MLGraphBuilder {
     { dimensions: [4,3] }, new Float32Array([0,1,2,10,11,12,20,21,22,30,31,32]));
 
     const indices1 = builder.constant(
-    { type: 'uint32', dimensions: [2] }, new Uint32Array([3,1]));
+    { dataType: 'uint32', dimensions: [2] }, new Uint32Array([3,1]));
 
     const indices2 = builder.constant(
-    { type: 'uint32', dimensions: [3] }, new Uint32Array([2,1,1]));
+    { dataType: 'uint32', dimensions: [3] }, new Uint32Array([2,1,1]));
 
     const indices3 = builder.constant(
-    { type: 'uint32', dimensions: [2,2] }, new Uint32Array([0,1,1,2]));
+    { dataType: 'uint32', dimensions: [2,2] }, new Uint32Array([0,1,1,2]));
 
     // axis = 0 (default)
     // indices of shape [2]: 
@@ -3166,7 +3244,7 @@ partial interface MLGraphBuilder {
     let hiddenState = options.initialHiddenState;
 
     if (!hiddenState) {
-      const desc = { type: 'float32', dimensions: [numDirections, 1, hiddenSize] };
+      const desc = { dataType: 'float32', dimensions: [numDirections, 1, hiddenSize] };
       const totalSize = numDirections * hiddenSize;
       hiddenState = builder.constant(desc, new Float32Array(totalSize).fill(0));
     }
@@ -4170,13 +4248,13 @@ partial interface MLGraphBuilder {
     let cellState = options.initialCellState;
 
     if (!hiddenState) {
-      const desc = { type: 'float32', dimensions: [numDirections, 1, hiddenSize] };
+      const desc = { dataType: 'float32', dimensions: [numDirections, 1, hiddenSize] };
       const totalSize = numDirections * hiddenSize;
       hiddenState = builder.constant(desc, new Float32Array(totalSize).fill(0));
     }
 
     if (!cellState) {
-      const desc = { type: 'float32', dimensions: [numDirections, 1, hiddenSize] };
+      const desc = { dataType: 'float32', dimensions: [numDirections, 1, hiddenSize] };
       const totalSize = numDirections * hiddenSize;
       cellState = builder.constant(desc, new Float32Array(totalSize).fill(0));
     }
@@ -4617,7 +4695,7 @@ partial interface MLGraphBuilder {
   <pre highlight="js">
     // input: [[1,2,3], [4,5,6]]
     const input = builder.constant(
-      { type: 'float32', dimensions: [2,3] }, new Float32Array([1,2,3,4,5,6]));
+      { dataType: 'float32', dimensions: [2,3] }, new Float32Array([1,2,3,4,5,6]));
 
     const beginningPadding = [1,2];
     const endingPadding = [1,2];
@@ -4654,7 +4732,7 @@ partial interface MLGraphBuilder {
 </div>
 
 ### Pooling operations ### {#api-mlgraphbuilder-pool2d}
-Compute a reduction operation across all the elements within the moving window over the input tensor. See the description of each type of reduction in [[#api-mlgraphbuilder-reduce]].
+Compute a pooling operation across all the elements within the moving window over the input tensor.
 <script type=idl>
 enum MLRoundingType {
   "floor",
@@ -4902,8 +4980,6 @@ dictionary MLReduceOptions {
 };
 
 partial interface MLGraphBuilder {
-  MLOperand reduceArgMax(MLOperand input, optional MLReduceOptions options = {});
-  MLOperand reduceArgMin(MLOperand input, optional MLReduceOptions options = {});
   MLOperand reduceL1(MLOperand input, optional MLReduceOptions options = {});
   MLOperand reduceL2(MLOperand input, optional MLReduceOptions options = {});
   MLOperand reduceLogSum(MLOperand input, optional MLReduceOptions options = {});
@@ -4938,8 +5014,6 @@ partial interface MLGraphBuilder {
 
 <div class="note">
     **Reduction types:**
-        - *ArgMax*: Return the index location of the maxmium value of all the input values along the axes.
-        - *ArgMin*: Return the index location of the minimum value of all the input values along the axes.
         - *L1*: Compute the <a href="https://mathworld.wolfram.com/L1-Norm.html">L1 norm</a> of all the input values along the axes.
         - *L2*: Compute the <a href="https://mathworld.wolfram.com/L2-Norm.html">L2 norm</a> of all the input values along the axes.
         - *LogSum*: Compute the log value of the sum of all the input values along the axes.
@@ -4957,11 +5031,15 @@ partial interface MLGraphBuilder {
     To <dfn for="MLGraphBuilder" data-lt="reduce-op">create reduce operation</dfn> given |op|, |input| and |options|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. [=Assert=]: |op| is one of "reduceArgMax", "reduceArgMin", "reduceL1", "reduceL2", "reduceLogSum", "reduceLogSumExp", "reduceMax", "reduceMean", "reduceMin", "reduceProduct", "reduceSum", "reduceSumSquare".
+    1. [=Assert=]: |op| is one of "reduceL1", "reduceL2", "reduceLogSum", "reduceLogSumExp", "reduceMax", "reduceMean", "reduceMin", "reduceProduct", "reduceSum", "reduceSumSquare".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |options|.{{MLReduceOptions/axes}} [=map/exists=], if any of its elements is not in [=the range=] 0 to the [=rank=] of |input|, exclusive, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Let |outputShape| be the result of invoking the underlying implementation for calculating reduction output dimensions, given |options|.
+    1. Let |desc| a new {{MLOperandDescriptor}}.
+    1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
+    1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |outputShape|.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
             1. Let |opImpl| be an [=implementation-defined=] platform operator for the |op| reduce operation, given |options|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -4977,20 +5055,6 @@ partial interface MLGraphBuilder {
   <summary>
     The following reduce algorithms are supported.
   </summary>
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>reduceArgMax(|input|, |options|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceArgMax", |input| and |options|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
-
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>reduceArgMin(|input|, |options|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceArgMin", |input| and |options|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
-
     <div algorithm>
     The <dfn method for=MLGraphBuilder>reduceL1(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceL1", |input| and |options|.
@@ -6049,10 +6113,10 @@ partial interface MLGraphBuilder {
     builder.add(
       builder.mul(
         input,
-        builder.cast(condition, input.type())),
+        builder.cast(condition, input.dataType())),
       builder.mul(
         other,
-        builder.cast(builder.not(condition), other.type())));
+        builder.cast(builder.not(condition), other.dataType())));
     </pre>
   </details>
 </div>
@@ -6066,7 +6130,7 @@ For instance, an {{MLOperand}} may represent a constant feeding to an operation 
 <script type=idl>
 [SecureContext, Exposed=(Window, DedicatedWorker)]
 interface MLOperand {
-  MLOperandDataType type();
+  MLOperandDataType dataType();
   sequence<unsigned long> shape();
 };
 </script>
@@ -6241,7 +6305,7 @@ Given the following build graph:
     const builder = new MLGraphBuilder(context);
 
     // Create MLOperandDescriptor object.
-    const desc = {type: 'float32', dimensions: TENSOR_DIMS};
+    const desc = {dataType: 'float32', dimensions: TENSOR_DIMS};
 
     // constant1 is a constant MLOperand with the value 0.5.
     const constantBuffer1 = new Float32Array(TENSOR_SIZE).fill(0.5);

--- a/index.bs
+++ b/index.bs
@@ -1439,7 +1439,7 @@ Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGr
   </div>
 </details>
 
-### {{MLGraphBuilder/batchNormalization}} ### {#api-mlgraphbuilder-batchnorm}
+### batchNormalization ### {#api-mlgraphbuilder-batchnorm}
 Normalize the values of the input tensor using [[Batch-Normalization]]. For each input feature, the mean and variance values of that feature are computed across all the samples in the batch dimension while the model is trained. These mean and variance values are then subsequently given to this operation during model inference.
 
 <script type=idl>
@@ -1537,7 +1537,7 @@ partial interface MLGraphBuilder {
   </details>
 </div>
 
-### {{MLGraphBuilder/build}} ### {#api-mlgraphbuilder-build}
+### build ### {#api-mlgraphbuilder-build}
 Build a composed graph up to a given output operand into a computational graph, asynchronously or synchronously.
 
 #### {{MLGraphBuilder/build(outputs)}} #### {#api-mlgraphbuilder-build-outputs}
@@ -1593,7 +1593,7 @@ Build a composed graph up to a given output operand into a computational graph, 
   </div>
 </details>
 
-### {{MLGraphBuilder/cast}} ### {#api-mlgraphbuilder-cast}
+### cast ### {#api-mlgraphbuilder-cast}
 Cast each element in the input tensor to the target data type.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -1627,7 +1627,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/clamp}} ### {#api-mlgraphbuilder-clamp}
+### clamp ### {#api-mlgraphbuilder-clamp}
 Clamp the input tensor element-wise within a range specified by the minimum and maximum values.
 <script type=idl>
 dictionary MLClampOptions {
@@ -1733,7 +1733,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/concat}} ### {#api-mlgraphbuilder-concat}
+### concat ### {#api-mlgraphbuilder-concat}
 Concatenates the input tensors along a given axis.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -1792,7 +1792,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/constant}} ### {#api-mlgraphbuilder-constant}
+### constant ### {#api-mlgraphbuilder-constant}
 Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
 
 #### {{MLGraphBuilder/constant(descriptor, bufferView)}} #### {#api-mlgraphbuilder-constant-bufferview}
@@ -1909,7 +1909,7 @@ Data truncation will occur when the values in the range exceed the range of the 
   </div>
 </details>
 
-### {{MLGraphBuilder/conv2d}} ### {#api-mlgraphbuilder-conv2d}
+### conv2d ### {#api-mlgraphbuilder-conv2d}
 Compute a 2-D convolution given 4-D input and filter tensors
 <script type=idl>
 enum MLConv2dFilterOperandLayout {
@@ -2077,7 +2077,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/convTranspose2d}} ### {#api-mlgraphbuilder-convtranspose2d}
+### convTranspose2d ### {#api-mlgraphbuilder-convtranspose2d}
 Compute a 2-D transposed convolution given 4-D input and filter tensors
 <script type=idl>
 
@@ -2398,7 +2398,7 @@ partial interface MLGraphBuilder {
 </details>
 
 <div class="note">
-Although operations {{MLGraphBuilder/greaterOrEqual}} and {{MLGraphBuilder/lesserOrEqual}} can each be implemented in terms of operations {{MLGraphBuilder/not}}, {{MLGraphBuilder/lesser}}, and {{MLGraphBuilder/greater}} in other words `greater-or-equal(a, b)` is `not(lesser(a, b))`, they are specifically defined for performance reason to avoid double comparisons in each element-wise test.
+Although operations *greaterOrEqual* and *lesserOrEqual* can each be implemented in terms of operations *not*, *lesser*, and *greater* in other words `greater-or-equal(a, b)` is `not(lesser(a, b))`, they are specifically defined for performance reason to avoid double comparisons in each element-wise test.
 </div>
 
 #### equal #### {#api-mlgraphbuilder-logical-equal}
@@ -2506,7 +2506,7 @@ Compute the square root of the input tensor, element-wise. See [[#api-mlgraphbui
 #### tan #### {#api-mlgraphbuilder-unary-tan}
 Compute the tangent of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
 
-### {{MLGraphBuilder/elu}} ### {#api-mlgraphbuilder-elu}
+### elu ### {#api-mlgraphbuilder-elu}
 Calculate the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)#ELU"> exponential linear unit function</a> (ELU) on the input tensor element-wise. The calculation follows the expression `max(0, x) + alpha * (exp(min(0, x)) - 1)`.
 
 <script type=idl>
@@ -2591,7 +2591,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/expand}} ### {#api-mlgraphbuilder-expand}
+### expand ### {#api-mlgraphbuilder-expand}
 Expand any dimension of size 1 of the input tensor to a larger size according to the new shape. The expansion is consistent with [[!numpy-broadcasting-rule]]. The input dimensions must have the size of 1 or match the sizes of the corresponding output dimensions according to the new shape.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -2635,7 +2635,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/gather}} ### {#api-mlgraphbuilder-gather}
+### gather ### {#api-mlgraphbuilder-gather}
 Gather values of the input tensor along an axis according to the indices.
 <script type=idl>
 dictionary MLGatherOptions {
@@ -2765,7 +2765,7 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-### {{MLGraphBuilder/gemm}} ### {#api-mlgraphbuilder-gemm}
+### gemm ### {#api-mlgraphbuilder-gemm}
 Calculate the [general matrix multiplication of the Basic Linear Algebra Subprograms](https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3). The calculation follows the expression `alpha * A * B + beta * C`, where `A` is a 2-D tensor with shape [M, K] or [K, M], `B` is a 2-D tensor with shape [K, N] or [N, K], and `C` is broadcastable to the shape [M, N]. `A` and `B` may optionally be transposed prior to the calculation.
 
 <script type=idl>
@@ -2865,7 +2865,7 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-### {{MLGraphBuilder/gru}} ### {#api-mlgraphbuilder-gru}
+### gru ### {#api-mlgraphbuilder-gru}
 Gated Recurrent Unit [[GRU]] recurrent network uses an update, reset, and new gate to compute the output state that rolls into the output across the temporal sequence of the network.
 <script type=idl>
 enum MLGruWeightLayout {
@@ -3044,7 +3044,7 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-### {{MLGraphBuilder/gruCell}} ### {#api-mlgraphbuilder-grucell}
+### gruCell ### {#api-mlgraphbuilder-grucell}
 A single time step of the Gated Recurrent Unit [[GRU]] recurrent network using an update gate and a reset gate to compute the hidden state that rolls into the output across the temporal sequence of a recurrent network.
 
 <script type=idl>
@@ -3232,7 +3232,7 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-### {{MLGraphBuilder/hardSigmoid}} ### {#api-mlgraphbuilder-hard-sigmoid}
+### hardSigmoid ### {#api-mlgraphbuilder-hard-sigmoid}
 Calculate the non-smooth <a href="https://en.wikipedia.org/wiki/Hard_sigmoid">hard sigmoid function</a> on the input tensor, used instead of the sigmoid function for faster computation.
 <script type=idl>
 dictionary MLHardSigmoidOptions {
@@ -3329,7 +3329,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/hardSwish}} ### {#api-mlgraphbuilder-hard-swish}
+### hardSwish ### {#api-mlgraphbuilder-hard-swish}
 Computes the nonlinear function `y = x * max(0, min(6, (x + 3))) / 6` that is introduced by [[MobileNetV3]] on the input tensor element-wise.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -3408,7 +3408,7 @@ partial interface MLGraphBuilder {
  </div>
 </details>
 
-### {{MLGraphBuilder/input}} ### {#api-mlgraphbuilder-input}
+### input ### {#api-mlgraphbuilder-input}
 Create a named {{MLOperand}} based on a descriptor, that can be used as an input.
 
 <div>
@@ -3443,7 +3443,7 @@ Create a named {{MLOperand}} based on a descriptor, that can be used as an input
   </div>
 </details>
 
-### {{MLGraphBuilder/instanceNormalization}} ### {#api-mlgraphbuilder-instancenorm}
+### instanceNormalization ### {#api-mlgraphbuilder-instancenorm}
 Normalize the input using [[Instance-Normalization]]. Unlike [[#api-mlgraphbuilder-batchnorm]] where the mean and variance values used in the normalization are computed across all the samples in the batch dimension while the model is trained, the mean and variance values used in the instance normalization are computed on the fly for each input feature of each individual sample in the batch.
 
 <script type=idl>
@@ -3548,7 +3548,7 @@ The {{MLInstanceNormalizationOptions}} members are:
 </details>
 </div>
 
-### {{MLGraphBuilder/layerNormalization}} ### {#api-mlgraphbuilder-layernorm}
+### layerNormalization ### {#api-mlgraphbuilder-layernorm}
 Normalize the input using [[Layer-Normalization]]. Unlike [[#api-mlgraphbuilder-batchnorm]] where the mean and variance values are computed across all the samples in the batch dimension while the model is trained, and in [[#api-mlgraphbuilder-instancenorm]] where the mean and variance values are computed on the fly for each input feature of each individual sample in the batch, the means and variance values of the layer normalization are computed on the fly across all the input features of each individual sample in the batch.
 
 <script type=idl>
@@ -3599,9 +3599,9 @@ The {{MLLayerNormalizationOptions}} members are:
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If the [=rank=] of |input| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=Assert=]:  the type of |options|.{{MLLayerNormalizationOptions/scale}} is {{MLOperand}}.
-    1. If the [=rank=] of |options|.{{MLLayerNormalizationOptions/scale}} is not equal to the [=list/size=] of |options|.{{MLBatchNormalizationOptions/axes}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |options|.{{MLLayerNormalizationOptions/scale}} is not equal to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=Assert=]: the type of |options|.{{MLLayerNormalizationOptions/bias}} is  {{MLOperand}}.
-    1. If the [=rank=] of |options|.{{MLLayerNormalizationOptions/bias}} is not equal to the [=list/size=] of |options|.{{MLBatchNormalizationOptions/axes}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |options|.{{MLLayerNormalizationOptions/bias}} is not equal to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
@@ -3658,7 +3658,7 @@ The {{MLLayerNormalizationOptions}} members are:
 </details>
 </div>
 
-### {{MLGraphBuilder/leakyRelu}} ### {#api-mlgraphbuilder-leakyrelu}
+### leakyRelu ### {#api-mlgraphbuilder-leakyrelu}
 Calculate the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)#Leaky_ReLU"> leaky version of rectified linear function</a> on the input tensor element-wise. The calculation follows the expression `max(0, x) + alpha ∗ min(0, x)`.
 
 <script type=idl>
@@ -3745,7 +3745,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/linear}} ### {#api-mlgraphbuilder-linear}
+### linear ### {#api-mlgraphbuilder-linear}
 Calculate a linear function `y = alpha * x + beta` on the input tensor.
 
 <script type=idl>
@@ -3837,7 +3837,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/lstm}} ### {#api-mlgraphbuilder-lstm}
+### lstm ### {#api-mlgraphbuilder-lstm}
 Long Short-Term Memory [[LSTM]] recurrent network uses an input, output, forget, and cell gate to compute the output state that rolls into the output across the temporal sequence of the network.
 
 <script type=idl>
@@ -4066,7 +4066,7 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-### {{MLGraphBuilder/lstmCell}} ### {#api-mlgraphbuilder-lstmcell}
+### lstmCell ### {#api-mlgraphbuilder-lstmcell}
 A single time step of the Long Short-Term Memory [[LSTM]] recurrent network using a cell state, an input, output, and forget gate to compute the cell state and the hidden state of the next time step that rolls into the output across the temporal sequence of the network.
 
 <script type=idl>
@@ -4280,7 +4280,7 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-### {{MLGraphBuilder/matmul}} ### {#api-mlgraphbuilder-matmul}
+### matmul ### {#api-mlgraphbuilder-matmul}
 Compute the matrix product of two input tensors.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -4349,7 +4349,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/pad}} ### {#api-mlgraphbuilder-pad}
+### pad ### {#api-mlgraphbuilder-pad}
 Inflate the tensor with constant or mirrored values on the edges.
 <script type=idl>
 enum MLPaddingMode {
@@ -4654,16 +4654,16 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-#### {{MLGraphBuilder/averagePool2d}} #### {#api-mlgraphbuilder-pool2d-average}
+#### {{MLGraphBuilder/averagePool2d(input, options)}} #### {#api-mlgraphbuilder-pool2d-average}
 Calculate the average value for patches of a feature map, and use it to create a pooled feature map. See [[#api-mlgraphbuilder-pool2d]] for more detail.
 
-#### {{MLGraphBuilder/l2Pool2d}} #### {#api-mlgraphbuilder-pool2d-l2}
+#### {{MLGraphBuilder/l2Pool2d(input, options)}} #### {#api-mlgraphbuilder-pool2d-l2}
 Apply the L2 norm function to a region of the input feature map. The L2 norm is the square root of the sum of the squares of its elements. See [[#api-mlgraphbuilder-pool2d]] for more detail.
 
-#### {{MLGraphBuilder/maxPool2d}} #### {#api-mlgraphbuilder-pool2d-max}
+#### {{MLGraphBuilder/maxPool2d(input, options)}} #### {#api-mlgraphbuilder-pool2d-max}
 Calculate the maximum value for patches of a feature map, and use it to create a pooled feature map. See [[#api-mlgraphbuilder-pool2d]] for more detail.
 
-### {{MLGraphBuilder/prelu}} ### {#api-mlgraphbuilder-prelu}
+### prelu ### {#api-mlgraphbuilder-prelu}
 Calculate the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)#Parametric_ReLU">parametric version of rectified linear function (Parametric ReLU)</a> on the input tensor element-wise. Parametric ReLU is a type of leaky ReLU that, instead of having a scalar slope like 0.01, making the slope (coefficient of leakage) into a parameter that is learned during the model training phase of this operation. The calculation follows the expression `max(0, x) + slope ∗ min(0, x)`.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -4908,7 +4908,7 @@ Compute the sum of all the input values along the axes. See [[#api-mlgraphbuilde
 #### reduceSumSquare #### {#api-mlgraphbuilder-reduce-sumsquare}
 Compute the sum of the square of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
 
-### {{MLGraphBuilder/relu}} ### {#api-mlgraphbuilder-relu-method}
+### relu ### {#api-mlgraphbuilder-relu-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)">rectified linear function</a> of the input tensor.
 
 <script type=idl>
@@ -4981,7 +4981,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/resample2d}} ### {#api-mlgraphbuilder-resample2d-method}
+### resample2d ### {#api-mlgraphbuilder-resample2d-method}
 Resample the tensor values from the source to the destination spatial dimensions according to the scaling factors.
 <script type=idl>
 enum MLInterpolationMode {
@@ -5086,7 +5086,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/reshape}} ### {#api-mlgraphbuilder-reshape-method}
+### reshape ### {#api-mlgraphbuilder-reshape-method}
 Alter the shape of a tensor to a new shape. Reshape does not copy or change the content of the tensor. It just changes the tensor's logical dimensions for the subsequent operations.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -5142,7 +5142,7 @@ partial interface MLGraphBuilder {
 <div class="note">
   <details open>
     <summary>
-    Many shape-related operations such as [squeeze](https://pytorch.org/docs/stable/generated/torch.squeeze.html), [unsqueeze](https://pytorch.org/docs/stable/generated/torch.unsqueeze.html), and [flatten](https://pytorch.org/docs/stable/generated/torch.flatten.html) can be generically implemented using the {{MLGraphBuilder/reshape}} operation as follows:
+    Many shape-related operations such as [squeeze](https://pytorch.org/docs/stable/generated/torch.squeeze.html), [unsqueeze](https://pytorch.org/docs/stable/generated/torch.unsqueeze.html), and [flatten](https://pytorch.org/docs/stable/generated/torch.flatten.html) can be generically implemented using the *reshape*}} operation as follows:
     </summary>
     <pre highlight="js">
     // Returns a tensor with all specified dimensions of input of size 1 removed.
@@ -5176,7 +5176,7 @@ partial interface MLGraphBuilder {
   </details>
 </div>
 
-### {{MLGraphBuilder/sigmoid}} ### {#api-mlgraphbuilder-sigmoid-method}
+### sigmoid ### {#api-mlgraphbuilder-sigmoid-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Sigmoid_function">sigmoid function</a> of the input tensor. The calculation follows the expression `1 / (exp(-x) + 1)`.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -5252,7 +5252,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/slice}} ### {#api-mlgraphbuilder-slice}
+### slice ### {#api-mlgraphbuilder-slice}
 Produce a slice of the input tensor.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -5290,7 +5290,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/softmax}} ### {#api-mlgraphbuilder-softmax-method}
+### softmax ### {#api-mlgraphbuilder-softmax-method}
 Compute the [softmax](https://en.wikipedia.org/wiki/Softmax_function) values of
 the 2-D input tensor along axis 1.
 <script type=idl>
@@ -5370,7 +5370,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/softplus}} ### {#api-mlgraphbuilder-softplus-method}
+### softplus ### {#api-mlgraphbuilder-softplus-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)#Softplus">softplus function</a> of the input tensor. The calculation follows the expression `ln(1 + exp(steepness * x)) / steepness`.
 <script type=idl>
 dictionary MLSoftplusOptions {
@@ -5460,7 +5460,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/softsign}} ### {#api-mlgraphbuilder-softsign-method}
+### softsign ### {#api-mlgraphbuilder-softsign-method}
 Compute the <a href="https://pytorch.org/docs/stable/generated/torch.nn.Softsign.html">softsign function</a> of the input tensor. The calculation follows the expression `x / (1 + |x|)`.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -5532,7 +5532,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/split}} ### {#api-mlgraphbuilder-split}
+### split ### {#api-mlgraphbuilder-split}
 Split the input tensor into a number of sub tensors along the given axis.
 <script type=idl>
 dictionary MLSplitOptions {
@@ -5609,7 +5609,7 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-### {{MLGraphBuilder/tanh}} ### {#api-mlgraphbuilder-tanh-method}
+### tanh ### {#api-mlgraphbuilder-tanh-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Hyperbolic_functions">hyperbolic tangent function</a> of the input tensor. The calculation follows the expression `(exp(2 * x) - 1) / (exp(2 * x) + 1)`.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -5683,7 +5683,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/transpose}} ### {#api-mlgraphbuilder-transpose}
+### transpose ### {#api-mlgraphbuilder-transpose}
 Permute the dimensions of the input tensor according to the *permutation* argument.
 <script type=idl>
 dictionary MLTransposeOptions {
@@ -5737,7 +5737,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/triangular}} ### {#api-mlgraphbuilder-triangular}
+### triangular ### {#api-mlgraphbuilder-triangular}
 Given a 2-D tensor (matrix), return a 2-D tensor containing either the upper or lower triangular part of the input tensor.
 
 <script type=idl>
@@ -5839,7 +5839,7 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-### {{MLGraphBuilder/where}} ### {#api-mlgraphbuilder-where}
+### where ### {#api-mlgraphbuilder-where}
 Select the values from the input or the other tensor depending on the corresponding Boolean values of the condition tensor. The condition tensor is often the output of one of the element-wise logical operations.
 
 The input tensors will be broadcasted according to [[!numpy-broadcasting-rule]] to the final output shape. The [=rank=] of the output tensor is the maximum [=rank=] of the input tensors.

--- a/index.bs
+++ b/index.bs
@@ -3847,10 +3847,10 @@ The {{MLLayerNormalizationOptions}} members are:
 
 <div>
     **Arguments:**
-        - *input*: an {{MLOperand}}. The input 4-D tensor.
+        - *input*: an {{MLOperand}}. The input N-D tensor.
         - *options*: an optional {{MLLayerNormalizationOptions}}. The optional parameters of the operation.
 
-    **Returns:** an {{MLOperand}}. The layer-normalized 4-D tensor of the same shape as *input*.
+    **Returns:** an {{MLOperand}}. The layer-normalized N-D tensor of the same shape as *input*.
 </div>
 
 <details open algorithm>

--- a/index.bs
+++ b/index.bs
@@ -3867,8 +3867,8 @@ The {{MLLayerNormalizationOptions}} members are:
         1. Let |axis| be |options|.{{MLLayerNormalizationOptions/axes}}[|index|].
         1. If |axis| is greater or equal to the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Let |size| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|axis|].
-        1. If |options|.{{MLLayerNormalizationOptions/scale}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|index] is not equal to |size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. If |options|.{{MLLayerNormalizationOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|index] is not equal to |size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLayerNormalizationOptions/scale}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|index|] is not equal to |size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLayerNormalizationOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|index|] is not equal to |size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
@@ -6117,13 +6117,14 @@ partial interface MLGraphBuilder {
     The behavior of this operation can be generically emulated from the usage of other operations as follow. However, user agents typically have a more efficient implementation for it, therefore its usage is encouraged from the performance standpoint.
     </summary>
     <pre highlight="js">
+    const c = builder.clamp(condition, {'minValue': 0, 'maxValue': 1});
     builder.add(
       builder.mul(
         input,
-        builder.cast(condition, input.dataType())),
+        builder.cast(c, input.dataType())),
       builder.mul(
         other,
-        builder.cast(builder.not(condition), other.dataType())));
+        builder.cast(builder.not(c), other.dataType())));
     </pre>
   </details>
 </div>

--- a/index.bs
+++ b/index.bs
@@ -1453,7 +1453,7 @@ Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGr
 </details>
 
 ### argMin/Max ### {#api-mlgraphbuilder-argminmax}
-Return the index location of the minium or maxmium values of all the input values along the axes.
+Return the index location of the minimum or maxmium values of all the input values along the axes.
 
 <script type=idl>
 dictionary MLArgMinMaxOptions {
@@ -2519,11 +2519,11 @@ partial interface MLGraphBuilder {
         - *greaterOrEqual*: Compare if the values of the first input tensor is greater or equal, element-wise.
         - *lesser*: Compare if the values of the first input tensor is lesser, element-wise.
         - *lesserOrEqual*: Compare if the values of the first input tensor is lesser or equal, element-wise.
-        - *not*: Invert the values of the input tensor to values 0 or 1, element-wise. Specifically, when the input value is non-zero, invert it to a {{boolean}} value 0. Conversely, for a zero input value, invert it to a {{boolean}} value. 
+        - *not*: Invert the values of the input tensor to values 0 or 1, element-wise. Specifically, when the input value is non-zero, invert it to a {{boolean}} value 0. Conversely, for a zero input value, invert it to a {{boolean}} value 1.
 </div>
 
 <div class="note">
-Although operations *greaterOrEqual* and *lesserOrEqual* can each be implemented in terms of operations *not*, *lesser*, and *greater* in other words `greater-or-equal(a, b)` is `not(lesser(a, b))`, they are specifically defined for performance reason to avoid double comparisons in each element-wise test.
+Although operations *greaterOrEqual* and *lesserOrEqual* can each be implemented in terms of operations *not*, *lesser*, and *greater* in other words `greater-or-equal(a, b)` is `not(lesser(a, b))`, they are specifically defined to handle NaN cases and for performance reason to avoid double comparisons.
 </div>
 
 <details open algorithm>
@@ -2919,7 +2919,7 @@ partial interface MLGraphBuilder {
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input N-D tensor from which the values are gathered.
-        - *indices*: an {{MLOperand}}. The indices N-D tensor of the input values to gather. The values must be of type "uint32" in the range [0, N-1] where N is the size of the input dimension indexed by *options.axis*.
+        - *indices*: an {{MLOperand}}. The indices N-D tensor of the input values to gather. The values must be of type "uint32" or "int64" in the range [0, N-1] where N is the size of the input dimension indexed by *options.axis*.
         - *options*: an optional {{MLGatherOptions}}. The optional parameters of the operation.
 
     **Returns:** an {{MLOperand}}. The output N-D tensor of [=rank=] equal to the [=rank=] of *input* + the [=rank=] of *indices* - 1.
@@ -2931,6 +2931,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| and |indices| is {{MLOperand}}.
+    1. If |indices|.{{MLOperand/dataType()}} is neither "uint32" nor "int64", then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |shapeInput| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |rankInput| be the [=list/size=] of |shapeInput|.
     1. Let |shapeIndices| be |indices|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Let |axis| be |options|.{{MLGatherOptions/axis}}.

--- a/index.bs
+++ b/index.bs
@@ -2924,7 +2924,7 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| and |indices| is {{MLOperand}}.
-    1. Let |shapeInput| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |rankInput| the [=list/size=] of |shapeInput|.
+    1. Let |shapeInput| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |rankInput| be the [=list/size=] of |shapeInput|.
     1. Let |shapeIndices| be |indices|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. Let |axis| be |options|.{{MLGatherOptions/axis}}.
     1. Let |axisSize| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|axis|]

--- a/index.bs
+++ b/index.bs
@@ -2922,7 +2922,7 @@ partial interface MLGraphBuilder {
         - *indices*: an {{MLOperand}}. The indices N-D tensor of the input values to gather. The values must be of type "uint32" in the range [0, N-1] where N is the size of the input dimension indexed by *options.axis*.
         - *options*: an optional {{MLGatherOptions}}. The optional parameters of the operation.
 
-    **Returns:** an {{MLOperand}}. The output N-D tensor of [=rank=] equal to M + N - 1 where M and N are the [=rank=] of the *input* and *indices* tensor respectively.
+    **Returns:** an {{MLOperand}}. The output N-D tensor of [=rank=] equal to the [=rank=] of *input* + the [=rank=] of *indices* - 1.
 </div>
 
 <details open algorithm>

--- a/index.bs
+++ b/index.bs
@@ -5737,22 +5737,22 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/tri}} ### {#api-mlgraphbuilder-tri}
+### {{MLGraphBuilder/triangular}} ### {#api-mlgraphbuilder-triangular}
 Given a 2-D tensor (matrix), return a 2-D tensor containing either the upper or lower triangular part of the input tensor.
 
 <script type=idl>
-dictionary MLTriOptions {
+dictionary MLTriangularOptions {
   boolean upper = true;
   long diagonal = 0;
 };
 
 partial interface MLGraphBuilder {
-  MLOperand tri(MLOperand input, optional MLTriOptions options = {});
+  MLOperand triangular(MLOperand input, optional MLTriangularOptions options = {});
 };
 </script>
 
-{{MLTriOptions}} has the following members:
-<dl dfn-type=dict-member dfn-for=MLTriOptions>
+{{MLTriangularOptions}} has the following members:
+<dl dfn-type=dict-member dfn-for=MLTriangularOptions>
     : <dfn>upper</dfn>
     ::
         A {{boolean}} value. Indicate whether the output the upper or the lower part of the input matrix is retained. If not set, it is assumed to be true, indicating that the upper part is retained.
@@ -5764,20 +5764,20 @@ partial interface MLGraphBuilder {
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input 2-D tensor.
-        - *options*: an optional {{MLTriOptions}}. The optional parameters of the operation.
+        - *options*: an optional {{MLTriangularOptions}}. The optional parameters of the operation.
 
     **Returns:** an {{MLOperand}}. The output 2-D tensor representing a triangular matrix.
 </div>
 
 <details open algorithm>
   <summary>
-    The <dfn method for=MLGraphBuilder>tri(|input|, |options|)</dfn> method steps are:
+    The <dfn method for=MLGraphBuilder>triangular(|input|, |options|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the tri operation, given |options|.
+            1. Let |opImpl| be an [=implementation-defined=] platform operator for the triangular operation, given |options|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
             1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Store a reference to |outputImpl| in |output|.{{MLOperand/[[operand]]}}.
@@ -5790,7 +5790,7 @@ partial interface MLGraphBuilder {
 <div class="example">
 <details open>
   <summary>
-    Examples of how tri works in different diagonal settings.
+    Examples of how triangular works in different diagonal settings.
   </summary>
   <pre highlight="js">
     // input:
@@ -5804,37 +5804,37 @@ partial interface MLGraphBuilder {
     //   [[7, 1, 2], 
     //    [0, 4, 8],
     //    [0, 0, 3]]
-    const upper = builder.tri(input);
+    const upper = builder.triangular(input);
 
     // upper triangular matrix with one additional set of diagonals excluded:
     //   [[0, 1, 2], 
     //    [0, 0, 8],
     //    [0, 0, 0]]
-    const upperPositive = builder.tri(input, { diagonal: 1 });
+    const upperPositive = builder.triangular(input, { diagonal: 1 });
 
     // upper triangular matrix with one additional set of diagonals retained:
     //   [[7, 1, 2], 
     //    [9, 4, 8],
     //    [0, 6, 3]]
-    const upperNegative = builder.tri(input, { diagonal: -1 });
+    const upperNegative = builder.triangular(input, { diagonal: -1 });
 
     // lower triangular matrix:
     //   [[7, 0, 0],
     //    [9, 4, 0],
     //    [2, 6, 3]]
-    const lower = builder.tri(input, { upper: false });
+    const lower = builder.triangular(input, { upper: false });
 
     // lower triangular matrix with one additional set of diagonals retained:
     //   [[7, 1, 0],
     //    [9, 4, 8],
     //    [2, 6, 3]]
-    const lowerPositive = builder.tri(input, { upper: false, diagonal: 1 });
+    const lowerPositive = builder.triangular(input, { upper: false, diagonal: 1 });
 
     // lower triangular matrix with one additional set of diagonals excluded:
     //   [[0, 0, 0],
     //    [9, 0, 0],
     //    [2, 6, 0]]
-    const lowerNegative = builder.tri(input, { upper: false, diagonal: -1 });
+    const lowerNegative = builder.triangular(input, { upper: false, diagonal: -1 });
   </pre>
 </details>
 </div>

--- a/index.bs
+++ b/index.bs
@@ -395,7 +395,7 @@ th, td {
 Introduction {#intro}
 =====================
 
-The Web Neural Network API defines a web-friendly hardware-agnostic abstraction layer that makes use of Machine Learning capabilities of operating systems and underlying hardware platforms without being tied to platform-specific capabilities. The abstraction layer addresses the requirements of key Machine Learning JavaScript frameworks and also allows web developers familiar with the ML domain to write custom code without the help of libraries. A complementary <a href="https://webmachinelearning.github.io/model-loader/">Model Loader API</a> defines a higher-level abstraction targeting primarily web developers.
+The Web Neural Network API defines a web-friendly hardware-agnostic abstraction layer that makes use of Machine Learning capabilities of operating systems and underlying hardware platforms without being tied to platform-specific capabilities. The abstraction layer addresses the requirements of key Machine Learning JavaScript frameworks and also allows web developers familiar with the ML domain to write custom code without the help of libraries.
 
 For an illustrated introduction, please see the <a href="https://github.com/webmachinelearning/webnn/blob/master/explainer.md">explainer</a>.
 
@@ -671,8 +671,8 @@ array data (such as its shape).
 
 As mentioned above, the operations have a functional semantics. This allows the implementation
 to potentially share the array data between multiple tensors. For example, the implementation
-of operations such as reshape, or slice, or squeeze may return a view of its input tensor
-that shares the same buffer as the input tensor. (In the case of reshape or squeeze,
+of operations such as reshape, or slice may return a view of its input tensor
+that shares the same buffer as the input tensor. (In the case of reshape,
 the entire data is shared, while in the case of slice, a part of the input data is shared.)
 The implementation may use views, as above, for intermediate values.
 
@@ -725,20 +725,7 @@ The following table summarizes the types of resource supported by the context cr
 API {#api}
 =====================
 
-## The navigator.ml interface ## {#api-navigator-ml}
-
-An {{ML}} object is available in the {{Window}} and {{DedicatedWorkerGlobalScope}} contexts through the {{Navigator}}
-and {{WorkerNavigator}} interfaces respectively and is exposed via `navigator.ml`.
-
-<script type=idl>
-interface mixin NavigatorML {
-  [SecureContext, SameObject] readonly attribute ML ml;
-};
-Navigator includes NavigatorML;
-WorkerNavigator includes NavigatorML;
-</script>
-
-## The ML interface ## {#api-ml}
+## {{ML}} interface ## {#api-ml}
 <script type=idl>
 enum MLDeviceType {
   "cpu",
@@ -774,7 +761,7 @@ This specification defines a <a>policy-controlled feature</a> identified by the
 string "<code><dfn data-lt="webnn-feature">webnn</dfn></code>".
 Its <a>default allowlist</a> is <code>'self'</code>.
 
-### The {{ML/createContext()}} method ### {#api-ml-createcontext}
+### {{ML/createContext}} ### {#api-ml-createcontext}
 
 <details open algorithm>
 <summary>
@@ -822,7 +809,7 @@ Its <a>default allowlist</a> is <code>'self'</code>.
 </div>
 </details>
 
-### The {{ML/createContextSync()}} method ### {#api-ml-createcontextsync}
+### {{ML/createContextSync}} ### {#api-ml-createcontextsync}
 
 <details open algorithm>
   <summary>
@@ -848,175 +835,7 @@ Its <a>default allowlist</a> is <code>'self'</code>.
   </div>
 </details>
 
-## The MLGraph interface ## {#api-mlgraph}
-The {{MLGraph}} interface represents a compiled computational graph. A compiled graph once constructed is immutable and cannot be subsequently changed.
-
-<script type=idl>
-[SecureContext, Exposed=(Window, DedicatedWorker)]
-interface MLGraph {};
-</script>
-
-<div class=internal-slots>
-{{MLGraph}} has the following internal slots:
-  <dl dfn-type=attribute dfn-for="MLGraph">
-    : <dfn>\[[context]]</dfn> of type {{MLContext}}
-    ::
-        The context of type {{MLContext}} associated with this {{MLGraph}}.
-
-    : <dfn>\[[inputDescriptors]]</dfn> of type [=record=]&lt;{{DOMString}}, {{MLOperandDescriptor}}&gt;
-    ::
-        Maps the name of an input {{MLOperand}} to its {{MLOperandDescriptor}} for all input {{MLOperand}}s of this {{MLGraph}}.
-
-    : <dfn>\[[outputDescriptors]]</dfn> of type [=record=]&lt;{{DOMString}}, {{MLOperandDescriptor}}&gt;
-    ::
-        Maps the name of an output {{MLOperand}} to its {{MLOperandDescriptor}} for all output {{MLOperand}}s of this {{MLGraph}}.
-
-    : <dfn>\[[implementation]]</dfn>
-    ::
-        The underlying implementation provided by the User Agent.
-  </dl>
-</div>
-
-### The MLOperandDescriptor dictionary ### {#api-mloperanddescriptor}
-<script type=idl>
-enum MLInputOperandLayout {
-  "nchw",
-  "nhwc"
-};
-
-enum MLOperandDataType {
-  "float32",
-  "float16",
-  "int32",
-  "uint32",
-  "int8",
-  "uint8"
-};
-
-dictionary MLOperandDescriptor {
-  // The operand data type.
-  required MLOperandDataType dataType;
-
-  // The dimensions field is only required for tensor operands.
-  sequence<unsigned long> dimensions;
-};
-</script>
-
-<details open algorithm>
-  <summary>
-    The <dfn for="MLOperandDescriptor">byte length</dfn> of an {{MLOperandDescriptor}} |desc| is the value returned by the following steps:
-  </summary>
-  <div class=algorithm-steps>
-    1. Let |elementLength| be 1.
-    1. [=map/For each=] |dimension| of |desc|.{{MLOperandDescriptor/dimensions}}:
-        1. Set |elementLength| to |elementLength| × |dimension|.
-    1. Let |elementSize| be the [=element size=] of one of the {{ArrayBufferView}} types that matches |desc|.{{MLOperandDescriptor/dataType}} according to [this table](#appendices-mloperanddatatype-arraybufferview-compatibility).
-    1. Return |elementLength| × |elementSize|.
-  </div>
-</details>
-
-### The MLOperand interface ### {#api-mloperand}
-
-An {{MLOperand}} represents an intermediary graph being constructed as a result of compositing parts of an operation into a fully composed operation.
-
-For instance, an {{MLOperand}} may represent a constant feeding to an operation or the result from combining multiple constants together into an operation. See also [[#programming-model]].
-
-<script type=idl>
-[SecureContext, Exposed=(Window, DedicatedWorker)]
-interface MLOperand {};
-</script>
-
-<div class=internal-slots>
-{{MLOperand}} has the following internal slots:
-  <dl dfn-type=attribute dfn-for="MLOperand">
-    : <dfn>\[[builder]]</dfn> of type {{MLGraphBuilder}}
-    ::
-        The {{MLOperand}}'s associated builder object.
-
-    : <dfn>\[[descriptor]]</dfn> of type {{MLOperandDescriptor}}
-    ::
-        The {{MLOperand}}'s descriptor.
-
-    : <dfn>\[[name]]</dfn> of type [=string=]
-    ::
-        The {{MLOperand}}'s name (only for input operands).
-
-    : <dfn>\[[operand]]</dfn> of type [=object=]
-    ::
-        Reference to {{MLOperand}}'s corresponding [=implementation-defined=] platform operand object.
-
-    : <dfn>\[[operator]]</dfn> of type [=object=]
-    ::
-        Reference to {{MLOperand}}'s corresponding [=implementation-defined=] platform operator object.
-  </dl>
-</div>
-
-<div algorithm>
-To get the <dfn for="MLOperand">rank</dfn> of an {{MLOperand}} |operand|, run the following steps:
-<div class=algorithm-steps>
-    1. Return the [=list/size=] of |operand|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-</div>
-</div>
-
-Since the {{MLOperand/[[builder]]}} object is bound by the {{MLGraphBuilder/constructor()}} constructor to an {{MLContext}} object, an {{MLOperand}} is also always bound to the same {{MLContext}} object.
-
-#### Creating {{MLOperand}} #### {#api-mloperand-create}
-The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, internally using the following algorithms.
-
-<details open algorithm>
-  <summary>
-    To <dfn>create an MLOperand</dfn> given |builder| and |desc|, run the following steps:
-  </summary>
-  <div class=algorithm-steps>
-    1. [=Assert=]: the type of |builder| is {{MLGraphBuilder}}.
-    1. [=Assert=]: the type of |desc| is {{MLOperandDescriptor}}.
-    1. Let |operand| be a new [=object=].
-    1. Set |operand|.{{MLOperand/[[builder]]}} to |builder|.
-    1. Set |operand|.{{MLOperand/[[descriptor]]}} to |desc|.
-    1. Return |operand|.
-  </div>
-</details>
-
-<details open algorithm>
-  <summary>
-    To <dfn>copy an MLOperand</dfn> given |operand|, run the following steps:
-  </summary>
-  <div class=algorithm-steps>
-    1. [=Assert=]: the type of |operand| is {{MLOperand}}.
-    1. Let |result| be a new [=object=].
-    1. Set |result|.{{MLOperand/[[builder]]}} to |operand|.{{MLOperand/[[builder]]}}.
-    1. Set |result|.{{MLOperand/[[descriptor]]}} to |operand|.{{MLOperand/[[descriptor]]}}.
-    1. If |operand|.{{MLOperand/[[name]]}} [=map/exists=], then set |result|.{{MLOperand/[[name]]}} to |operand|.{{MLOperand/[[name]]}}.
-    1. Return |result|.
-  </div>
-</details>
-
-<details open algorithm>
-  <summary>
-    To <dfn>check dimensions</dfn> given |dimensions| and |type|, run the following steps:
-  </summary>
-  <div class=algorithm-steps>
-    1. If the [=list/size=] of |dimensions| is 0, return false.
-    1. If the [=list/size=] of |dimensions| is too large to be supported by the implementation, return false.
-    1. If any element of |dimensions| is not a positive number, or it is too large to be supported by the implementation given |type|, return false.
-    1. Return true.
-  </div>
-</details>
-
-<details open algorithm>
-  <summary>
-    To <dfn for="MLOperand">validate MLOperand</dfn> given |operand| and |builder|, run the following steps:
-  </summary>
-  <div class=algorithm-steps>
-    1. [=Assert=]: the type of |operand|.{{MLOperand/[[builder]]}} is {{MLGraphBuilder}}.
-    1. If |builder| is not equal to |operand|.{{MLOperand/[[builder]]}}, return false.
-    1. Let |desc| be |operand|.{{MLOperand/[[descriptor]]}}.
-    1. If |desc|.{{MLOperandDescriptor/dimensions}} [=map/exists=] and invoking <a>check dimensions</a> given |desc|.{{MLOperandDescriptor/dimensions}} and |desc|.{{MLOperandDescriptor/dataType}} returns false, then return false.
-    1. Return true.
-  </div>
-</details>
-
-### The MLActivation interface ### {#api-mlactivation}
+## {{MLActivation}} interface ## {#api-mlactivation}
 
 Objects implementing the {{MLActivation}} interface represent activation function types.
 
@@ -1048,7 +867,7 @@ interface MLActivation {
 These activations function types are used to create other operations. One such use of this interface is for when an activation function is fused into another operation such as [[#api-mlgraphbuilder-conv2d]] or [[#api-mlgraphbuilder-batchnorm]] during a graph construction session. Such fused activation functions can provide a significant performance improvement when supported natively by the underlying implementation. This is intended as an optimization opportunity for implementers.
 </div>
 
-#### Creating {{MLActivation}} #### {#api-mlactivation-create}
+### Creating {{MLActivation}} ### {#api-mlactivation-create}
 <div class="note">
 The {{MLActivation}} objects (including the ones passed as input to methods) are created by the methods of {{MLGraphBuilder}} and are identified by their name. The |options| dictionary is defined by those methods. The actual creation of the activation function e.g. a [[#api-mlgraphbuilder-sigmoid-method]] or [[#api-mlgraphbuilder-relu-method]] can then be deferred until when the rest of the graph is ready to connect with it such as during the construction of [[#api-mlgraphbuilder-conv2d]] for example.
 </div>
@@ -1074,316 +893,7 @@ The {{MLActivation}} objects (including the ones passed as input to methods) are
   </div>
 </details>
 
-## The MLContext interface ## {#api-mlcontext}
-The {{MLContext}} interface represents a global state of neural network compute workload and execution processes. Each {{MLContext}} object has associated [=context type=], [=device type=] and [=power preference=].
-
-The <dfn>context type</dfn> is the type of the execution context that manages the resources and facilitates the compilation and execution of the neural network graph:
-<dl>
-<dt>"<code><dfn data-lt="default-context">default</dfn></code>"</dt>
-<dd>Context created per user preference options.</dd>
-<dt>"<code><dfn data-lt="webgpu-context">webgpu</dfn></code>"</dt>
-<dd>Context created from WebGPU device.</dd>
-</dl>
-
-The <dfn>device type</dfn> indicates the kind of device used for the context. It is one of the following:
-<dl>
-<dt>"<code><dfn data-lt="device-type-cpu">cpu</dfn></code>"</dt>
-<dd>Provides the broadest compatibility and usability across all client devices with varying degrees of performance.</dd>
-<dt>"<code><dfn data-lt="device-type-gpu">gpu</dfn></code>"</dt>
-<dd>Provides the broadest range of achievable performance across graphics hardware platforms from consumer devices to professional workstations.</dd>
-</dl>
-
-The <dfn>power preference</dfn> indicates preference as related to power consumption. It is one of the following:
-<dl>
-<dt>"<code><dfn data-lt="power-preference-default">default</dfn></code>"</dt>
-<dd>Let the user agent select the most suitable behavior.</dd>
-<dt>"<code><dfn data-lt="power-preference-high-performance">high-performance</dfn></code>"</dt>
-<dd>Prioritizes execution speed over power consumption.</dd>
-<dt>"<code><dfn data-lt="power-preference-low-power">low-power</dfn></code>"</dt>
-<dd>Prioritizes power consumption over other considerations such as execution speed.</dd>
-</dl>
-
-<script type=idl>
-typedef record<DOMString, ArrayBufferView> MLNamedArrayBufferViews;
-
-[SecureContext, Exposed=(Window, DedicatedWorker)]
-interface MLContext {};
-</script>
-
-<div class=internal-slots>
-{{MLContext}} has the following internal slots:
-  <dl dfn-type=attribute dfn-for="MLContext">
-    : <dfn>\[[contextType]]</dfn> of type [=context type=]
-    ::
-        The {{MLContext}}'s [=context type=].
-    : <dfn>\[[deviceType]]</dfn> of type [=device type=]
-    ::
-        The {{MLContext}}'s [=device type=].
-    : <dfn>\[[powerPreference]]</dfn> of type [=power preference=]
-    ::
-        The {{MLContext}}'s [=power preference=].
-  </dl>
-</div>
-
-<div class="note">
-When the {{[[contextType]]}} is set to [=default-context|default=] with the {{MLContextOptions}}.{{deviceType}} set to [=device-type-gpu|gpu=], the user agent is responsible for creating an internal GPU device that operates within the context and is capable of ML workload submission on behalf of the calling application. In this setting however, only {{ArrayBufferView}} inputs and outputs are allowed in and out of the graph execution since the application has no way to know what type of internal GPU device is being created on their behalf. In this case, the user agent is responsible for automatic uploads and downloads of the inputs and outputs to and from the GPU memory using this said internal device.
-</div>
-
-### The {{MLContext}} validation algorithm ### {#api-mlcontext-validate}
-
-<details open algorithm>
-  <summary>
-    To <dfn>validate MLContext</dfn>, given |context|, run these steps:
-  </summary>
-  <div class=algorithm-steps>
-    1. If |context|.{{[[contextType]]}} is not "[=webgpu-context|webgpu=]" or "[=default-context|default=]", return false.
-    1. If |context|.{{[[deviceType]]}} is not "[=device-type-cpu|cpu=]" or "[=device-type-gpu|gpu=]", return false.
-    1. If |context|.{{[[powerPreference]]}} is not "[=power-preference-default|default=]" or "[=power-preference-high-performance|high-performance=]" or "[=power-preference-low-power|low-power=]", return false.
-    1. If the user agent cannot support |context|.{{[[contextType]]}}, |context|.{{[[deviceType]]}} and |context|.{{[[powerPreference]]}}, return false.
-    1. Return true;
-  </div>
-</details>
-
-### Synchronous Execution ### {#api-mlcontext-sync-execution}
-Synchronously carries out the computational workload of a compiled graph {{MLGraph}} on the calling thread, which must be a worker thread, to produce results as defined by the operations in the graph. This method of execution requires an {{MLContext}} created with {{MLContextOptions}}. Otherwise, it[=exception/throws=] an "{{OperationError}}" {{DOMException}}.
-
-<script type=idl>
-partial interface MLContext {
-  [Exposed=(DedicatedWorker)]
-  undefined computeSync(
-      MLGraph graph, MLNamedArrayBufferViews inputs, MLNamedArrayBufferViews outputs);
-};
-</script>
-
-<div>
-    **Arguments:**
-      - *graph*: an {{MLGraph}}. The compiled graph to be executed.
-      - *inputs*: an {{MLNamedArrayBufferViews}}. The resources of inputs.
-      - *outputs*: an {{MLNamedArrayBufferViews}}. The pre-allocated resources of required outputs.
-
-    **Returns:** {{undefined}}.
-</div>
-
-<details open algorithm>
-  <summary>
-    The <dfn method for=MLContext>computeSync(|graph|, |inputs|, |outputs|)</dfn> method steps are:
-  </summary>
-  <div class=algorithm-steps>
-    1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=]", [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-    1. If <a>validating graph resources</a> given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If <a>validating graph resources</a> given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. Invoke <a>execute graph</a> given |graph|, |inputs| and |outputs|.
-    1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
-    1. Return {{undefined}}.
-  </div>
-</details>
-
-<details open algorithm>
-  <summary>
-    To <dfn>validate graph resources</dfn>, given |resources| and |descriptors|, run the following steps:
-  </summary>
-  <div class=algorithm-steps>
-    1. [=Assert=]: the type of |resources| is {{MLNamedArrayBufferViews}}.
-    1. [=map/For each=] [=record=] <|key|, |value|> of |resources|:
-        1. If |descriptors|[|key|] does not [=map/exist=], return false.
-        1. [=Assert=]: the type of |value| is {{ArrayBufferView}}.
-        1. If <a>validating buffer with descriptor</a> given |value| and |descriptors|[|key|] returns false, then return false.
-    1. Return true.
-  </div>
-</details>
-
-<details open algorithm>
-  <summary>
-    To <dfn>validate buffer with descriptor</dfn> given |bufferView| and |descriptor|, run the following steps:
-  </summary>
-  <div class=algorithm-steps>
-    1. If |bufferView| is not an {{MLBufferView}}, return false.
-    1. If |bufferView|'s [=element type=] does not match to |descriptor|.{{MLOperandDescriptor/dataType}}  according to [this table](#appendices-mloperanddatatype-arraybufferview-compatibility), return false.
-    1. If |bufferView|.\[[ByteLength]] is not equal to the [=byte length=] of |descriptor|, return false.
-  </div>
-</details>
-
-<details open algorithm>
-  <summary>
-    To <dfn>execute graph</dfn>, given |graph|, |inputs| and |outputs|, run the following steps:
-  </summary>
-  <div class=algorithm-steps>
-    1. [=Assert=]: the type of |inputs| is {{MLNamedArrayBufferViews}}.
-    1. Let |inputResources| denote the input resources of |graph|.{{MLGraph/[[implementation]]}}.
-    1. [=map/For each=] <|key|, |inputValue|> of |inputs|:
-        1. Let |inputDescriptor| be |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|].
-        1. Let |inputTensor| be a new tensor for |graph|.{{MLGraph/[[implementation]]}} as follows:
-            1. Set the data type of |inputTensor| to the one that matches the [=element type=] of |inputValue|.
-            1. Set the dimensions of |inputTensor| to |inputDescriptor|.{{MLOperandDescriptor/dimensions}}.
-            1. Set the values of elements in |inputTensor| to the values of elements in |inputValue|.
-        1. Request the underlying implementation of |graph| to bind |inputResources|[|key|] to |inputTensor|.
-    1. [=Assert=]: the type of |outputs| is {{MLNamedArrayBufferViews}}.
-    1. [=map/For each=] <|key|, |outputValue|> of |outputs|:
-        1. Issue a compute request to |graph|.{{MLGraph/[[implementation]]}} given |key| and |inputResources| and wait for completion.
-            1. If that returns an error, then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-            1. Otherwise, store the result in |outputTensor|.
-        1. Let |outputDesc| be |graph|.{{MLGraph/[[outputDescriptors]]}}[|key|].
-        1. If the byte length of |outputTensor| is not equal to the [=byte length=] of |outputDesc|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. If the [=element type=] of |outputTensor| doesn't match the [=element type=] of |outputValue|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. Request the underlying implementation of |graph| to set the values of elements in |outputValue| to the values of elements in |outputTensor|.
-    1. Return {{undefined}}.
-  </div>
-</details>
-
-#### Examples #### {#api-mlcontext-sync-execution-examples}
-
-<div class="example">
-<details open>
-  <summary>
-    The following code showcases the synchronous computation with optional outputs in a worker.
-  </summary>
-  <pre highlight="js">
-    const context = navigator.ml.createContextSync();
-
-    // Build a graph with two outputs.
-    const builder = new MLGraphBuilder(context);
-    const descA = {dataType: 'float32', dimensions: [3, 4]};
-    const a = builder.input('a', descA);
-    const descB = {dataType: 'float32', dimensions: [4, 3]};
-    const bufferB = new Float32Array(sizeOfShape(descB.dimensions)).fill(0.5);
-    const b = builder.constant(descB, bufferB);
-    const descC = {dataType: 'float32', dimensions: [3, 3]};
-    const bufferC = new Float32Array(sizeOfShape(descC.dimensions)).fill(1);
-    const c = builder.constant(descC, bufferC);
-    const d = builder.matmul(a, b);
-    const e = builder.add(d, c);
-    const graph = builder.buildSync({'d': d, 'e': e});
-
-    const bufferA = new Float32Array(sizeOfShape(descA.dimensions)).fill(0.5);
-    const inputs = {'a': bufferA};
-
-    // Compute d.
-    const bufferD = new Float32Array(sizeOfShape([3, 3]));
-    context.computeSync(graph, inputs, {'d': bufferD});
-    console.log(&#96;values: ${bufferD}&#96;);
-
-    // Compute e.
-    const bufferE = new Float32Array(sizeOfShape([3, 3]));
-    context.computeSync(graph, inputs, {'e': bufferE});
-    console.log(&#96;values: ${bufferE}&#96;);
-  </pre>
-</details>
-</div>
-
-### The {{MLNamedArrayBufferViews}} transfer algorithm ### {#mlnamedarraybufferviews-transfer-alg}
-
-<details open algorithm>
-  <summary>
-    To <dfn for="MLNamedArrayBufferViews">transfer</dfn> an {{MLNamedArrayBufferViews}} |views|:
-  </summary>
-  <div class=algorithm-steps>
-    1. Let |transferredViews| be a new {{MLNamedArrayBufferViews}}.
-    1. [=map/For each=] |key| &rarr; |value| of |views|:
-        1. Let |transferredBuffer| be the result of [=ArrayBuffer/transfer|transferring=] the [=underlying buffer=] of |value|.
-        1. Let |constructor| be the appropriate [=view constructor=] for the type of {{ArrayBufferView}} |value|.
-        1. Let |elementsNumber| be the result of the [=BufferSource/byte length=] of |value| ÷ [=element size=] of |value|.
-        1. Let |transferredView| be [$Construct$](|constructor|, |transferredBuffer|, |value|.\[[ByteOffset]], |elementsNumber|).
-        1. Set |transferredViews|[|key|] to |transferredView|.
-    1. Return |transferredViews|.
-  </div>
-</details>
-
-### Asynchronous Execution ### {#api-mlcontext-async-execution}
-Asynchronously carries out the computational workload of a compiled graph {{MLGraph}} on a separate timeline, either on a worker thread for the CPU execution, or on a GPU timeline for the submission of GPU workload on the command queue. The asynchronous nature of this call avoids blocking the calling thread while the computation for result is ongoing. This method of execution requires an {{MLContext}} created with {{MLContextOptions}}. Otherwise, it[=exception/throws=] an "{{OperationError}}" {{DOMException}}.
-
-<div class="note">
-In accordance with the [=ArrayBufferView/write|Web IDL warning=], to prevent the calling thread from modifying the input and output resources while the computation is ongoing, this method [=MLNamedArrayBufferViews/transfer|transfers=] the input and output {{MLNamedArrayBufferViews}} to new views that share the same backing memory allocations. The transferred views are returned to the caller via the promise fulfillment with the computation result written into the backing memory of the output views.
-</div>
-
-<script type=idl>
-dictionary MLComputeResult {
-  MLNamedArrayBufferViews inputs;
-  MLNamedArrayBufferViews outputs;
-};
-
-partial interface MLContext {
-  Promise<MLComputeResult> compute(
-      MLGraph graph, MLNamedArrayBufferViews inputs, MLNamedArrayBufferViews outputs);
-};
-</script>
-<div>
-    **Arguments:**
-      - *graph*: an {{MLGraph}}. The compiled graph to be executed.
-      - *inputs*: an {{MLNamedArrayBufferViews}}. The resources of inputs. Will be [=MLNamedArrayBufferViews/transfer|transferred=] if there are no validation errors.
-      - *outputs*: an {{MLNamedArrayBufferViews}}. The pre-allocated resources of required outputs. Will be [=MLNamedArrayBufferViews/transfer|transferred=] if there are no validation errors.
-
-    **Returns:** Promise<{{MLComputeResult}}>.
-</div>
-
-<details open algorithm>
-  <summary>
-    The <dfn method for=MLContext>compute(|graph|, |inputs|, |outputs|)</dfn> method steps are:
-  </summary>
-  <div class=algorithm-steps>
-    1. Let |promise| be [=a new promise=].
-    1. Return |promise| and run the following steps [=in parallel=]:
-        1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=]", [=reject=] |promise| with an "{{OperationError}}" {{DOMException}}.
-        1. If <a>validating graph resources</a> given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns false, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}}.
-        1. If <a>validating graph resources</a> given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns false, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}}.
-        1. Let |transferredInputs| be the result of [=MLNamedArrayBufferViews/transfer|transferring=] {{MLNamedArrayBufferViews}} |inputs|.
-        1. Let |transferredOutputs| be the result of [=MLNamedArrayBufferViews/transfer|transferring=] {{MLNamedArrayBufferViews}} |outputs|.
-        1. Invoke <a>execute graph</a> given |graph|, |transferredInputs| and |transferredOutputs|.
-        1. If that [=exception/throws=] an error, [=reject=] |promise| with the error.
-        1. Otherwise, when <a>execute graph</a> has completed:
-            1. Let |result| be a new {{MLComputeResult}}.
-            1. Set |result|.{{MLComputeResult/inputs}} to |transferredInputs|.
-            1. Set |result|.{{MLComputeResult/outputs}} to |transferredOutputs|.
-            1. [=Resolve=] |promise| with |result|.
-  </div>
-</details>
-
-#### Examples #### {#api-mlcontext-async-execution-examples}
-<div class="example">
-<details open>
-  <summary>
-    The following code showcases the asynchronous computation.
-  </summary>
-  <pre highlight="js">
-    const operandType = {dataType: 'float32', dimensions: [2, 2]};
-    const context = await navigator.ml.createContext();
-    const builder = new MLGraphBuilder(context);
-    // 1. Create a computational graph 'C = 0.2 * A + B'.
-    const constant = builder.constant(0.2);
-    const A = builder.input('A', operandType);
-    const B = builder.input('B', operandType);
-    const C = builder.add(builder.mul(A, constant), B);
-    // 2. Compile it into an executable.
-    const graph = await builder.build({'C': C});
-    // 3. Bind inputs to the graph and execute for the result.
-    const bufferA = new Float32Array(4).fill(1.0);
-    const bufferB = new Float32Array(4).fill(0.8);
-    const bufferC = new Float32Array(4);
-    const inputs = {'A': bufferA, 'B': bufferB};
-    const outputs = {'C': bufferC};
-    const result = await context.compute(graph, inputs, outputs);
-    // The computed result of [[1, 1], [1, 1]] is in the buffer associated with
-    // the output operand.
-    console.log('Output value: ' + result.outputs.C);
-    // Note: the result.outputs.C buffer is different from the bufferC, but it
-    // shares the same backing memory allocation.
-  </pre>
-</details>
-</div>
-
-### WebGPU Interoperability ### {#api-mlcontext-webgpu-interop}
-Create {{MLCommandEncoder}} interface used to record the ML workload onto a WebGPU-compatible {{GPUCommandBuffer}} to allow mixing of ML workload with other GPU workload in an application that leverages WebGPU. This method only succeeds on an {{MLContext}} created with {{GPUDevice}}. Otherwise, it[=exception/throws=] an "{{OperationError}}" {{DOMException}}.
-
-<script type=idl>
-partial interface MLContext {
-  MLCommandEncoder createCommandEncoder();
-};
-</script>
-
-<div algorithm=mlcontext.createcommandencoder>
-    **Returns:** {{MLCommandEncoder}}. The command encoder used to record ML workload on the GPU.
-</div>
-
-## The MLCommandEncoder interface ## {#api-mlcommandencoder}
+## {{MLCommandEncoder}} interface ## {#api-mlcommandencoder}
 The {{MLCommandEncoder}} interface represents a method of execution that synchronously records the computational workload of a compiled {{MLGraph}} to a {{GPUCommandBuffer}} on the calling thread. Since the workload is not immediately executed, just recorded, this method allows more flexibility for the caller to determine how and when the recorded commands will be submitted for execution on the GPU relative to other GPU workload on the same or different queue.
 
 <script type=idl>
@@ -1430,7 +940,7 @@ partial interface MLCommandEncoder {
   </summary>
   <div>
     <div class="note">
-        Graph initialization stage typically involves a process known as "weight preprocessing" where all the constant inputs to the graph are preprocessed and cached at the operating system level for subsequent graph execution calls. The initializing inputs are typically the constant weight data specified through the {{MLGraphBuilder/constant(descriptor, bufferView)|MLGraphBuilder/constant(value, dataType)}} method as constant operands during graph construction time.
+        Graph initialization stage typically involves a process known as "weight preprocessing" where all the constant inputs to the graph are preprocessed and cached at the operating system level for subsequent graph execution calls. The initializing inputs are typically the constant weight data specified through the {{MLGraphBuilder/constant(descriptor, bufferView)|MLGraphBuilder/constant(value, type)}} method as constant operands during graph construction time.
     </div>
   </div>
 </details>
@@ -1512,7 +1022,345 @@ partial interface MLCommandEncoder {
   </div>
 </details>
 
-## The MLGraphBuilder interface ## {#api-mlgraphbuilder}
+## {{MLContext}} interface ## {#api-mlcontext}
+The {{MLContext}} interface represents a global state of neural network compute workload and execution processes. Each {{MLContext}} object has associated [=context type=], [=device type=] and [=power preference=].
+
+The <dfn>context type</dfn> is the type of the execution context that manages the resources and facilitates the compilation and execution of the neural network graph:
+<dl>
+<dt>"<code><dfn data-lt="default-context">default</dfn></code>"</dt>
+<dd>Context created per user preference options.</dd>
+<dt>"<code><dfn data-lt="webgpu-context">webgpu</dfn></code>"</dt>
+<dd>Context created from WebGPU device.</dd>
+</dl>
+
+The <dfn>device type</dfn> indicates the kind of device used for the context. It is one of the following:
+<dl>
+<dt>"<code><dfn data-lt="device-type-cpu">cpu</dfn></code>"</dt>
+<dd>Provides the broadest compatibility and usability across all client devices with varying degrees of performance.</dd>
+<dt>"<code><dfn data-lt="device-type-gpu">gpu</dfn></code>"</dt>
+<dd>Provides the broadest range of achievable performance across graphics hardware platforms from consumer devices to professional workstations.</dd>
+</dl>
+
+The <dfn>power preference</dfn> indicates preference as related to power consumption. It is one of the following:
+<dl>
+<dt>"<code><dfn data-lt="power-preference-default">default</dfn></code>"</dt>
+<dd>Let the user agent select the most suitable behavior.</dd>
+<dt>"<code><dfn data-lt="power-preference-high-performance">high-performance</dfn></code>"</dt>
+<dd>Prioritizes execution speed over power consumption.</dd>
+<dt>"<code><dfn data-lt="power-preference-low-power">low-power</dfn></code>"</dt>
+<dd>Prioritizes power consumption over other considerations such as execution speed.</dd>
+</dl>
+
+<script type=idl>
+typedef record<DOMString, ArrayBufferView> MLNamedArrayBufferViews;
+
+[SecureContext, Exposed=(Window, DedicatedWorker)]
+interface MLContext {};
+</script>
+
+<div class=internal-slots>
+{{MLContext}} has the following internal slots:
+  <dl dfn-type=attribute dfn-for="MLContext">
+    : <dfn>\[[contextType]]</dfn> of type [=context type=]
+    ::
+        The {{MLContext}}'s [=context type=].
+    : <dfn>\[[deviceType]]</dfn> of type [=device type=]
+    ::
+        The {{MLContext}}'s [=device type=].
+    : <dfn>\[[powerPreference]]</dfn> of type [=power preference=]
+    ::
+        The {{MLContext}}'s [=power preference=].
+  </dl>
+</div>
+
+<div class="note">
+When the {{[[contextType]]}} is set to [=default-context|default=] with the {{MLContextOptions}}.{{deviceType}} set to [=device-type-gpu|gpu=], the user agent is responsible for creating an internal GPU device that operates within the context and is capable of ML workload submission on behalf of the calling application. In this setting however, only {{ArrayBufferView}} inputs and outputs are allowed in and out of the graph execution since the application has no way to know what type of internal GPU device is being created on their behalf. In this case, the user agent is responsible for automatic uploads and downloads of the inputs and outputs to and from the GPU memory using this said internal device.
+</div>
+
+### {{MLContext}} validation algorithm ### {#api-mlcontext-validate}
+
+<details open algorithm>
+  <summary>
+    To <dfn>validate MLContext</dfn>, given |context|, run these steps:
+  </summary>
+  <div class=algorithm-steps>
+    1. If |context|.{{[[contextType]]}} is not "[=webgpu-context|webgpu=]" or "[=default-context|default=]", return false.
+    1. If |context|.{{[[deviceType]]}} is not "[=device-type-cpu|cpu=]" or "[=device-type-gpu|gpu=]", return false.
+    1. If |context|.{{[[powerPreference]]}} is not "[=power-preference-default|default=]" or "[=power-preference-high-performance|high-performance=]" or "[=power-preference-low-power|low-power=]", return false.
+    1. If the user agent cannot support |context|.{{[[contextType]]}}, |context|.{{[[deviceType]]}} and |context|.{{[[powerPreference]]}}, return false.
+    1. Return true;
+  </div>
+</details>
+
+### Synchronous Execution ### {#api-mlcontext-sync-execution}
+Synchronously carries out the computational workload of a compiled graph {{MLGraph}} on the calling thread, which must be a worker thread, to produce results as defined by the operations in the graph. This method of execution requires an {{MLContext}} created with {{MLContextOptions}}. Otherwise, it[=exception/throws=] an "{{OperationError}}" {{DOMException}}.
+
+<script type=idl>
+partial interface MLContext {
+  [Exposed=(DedicatedWorker)]
+  undefined computeSync(
+      MLGraph graph, MLNamedArrayBufferViews inputs, MLNamedArrayBufferViews outputs);
+};
+</script>
+
+<div>
+    **Arguments:**
+      - *graph*: an {{MLGraph}}. The compiled graph to be executed.
+      - *inputs*: an {{MLNamedArrayBufferViews}}. The resources of inputs.
+      - *outputs*: an {{MLNamedArrayBufferViews}}. The pre-allocated resources of required outputs.
+
+    **Returns:** {{undefined}}.
+</div>
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLContext>computeSync(|graph|, |inputs|, |outputs|)</dfn> method steps are:
+  </summary>
+  <div class=algorithm-steps>
+    1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=]", [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. If <a>validating graph resources</a> given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If <a>validating graph resources</a> given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Invoke <a>execute graph</a> given |graph|, |inputs| and |outputs|.
+    1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
+    1. Return {{undefined}}.
+  </div>
+</details>
+
+<details open algorithm>
+  <summary>
+    To <dfn>validate graph resources</dfn>, given |resources| and |descriptors|, run the following steps:
+  </summary>
+  <div class=algorithm-steps>
+    1. [=Assert=]: the type of |resources| is {{MLNamedArrayBufferViews}}.
+    1. [=map/For each=] [=record=] <|key|, |value|> of |resources|:
+        1. If |descriptors|[|key|] does not [=map/exist=], return false.
+        1. [=Assert=]: the type of |value| is {{ArrayBufferView}}.
+        1. If <a>validating buffer with descriptor</a> given |value| and |descriptors|[|key|] returns false, then return false.
+    1. Return true.
+  </div>
+</details>
+
+<details open algorithm>
+  <summary>
+    To <dfn>validate buffer with descriptor</dfn> given |bufferView| and |descriptor|, run the following steps:
+  </summary>
+  <div class=algorithm-steps>
+    1. If |bufferView| is not an {{MLBufferView}}, return false.
+    1. If |bufferView|'s [=element type=] does not match to |descriptor|.{{MLOperandDescriptor/type}}  according to [this table](#appendices-mloperanddatatype-arraybufferview-compatibility), return false.
+    1. If |bufferView|.\[[ByteLength]] is not equal to the [=byte length=] of |descriptor|, return false.
+  </div>
+</details>
+
+<details open algorithm>
+  <summary>
+    To <dfn>execute graph</dfn>, given |graph|, |inputs| and |outputs|, run the following steps:
+  </summary>
+  <div class=algorithm-steps>
+    1. [=Assert=]: the type of |inputs| is {{MLNamedArrayBufferViews}}.
+    1. Let |inputResources| denote the input resources of |graph|.{{MLGraph/[[implementation]]}}.
+    1. [=map/For each=] <|key|, |inputValue|> of |inputs|:
+        1. Let |inputDescriptor| be |graph|.{{MLGraph/[[inputDescriptors]]}}[|key|].
+        1. Let |inputTensor| be a new tensor for |graph|.{{MLGraph/[[implementation]]}} as follows:
+            1. Set the data type of |inputTensor| to the one that matches the [=element type=] of |inputValue|.
+            1. Set the dimensions of |inputTensor| to |inputDescriptor|.{{MLOperandDescriptor/dimensions}}.
+            1. Set the values of elements in |inputTensor| to the values of elements in |inputValue|.
+        1. Request the underlying implementation of |graph| to bind |inputResources|[|key|] to |inputTensor|.
+    1. [=Assert=]: the type of |outputs| is {{MLNamedArrayBufferViews}}.
+    1. [=map/For each=] <|key|, |outputValue|> of |outputs|:
+        1. Issue a compute request to |graph|.{{MLGraph/[[implementation]]}} given |key| and |inputResources| and wait for completion.
+            1. If that returns an error, then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+            1. Otherwise, store the result in |outputTensor|.
+        1. Let |outputDesc| be |graph|.{{MLGraph/[[outputDescriptors]]}}[|key|].
+        1. If the byte length of |outputTensor| is not equal to the [=byte length=] of |outputDesc|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If the [=element type=] of |outputTensor| doesn't match the [=element type=] of |outputValue|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. Request the underlying implementation of |graph| to set the values of elements in |outputValue| to the values of elements in |outputTensor|.
+    1. Return {{undefined}}.
+  </div>
+</details>
+
+#### Examples #### {#api-mlcontext-sync-execution-examples}
+
+<div class="example">
+<details open>
+  <summary>
+    The following code showcases the synchronous computation with optional outputs in a worker.
+  </summary>
+  <pre highlight="js">
+    const context = navigator.ml.createContextSync();
+
+    // Build a graph with two outputs.
+    const builder = new MLGraphBuilder(context);
+    const descA = {type: 'float32', dimensions: [3, 4]};
+    const a = builder.input('a', descA);
+    const descB = {type: 'float32', dimensions: [4, 3]};
+    const bufferB = new Float32Array(sizeOfShape(descB.dimensions)).fill(0.5);
+    const b = builder.constant(descB, bufferB);
+    const descC = {type: 'float32', dimensions: [3, 3]};
+    const bufferC = new Float32Array(sizeOfShape(descC.dimensions)).fill(1);
+    const c = builder.constant(descC, bufferC);
+    const d = builder.matmul(a, b);
+    const e = builder.add(d, c);
+    const graph = builder.buildSync({'d': d, 'e': e});
+
+    const bufferA = new Float32Array(sizeOfShape(descA.dimensions)).fill(0.5);
+    const inputs = {'a': bufferA};
+
+    // Compute d.
+    const bufferD = new Float32Array(sizeOfShape([3, 3]));
+    context.computeSync(graph, inputs, {'d': bufferD});
+    console.log(&#96;values: ${bufferD}&#96;);
+
+    // Compute e.
+    const bufferE = new Float32Array(sizeOfShape([3, 3]));
+    context.computeSync(graph, inputs, {'e': bufferE});
+    console.log(&#96;values: ${bufferE}&#96;);
+  </pre>
+</details>
+</div>
+
+### {{MLNamedArrayBufferViews}} transfer algorithm ### {#mlnamedarraybufferviews-transfer-alg}
+
+<details open algorithm>
+  <summary>
+    To <dfn for="MLNamedArrayBufferViews">transfer</dfn> an {{MLNamedArrayBufferViews}} |views|:
+  </summary>
+  <div class=algorithm-steps>
+    1. Let |transferredViews| be a new {{MLNamedArrayBufferViews}}.
+    1. [=map/For each=] |key| &rarr; |value| of |views|:
+        1. Let |transferredBuffer| be the result of [=ArrayBuffer/transfer|transferring=] the [=underlying buffer=] of |value|.
+        1. Let |constructor| be the appropriate [=view constructor=] for the type of {{ArrayBufferView}} |value|.
+        1. Let |elementsNumber| be the result of the [=BufferSource/byte length=] of |value| ÷ [=element size=] of |value|.
+        1. Let |transferredView| be [$Construct$](|constructor|, |transferredBuffer|, |value|.\[[ByteOffset]], |elementsNumber|).
+        1. Set |transferredViews|[|key|] to |transferredView|.
+    1. Return |transferredViews|.
+  </div>
+</details>
+
+### Asynchronous Execution ### {#api-mlcontext-async-execution}
+Asynchronously carries out the computational workload of a compiled graph {{MLGraph}} on a separate timeline, either on a worker thread for the CPU execution, or on a GPU timeline for the submission of GPU workload on the command queue. The asynchronous nature of this call avoids blocking the calling thread while the computation for result is ongoing. This method of execution requires an {{MLContext}} created with {{MLContextOptions}}. Otherwise, it[=exception/throws=] an "{{OperationError}}" {{DOMException}}.
+
+<div class="note">
+In accordance with the [=ArrayBufferView/write|Web IDL warning=], to prevent the calling thread from modifying the input and output resources while the computation is ongoing, this method [=MLNamedArrayBufferViews/transfer|transfers=] the input and output {{MLNamedArrayBufferViews}} to new views that share the same backing memory allocations. The transferred views are returned to the caller via the promise fulfillment with the computation result written into the backing memory of the output views.
+</div>
+
+<script type=idl>
+dictionary MLComputeResult {
+  MLNamedArrayBufferViews inputs;
+  MLNamedArrayBufferViews outputs;
+};
+
+partial interface MLContext {
+  Promise<MLComputeResult> compute(
+      MLGraph graph, MLNamedArrayBufferViews inputs, MLNamedArrayBufferViews outputs);
+};
+</script>
+<div>
+    **Arguments:**
+      - *graph*: an {{MLGraph}}. The compiled graph to be executed.
+      - *inputs*: an {{MLNamedArrayBufferViews}}. The resources of inputs. Will be [=MLNamedArrayBufferViews/transfer|transferred=] if there are no validation errors.
+      - *outputs*: an {{MLNamedArrayBufferViews}}. The pre-allocated resources of required outputs. Will be [=MLNamedArrayBufferViews/transfer|transferred=] if there are no validation errors.
+
+    **Returns:** Promise<{{MLComputeResult}}>.
+</div>
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLContext>compute(|graph|, |inputs|, |outputs|)</dfn> method steps are:
+  </summary>
+  <div class=algorithm-steps>
+    1. Let |promise| be [=a new promise=].
+    1. Return |promise| and run the following steps [=in parallel=]:
+        1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=default-context|default=]", [=reject=] |promise| with an "{{OperationError}}" {{DOMException}}.
+        1. If <a>validating graph resources</a> given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns false, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}}.
+        1. If <a>validating graph resources</a> given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns false, then [=reject=] |promise| with a "{{DataError}}" {{DOMException}}.
+        1. Let |transferredInputs| be the result of [=MLNamedArrayBufferViews/transfer|transferring=] {{MLNamedArrayBufferViews}} |inputs|.
+        1. Let |transferredOutputs| be the result of [=MLNamedArrayBufferViews/transfer|transferring=] {{MLNamedArrayBufferViews}} |outputs|.
+        1. Invoke <a>execute graph</a> given |graph|, |transferredInputs| and |transferredOutputs|.
+        1. If that [=exception/throws=] an error, [=reject=] |promise| with the error.
+        1. Otherwise, when <a>execute graph</a> has completed:
+            1. Let |result| be a new {{MLComputeResult}}.
+            1. Set |result|.{{MLComputeResult/inputs}} to |transferredInputs|.
+            1. Set |result|.{{MLComputeResult/outputs}} to |transferredOutputs|.
+            1. [=Resolve=] |promise| with |result|.
+  </div>
+</details>
+
+#### Examples #### {#api-mlcontext-async-execution-examples}
+<div class="example">
+<details open>
+  <summary>
+    The following code showcases the asynchronous computation.
+  </summary>
+  <pre highlight="js">
+    const operandType = {type: 'float32', dimensions: [2, 2]};
+    const context = await navigator.ml.createContext();
+    const builder = new MLGraphBuilder(context);
+    // 1. Create a computational graph 'C = 0.2 * A + B'.
+    const constant = builder.constant(0.2);
+    const A = builder.input('A', operandType);
+    const B = builder.input('B', operandType);
+    const C = builder.add(builder.mul(A, constant), B);
+    // 2. Compile it into an executable.
+    const graph = await builder.build({'C': C});
+    // 3. Bind inputs to the graph and execute for the result.
+    const bufferA = new Float32Array(4).fill(1.0);
+    const bufferB = new Float32Array(4).fill(0.8);
+    const bufferC = new Float32Array(4);
+    const inputs = {'A': bufferA, 'B': bufferB};
+    const outputs = {'C': bufferC};
+    const result = await context.compute(graph, inputs, outputs);
+    // The computed result of [[1, 1], [1, 1]] is in the buffer associated with
+    // the output operand.
+    console.log('Output value: ' + result.outputs.C);
+    // Note: the result.outputs.C buffer is different from the bufferC, but it
+    // shares the same backing memory allocation.
+  </pre>
+</details>
+</div>
+
+### WebGPU Interoperability ### {#api-mlcontext-webgpu-interop}
+Create {{MLCommandEncoder}} interface used to record the ML workload onto a WebGPU-compatible {{GPUCommandBuffer}} to allow mixing of ML workload with other GPU workload in an application that leverages WebGPU. This method only succeeds on an {{MLContext}} created with {{GPUDevice}}. Otherwise, it[=exception/throws=] an "{{OperationError}}" {{DOMException}}.
+
+<script type=idl>
+partial interface MLContext {
+  MLCommandEncoder createCommandEncoder();
+};
+</script>
+
+<div algorithm=mlcontext.createcommandencoder>
+    **Returns:** {{MLCommandEncoder}}. The command encoder used to record ML workload on the GPU.
+</div>
+
+## {{MLGraph}} interface ## {#api-mlgraph}
+The {{MLGraph}} interface represents a compiled computational graph. A compiled graph once constructed is immutable and cannot be subsequently changed.
+
+<script type=idl>
+[SecureContext, Exposed=(Window, DedicatedWorker)]
+interface MLGraph {};
+</script>
+
+<div class=internal-slots>
+{{MLGraph}} has the following internal slots:
+  <dl dfn-type=attribute dfn-for="MLGraph">
+    : <dfn>\[[context]]</dfn> of type {{MLContext}}
+    ::
+        The context of type {{MLContext}} associated with this {{MLGraph}}.
+
+    : <dfn>\[[inputDescriptors]]</dfn> of type [=record=]&lt;{{DOMString}}, {{MLOperandDescriptor}}&gt;
+    ::
+        Maps the name of an input {{MLOperand}} to its {{MLOperandDescriptor}} for all input {{MLOperand}}s of this {{MLGraph}}.
+
+    : <dfn>\[[outputDescriptors]]</dfn> of type [=record=]&lt;{{DOMString}}, {{MLOperandDescriptor}}&gt;
+    ::
+        Maps the name of an output {{MLOperand}} to its {{MLOperandDescriptor}} for all output {{MLOperand}}s of this {{MLGraph}}.
+
+    : <dfn>\[[implementation]]</dfn>
+    ::
+        The underlying implementation provided by the User Agent.
+  </dl>
+</div>
+
+## {{MLGraphBuilder}} interface ## {#api-mlgraphbuilder}
 
 The {{MLGraphBuilder}} interface defines a set of operations as identified by the [[#usecases]] that can be composed into a computational graph. It also represents the intermediate state of a graph building session.
 
@@ -1539,7 +1387,7 @@ interface MLGraphBuilder {
   MLOperand constant(MLOperandDescriptor descriptor, MLBufferView bufferView);
 
   // Create a single-value operand from the specified number of the specified type.
-  MLOperand constant(double value, optional MLOperandDataType dataType = "float32");
+  MLOperand constant(double value, optional MLOperandDataType type = "float32");
 
   // Compile the graph up to the specified output operands asynchronously.
   Promise<MLGraph> build(MLNamedOperands outputs);
@@ -1578,7 +1426,7 @@ Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGr
   </dl>
 </div>
 
-### The {{MLGraphBuilder}} constructor ### {#api-mlgraphbuilder-constructor}
+### {{MLGraphBuilder}} constructor ### {#api-mlgraphbuilder-constructor}
 
 <details open algorithm>
   <summary>
@@ -1591,166 +1439,8 @@ Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGr
   </div>
 </details>
 
-### The {{MLGraphBuilder/input()}} method  ### {#api-mlgraphbuilder-input}
-Create a named {{MLOperand}} based on a descriptor, that can be used as an input.
-
-<div>
-    **Arguments:**
-        - *name*: a [=string=] name of the input.
-        - *descriptor*: an {{MLOperandDescriptor}} object.
-    **Returns:**: an {{MLOperand}} object.
-</div>
-
-<details open algorithm>
-  <summary>
-    The <dfn method for=MLGraphBuilder>input(|name|, |descriptor|)</dfn> method steps are:
-  </summary>
-  <div class=algorithm-steps>
-    <div class="note">
-        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
-    </div>
-    1. If |name| is empty, then [=exception/throw=] a {{TypeError}}.
-    1. [=Assert=]: the type of |descriptor| is {{MLOperandDescriptor}}.
-    1. [=Assert=]: If |descriptor|.{{MLOperandDescriptor/dimensions}} does not [=map/exist=], then |descriptor| defines a scalar input.
-    1. If |descriptor|.{{MLOperandDescriptor/dimensions}} [=map/exists=]:
-        1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/dataType}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-        1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
-        1. Set |operand|.{{MLOperand/[[name]]}} to |name|.
-        1. Make a request to the underlying platform to:
-            1. Create an [=implementation-defined=] platform input operand |operandImpl| given |descriptor|.
-            1. Store a reference of |operandImpl| in |operand|.{{MLOperand/[[operand]]}}.
-            1. Register |operand| as an input.
-    1. Return |operand|.
-  </div>
-</details>
-
-### The build() method ### {#api-mlgraphbuilder-build}
-Build a composed graph up to a given output operand into a computational graph, asynchronously or synchronously.
-
-#### The {{MLGraphBuilder/build(outputs)}} method #### {#api-mlgraphbuilder-build-outputs}
-
-<details open algorithm>
-  <summary>
-    The <dfn method for=MLGraphBuilder>build(|outputs|)</dfn> method steps are:
-  </summary>
-  <div class=algorithm-steps>
-    <div class="note">
-        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
-    </div>
-    1. Let |promise| be [=a new promise=].
-    1. Return |promise| and run the following steps [=in parallel=].
-    1. Return the result of invoking {{MLGraphBuilder/buildSync(outputs)}} given |outputs|.
-        1. If that [=exception/throws=], re-[=exception/throw=] the error.
-  </div>
-</details>
-
-#### The {{MLGraphBuilder/buildSync(outputs)}} method #### {#api-mlgraphbuilder-buildsync-outputs}
-
-<details open algorithm>
-  <summary>
-    The <dfn method for=MLGraphBuilder>buildSync(|outputs|)</dfn> method steps are:
-  </summary>
-  <div class=algorithm-steps>
-    <div class="note">
-        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
-    </div>
-    1. [=Assert=]: the type of |outputs| is {{MLNamedOperands}}.
-    1. If |outputs| is empty, then [=exception/throw=] a {{TypeError}}.
-    1. [=map/For each=] |element| in |outputs|:
-        1. [=Assert=]: the type of |element|.key is [=string=].
-        1. If |element|.key is empty, then [=exception/throw=] a {{TypeError}}.
-        1. [=Assert=]: the type of |element|.value is {{MLOperand}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-        1. Let |graph| be a new {{MLGraph}}:
-            1. Set |graph|.{{MLGraph/[[context]]}} to [=this=].{{MLGraphBuilder/[[context]]}}.
-        1. Make a request to the underlying platform to:
-            1. Connect |graph| to a new [=implementation-defined=] graph implementation |graphImpl| given |graph|.
-            1. Store a reference to |graphImpl| in |graph|.{{MLGraph/[[implementation]]}}.
-        1. Make a request to the underlying platform to initialize the graph:
-            1. [=map/For each=] |operand| in |outputs|:
-                1. If <a>validating MLOperand</a> given |operand| and [=this=] returns false, then [=exception/throw=] a {{TypeError}}.
-                1. If |operand| was created as an input by the underlying platform:
-                    1. If |operand|.{{MLOperand/[[name]]}}] is not unique for |graphImpl|, then [=exception/throw=] a {{TypeError}}.
-                    1. Add |operand|.{{MLOperand/[[descriptor]]}} to |graph|.{{MLGraph/[[inputDescriptors]]}}[|operand|.{{MLOperand/[[name]]}}].
-                1. If |operand| was created as a constant by the underlying platform:
-                    1. Implementations MAY preprocess and optimize the tensor data of |operand| for the underlying platform.
-                1. Register |operand|.{{MLOperand/[[operand]]}} in |graphImpl| as graph output.
-                1. Register |operand|.{{MLOperand/[[operator]]}} to |graphImpl|.
-    1. Return |graph|.
-  </div>
-</details>
-
-### The constant() method  ### {#api-mlgraphbuilder-constant-method}
-Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
-
-#### The {{MLGraphBuilder/constant(descriptor, bufferView)}} method  #### {#api-mlgraphbuilder-constant}
-<div>
-    **Arguments:**
-        - *descriptor*: an {{MLOperandDescriptor}} object
-        - *bufferView*: an {{MLBufferView}}
-    **Returns:**: an {{MLOperand}} object.
-</div>
-
-<details open algorithm>
-  <summary>
-    The <dfn method for=MLGraphBuilder>constant(|descriptor|, |bufferView|)</dfn> method steps are:
-  </summary>
-  <div class=algorithm-steps>
-    <div class="note">
-        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
-    </div>
-    1. [=Assert=]: the type of |descriptor| is {{MLOperandDescriptor}}.
-    1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/dataType}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If <a>validating buffer with descriptor</a> given |bufferView| and |descriptor| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-        1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
-        1. Let |bytes| be the result of invoking the [=get a copy of the bytes held by the buffer source=] steps given |bufferView|.
-        1. Make a request to the underlying platform to:
-            1. Create an [=implementation-defined=] platform operand |constantImpl| to represent a constant, given |descriptor|.
-            1. Store a reference of |constantImpl| in |operand|.{{MLOperand/[[operand]]}}.
-            1. Register |operand| as a tensor constant with |bytes| as value.
-    1. Return |operand|.
-  </div>
-</details>
-
-#### The {{MLGraphBuilder/constant(value, dataType)}} method  #### {#api-mlgraphbuilder-constant-value-datatype}
-
-<div>
-    **Arguments:**
-        - *value*: a number
-        - *dataType*: an optional {{MLOperandDataType}}, by default *"float32"*.
-    **Returns:**: an {{MLOperand}} object.
-</div>
-
-<details open algorithm>
-  <summary>
-    The <dfn method for=MLGraphBuilder>constant(|value|, |dataType|)</dfn> method steps are:
-  </summary>
-  <div class=algorithm-steps>
-    <div class="note">
-        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
-    </div>
-    1. Let |descriptor| be a new {{MLOperandDescriptor}}.
-        1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |dataType|.
-        1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to `undefined`.
-            <div class="note">
-                In the case of a scalar constant, |descriptor|.{{MLOperandDescriptor/dimensions}} is ignored.
-            </div>
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-        1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
-        1. Make a request to the underlying platform to:
-            1. Create an [=implementation-defined=] platform operand |constantImpl| to represent a constant, given |descriptor|.
-            1. Store a reference of |constantImpl| in |operand|.{{MLOperand/[[operand]]}}.
-            1. Register |operand| as a scalar constant with |value| as value.
-    1. Return |operand|.
-  </div>
-</details>
-
-### The batchNormalization() method ### {#api-mlgraphbuilder-batchnorm}
-Normalize the tensor values of input features across the batch dimension using [[Batch-Normalization]]. For each input feature, the mean and variance values of that feature supplied in this calculation as parameters are previously computed across the batch dimension of the input during the model training phase of this operation.
+### {{MLGraphBuilder/batchNormalization}} ### {#api-mlgraphbuilder-batchnorm}
+Normalize the values of the input tensor using [[Batch-Normalization]]. For each input feature, the mean and variance values of that feature are computed across all the samples in the batch dimension while the model is trained. These mean and variance values are then subsequently given to this operation during model inference.
 
 <script type=idl>
 dictionary MLBatchNormalizationOptions {
@@ -1779,7 +1469,7 @@ partial interface MLGraphBuilder {
 
     : <dfn>axis</dfn>
     ::
-        A {{long}} scalar. Specifies the index to the feature count dimension of the input shape for which the mean and variance values are. Its value must be in the range [0, N-1] where N is the [=rank=] of the input tensor. The default value is 1, corresponding to the channel (*"c"*) dimension in the *"nchw"* data layout.
+        An {{unsigned long}} scalar. Specifies the index to the feature count dimension of the input shape for which the mean and variance values are. Its value must be in the range [0, N-1] where N is the [=rank=] of the input tensor. The default value is 1, corresponding to the channel (*"c"*) dimension in the *"nchw"* data layout.
 
     : <dfn>epsilon</dfn>
     ::
@@ -1840,16 +1530,104 @@ partial interface MLGraphBuilder {
           builder.reshape(options.scale, shape),
           builder.div(
             builder.sub(input, builder.reshape(mean, shape)),
-            builder.pow(
-              builder.add(builder.reshape(variance, shape), builder.constant(options.epsilon)),
-              builder.constant(0.5))
+            builder.sqrt(builder.add(builder.reshape(variance, shape), builder.constant(options.epsilon)))
             )),
         builder.reshape(options.bias, shape)));
     </pre>
   </details>
 </div>
 
-### The clamp() method ### {#api-mlgraphbuilder-clamp}
+### {{MLGraphBuilder/build}} ### {#api-mlgraphbuilder-build}
+Build a composed graph up to a given output operand into a computational graph, asynchronously or synchronously.
+
+#### {{MLGraphBuilder/build(outputs)}} #### {#api-mlgraphbuilder-build-outputs}
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLGraphBuilder>build(|outputs|)</dfn> method steps are:
+  </summary>
+  <div class=algorithm-steps>
+    <div class="note">
+        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
+    </div>
+    1. Let |promise| be [=a new promise=].
+    1. Return |promise| and run the following steps [=in parallel=].
+    1. Return the result of invoking {{MLGraphBuilder/buildSync(outputs)}} given |outputs|.
+        1. If that [=exception/throws=], re-[=exception/throw=] the error.
+  </div>
+</details>
+
+#### {{MLGraphBuilder/buildSync(outputs)}} #### {#api-mlgraphbuilder-buildsync-outputs}
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLGraphBuilder>buildSync(|outputs|)</dfn> method steps are:
+  </summary>
+  <div class=algorithm-steps>
+    <div class="note">
+        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
+    </div>
+    1. [=Assert=]: the type of |outputs| is {{MLNamedOperands}}.
+    1. If |outputs| is empty, then [=exception/throw=] a {{TypeError}}.
+    1. [=map/For each=] |element| in |outputs|:
+        1. [=Assert=]: the type of |element|.key is [=string=].
+        1. If |element|.key is empty, then [=exception/throw=] a {{TypeError}}.
+        1. [=Assert=]: the type of |element|.value is {{MLOperand}}.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+        1. Let |graph| be a new {{MLGraph}}:
+            1. Set |graph|.{{MLGraph/[[context]]}} to [=this=].{{MLGraphBuilder/[[context]]}}.
+        1. Make a request to the underlying platform to:
+            1. Connect |graph| to a new [=implementation-defined=] graph implementation |graphImpl| given |graph|.
+            1. Store a reference to |graphImpl| in |graph|.{{MLGraph/[[implementation]]}}.
+        1. Make a request to the underlying platform to initialize the graph:
+            1. [=map/For each=] |operand| in |outputs|:
+                1. If <a>validating MLOperand</a> given |operand| and [=this=] returns false, then [=exception/throw=] a {{TypeError}}.
+                1. If |operand| was created as an input by the underlying platform:
+                    1. If |operand|.{{MLOperand/[[name]]}}] is not unique for |graphImpl|, then [=exception/throw=] a {{TypeError}}.
+                    1. Add |operand|.{{MLOperand/[[descriptor]]}} to |graph|.{{MLGraph/[[inputDescriptors]]}}[|operand|.{{MLOperand/[[name]]}}].
+                1. If |operand| was created as a constant by the underlying platform:
+                    1. Implementations MAY preprocess and optimize the tensor data of |operand| for the underlying platform.
+                1. Register |operand|.{{MLOperand/[[operand]]}} in |graphImpl| as graph output.
+                1. Register |operand|.{{MLOperand/[[operator]]}} to |graphImpl|.
+    1. Return |graph|.
+  </div>
+</details>
+
+### {{MLGraphBuilder/cast}} ### {#api-mlgraphbuilder-cast}
+Cast each element in the input tensor to the target data type.
+<script type=idl>
+partial interface MLGraphBuilder {
+  MLOperand cast(MLOperand input, MLOperandDataType type);
+};
+</script>
+<div>
+    **Arguments:**
+        - *input*: an {{MLOperand}}. The input N-D tensor.
+        - *type*: an {{MLOperandDataType}}. The target data type.
+
+    **Returns:** an {{MLOperand}}. The N-D tensor of the same shape as *input* with each element casted to the target data type.
+</div>
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLGraphBuilder>cast(|input|, |type|)</dfn> method steps are:
+  </summary>
+  <div class=algorithm-steps>
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
+        1. Make a request to the underlying platform to:
+            1. Create an [=implementation-defined=] platform operator |castImpl| for this method, given |type|.
+            1. Store a reference of |castImpl| in |output|.{{MLOperand/[[operator]]}}.
+            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent clamp output, given |output| and |castImpl|.
+            1. Store a reference to |outputImpl| in |output|.{{MLOperand/[[operand]]}}.
+        1. Connect |operand|.{{MLOperand/[[operand]]}} as input to |castImpl|.
+        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |castImpl|.
+    1. Return |output|.
+  </div>
+</details>
+
+### {{MLGraphBuilder/clamp}} ### {#api-mlgraphbuilder-clamp}
 Clamp the input tensor element-wise within a range specified by the minimum and maximum values.
 <script type=idl>
 dictionary MLClampOptions {
@@ -1858,7 +1636,7 @@ dictionary MLClampOptions {
 };
 
 partial interface MLGraphBuilder {
-  MLOperand clamp(MLOperand operand, optional MLClampOptions options = {});
+  MLOperand clamp(MLOperand input, optional MLClampOptions options = {});
   MLActivation clamp(optional MLClampOptions options = {});
 };
 </script>
@@ -1874,16 +1652,16 @@ partial interface MLGraphBuilder {
   <pre highlight="js">
     if (options.minValue === undefined) {
       if (options.maxValue === undefined) {
-        return operand;
+        return input;
       } else {
-        return builder.min(operand, builder.constant(options.maxValue));
+        return builder.min(input, builder.constant(options.maxValue));
       }
     } else {
       if (options.maxValue === undefined) {
-        return builder.max(operand, builder.constant(options.minValue));
+        return builder.max(input, builder.constant(options.minValue));
       } else {
         return builder.min(
-            builder.max(operand, builder.constant(options.minValue)),
+            builder.max(input, builder.constant(options.minValue)),
             builder.constant(options.maxValue));
       }
     }
@@ -1901,10 +1679,10 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-#### The {{MLGraphBuilder/clamp(operand, options)}} method #### {#api-mlgraphbuilder-clamp-operand-options}
+#### {{MLGraphBuilder/clamp(input, options)}} #### {#api-mlgraphbuilder-clamp-operand-options}
 <div>
     **Arguments:**
-        - *operand*: an {{MLOperand}}. The input tensor.
+        - *input*: an {{MLOperand}}. The input tensor.
         - *options*: an optional {{MLClampOptions}}. The optional parameters of the operation.
             - *minValue*: a {{float}} scalar. Specifies the minimum value of the range. When it is not specified, the clamping is not performed on the lower limit of the range.
             - *maxValue*: a {{float}} scalar. Specifies the maximum value of the range. When it is not specified, the clamping is not performed on the upper limit of the range.
@@ -1913,27 +1691,26 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
-    The <dfn method for=MLGraphBuilder>clamp(|operand|, |options|)</dfn> method steps are:
+    The <dfn method for=MLGraphBuilder>clamp(|input|, |options|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. [=Assert=]: the type of |operand| is {{MLOperand}}.
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If running the <a>check clamp options</a> steps given |options| returns false, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-        1. Let |output| be the result of  <a>copying an MLOperand</a> given |operand|.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform operator |clampImpl| for this method, given |options|.{{MLClampOptions/minValue}} and |options|.{{MLClampOptions/maxValue}}.
             1. Store a reference of |clampImpl| in |output|.{{MLOperand/[[operator]]}}.
             1. Create an [=implementation-defined=] platform operand |outputImpl| to represent clamp output, given |output| and |clampImpl|.
             1. Store a reference to |outputImpl| in |output|.{{MLOperand/[[operand]]}}.
-        1. Connect |operand|.{{MLOperand/[[operand]]}} as input to |clampImpl|.
+        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |clampImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |clampImpl|.
     1. Return |output|.
   </div>
 </details>
 
-#### The {{MLGraphBuilder/clamp(options)}} method #### {#api-mlgraphbuilder-clamp-options}
+#### {{MLGraphBuilder/clamp(options)}} #### {#api-mlgraphbuilder-clamp-options}
 <div>
     **Arguments:**
         - *options*: an optional {{MLClampOptions}}. The optional parameters of the operation.
@@ -1956,7 +1733,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The concat() method ### {#api-mlgraphbuilder-concat}
+### {{MLGraphBuilder/concat}} ### {#api-mlgraphbuilder-concat}
 Concatenates the input tensors along a given axis.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -1987,7 +1764,7 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |inputs| is sequence of {{MLOperand}} objects.
     1. [=Assert=]: the type of |axis| is `unsigned long`.
     1. [=Assert=]: the shape, i.e. {{MLOperandDescriptor/dimensions}} of each operand in |inputs| is the same, except on the dimension given by |axis| on which they are concatenated.
-    1. [=Assert=]: the {{MLOperandDescriptor/dataType}} of each operand in |inputs| is the same.
+    1. [=Assert=]: the {{MLOperandDescriptor/type}} of each operand in |inputs| is the same.
     1. If any of the following steps fail, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Let |desc| be |inputs|[0].{{MLOperand/[[descriptor]]}}.
         1. If |axis| is greater than or equal to the [=rank=] of |desc|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -1995,7 +1772,7 @@ partial interface MLGraphBuilder {
         1. [=map/For each=] |index| in [=the range=] 0 to the [=rank=] of |inputs|, exclusive:
             1. Let |input| be |inputs|[|index|].
             1. If <a>validating MLOperand</a> given |input| and [=this=] returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-            1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} is not equal to |inputs|[0].{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+            1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not equal to |inputs|[0].{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
             1. [=map/For each=] |dim| in [=the range=] 0 to the [=rank=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, exclusive:
                 <div class="note">
                     If the shape of each corresponding dimension and type of the operands, except for those of the dimension given by |axis|, is not the same, fail.
@@ -2015,7 +1792,74 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The conv2d() method ### {#api-mlgraphbuilder-conv2d}
+### {{MLGraphBuilder/constant}} ### {#api-mlgraphbuilder-constant-method}
+Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
+
+#### {{MLGraphBuilder/constant(descriptor, bufferView)}} method  #### {#api-mlgraphbuilder-constant}
+<div>
+    **Arguments:**
+        - *descriptor*: an {{MLOperandDescriptor}} object
+        - *bufferView*: an {{MLBufferView}}
+    **Returns:**: an {{MLOperand}} object.
+</div>
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLGraphBuilder>constant(|descriptor|, |bufferView|)</dfn> method steps are:
+  </summary>
+  <div class=algorithm-steps>
+    <div class="note">
+        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
+    </div>
+    1. [=Assert=]: the type of |descriptor| is {{MLOperandDescriptor}}.
+    1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If <a>validating buffer with descriptor</a> given |bufferView| and |descriptor| returns false, then [=exception/throw=] a {{TypeError}}.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+        1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
+        1. Let |bytes| be the result of invoking the [=get a copy of the bytes held by the buffer source=] steps given |bufferView|.
+        1. Make a request to the underlying platform to:
+            1. Create an [=implementation-defined=] platform operand |constantImpl| to represent a constant, given |descriptor|.
+            1. Store a reference of |constantImpl| in |operand|.{{MLOperand/[[operand]]}}.
+            1. Register |operand| as a tensor constant with |bytes| as value.
+    1. Return |operand|.
+  </div>
+</details>
+
+#### {{MLGraphBuilder/constant(value, type)}} method  #### {#api-mlgraphbuilder-constant-value-type}
+
+<div>
+    **Arguments:**
+        - *value*: a number
+        - *type*: an optional {{MLOperandDataType}}, by default *"float32"*.
+    **Returns:**: an {{MLOperand}} object.
+</div>
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLGraphBuilder>constant(|value|, |type|)</dfn> method steps are:
+  </summary>
+  <div class=algorithm-steps>
+    <div class="note">
+        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
+    </div>
+    1. Let |descriptor| be a new {{MLOperandDescriptor}}.
+        1. Set |descriptor|.{{MLOperandDescriptor/type}} to |type|.
+        1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to `undefined`.
+            <div class="note">
+                In the case of a scalar constant, |descriptor|.{{MLOperandDescriptor/dimensions}} is ignored.
+            </div>
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+        1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
+        1. Make a request to the underlying platform to:
+            1. Create an [=implementation-defined=] platform operand |constantImpl| to represent a constant, given |descriptor|.
+            1. Store a reference of |constantImpl| in |operand|.{{MLOperand/[[operand]]}}.
+            1. Register |operand| as a scalar constant with |value| as value.
+    1. Return |operand|.
+  </div>
+</details>
+
+### {{MLGraphBuilder/conv2d}} ### {#api-mlgraphbuilder-conv2d}
 Compute a 2-D convolution given 4-D input and filter tensors
 <script type=idl>
 enum MLConv2dFilterOperandLayout {
@@ -2146,7 +1990,7 @@ partial interface MLGraphBuilder {
     1. Let |filterSize| be the [=list/size=] of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. If |inputSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |filterSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} is not the same as |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}, then [=exception/throw=] a {{TypeError}}.
+    1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/padding}} does not [=map/exist=], set it to `« 0, 0, 0, 0 »`.
     1. Else if the [=list/size=] of |options|.{{MLConv2dOptions/padding}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConv2dOptions/strides}} does not [=map/exist=], set it to `« 1, 1 »`.
@@ -2161,13 +2005,13 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLConv2dOptions/bias}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConv2dOptions/bias}} is {{MLOperand}}.
     1. If the [=list/size=] of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}}.
-    1. If |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}, then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/activation}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConv2dOptions/activation}} is {{MLActivation}}.
     1. Let |outputShape| be the result of invoking the underlying implementation for calculating output dimensions, given |options|.
     1. If |outputShape| is not the same as the shape of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
-    1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
+    1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |outputShape|.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
@@ -2183,7 +2027,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The convTranspose2d() method ### {#api-mlgraphbuilder-convtranspose2d}
+### {{MLGraphBuilder/convTranspose2d}} ### {#api-mlgraphbuilder-convtranspose2d}
 Compute a 2-D transposed convolution given 4-D input and filter tensors
 <script type=idl>
 
@@ -2322,7 +2166,7 @@ partial interface MLGraphBuilder {
     1. Let |filterSize| be the [=list/size=] of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. If |inputSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |filterSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} is not the same as {{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}, then [=exception/throw=] a {{TypeError}}.
+    1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as {{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/padding}} does not [=map/exist=], set it to `« 0, 0, 0, 0 »`.
     1. Else if the [=list/size=] of |options|.{{MLConvTranspose2dOptions/padding}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConvTranspose2dOptions/strides}} does not [=map/exist=], set it to `« 1, 1 »`.
@@ -2340,13 +2184,13 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLConvTranspose2dOptions/bias}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConvTranspose2dOptions/bias}} is {{MLOperand}}.
     1. If the [=list/size=] of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}}.
-    1. If |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}, then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/activation}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConvTranspose2dOptions/activation}} is {{MLActivation}}.
     1. Let |outputShape| be the result of invoking the underlying implementation for calculating output dimensions, given |options|.
     1. If |outputShape| is not the same as the shape of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
-    1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
+    1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |outputShape|.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
@@ -2390,28 +2234,17 @@ partial interface MLGraphBuilder {
     **Returns:** an {{MLOperand}}. The output tensor that contains the result of
     element-wise binary operation of the two input tensors.
 </div>
-<div>
-    **Operation types:**
-        - *add*: Add the values of the two input tensors, element-wise.
-        - *sub*: Subtract the values of the second input tensor from the values of the first input tensor, element-wise.
-        - *mul*: Multiply the values of the two input tensors, element-wise.
-        - *div*: Divide the values of the first input tensor with the values of the second tensor, element-wise.
-        - *max*: Select the greater values of the two input tensors, element-wise.
-        - *min*: Select the lesser values of the two input tensors, element-wise.
-        - *pow*: Compute the values of the values of the first input tensor to the power of the values of the second input tensor, element-wise.
-</div>
 
 <details open algorithm>
-
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="element-wise-binary-op">create element-wise binary operation</dfn> given |op|, |a| and |b|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "add", "sub", "mul", "div", "max", "min", "pow".
     1. [=Assert=]: the type of |a| and |b| is {{MLOperand}}.
-    1. If |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} is not equal to |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not equal to |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
-    1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
+    1. Set |descriptor|.{{MLOperandDescriptor/type}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. Let |descriptor|.{{MLOperandDescriptor/dimensions}} be the result of running the [=MLGraphBuilder/broadcast-shapes=] steps given |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -2428,7 +2261,6 @@ partial interface MLGraphBuilder {
 </details>
 
 <details open algorithm>
-
   <summary>
     To <dfn for="MLGraphBuilder">broadcast-shapes</dfn> given |shape1| and |shape2|, run the following steps:
   </summary>
@@ -2443,61 +2275,99 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-<details open>
+#### add #### {#api-mlgraphbuilder-binary-add}
+Add the values of the two input tensors, element-wise. See [[#api-mlgraphbuilder-binary]] for more detail.
+
+#### div #### {#api-mlgraphbuilder-binary-div}
+Divide the values of the first input tensor with the values of the second tensor, element-wise. See [[#api-mlgraphbuilder-binary]] for more detail.
+
+#### max #### {#api-mlgraphbuilder-binary-max}
+Select the greater values of the two input tensors, element-wise. See [[#api-mlgraphbuilder-binary]] for more detail.
+
+#### min #### {#api-mlgraphbuilder-binary-min}
+Select the lesser values of the two input tensors, element-wise. See [[#api-mlgraphbuilder-binary]] for more detail.
+
+#### mul #### {#api-mlgraphbuilder-binary-mul}
+Multiply the values of the two input tensors, element-wise. See [[#api-mlgraphbuilder-binary]] for more detail.
+
+#### pow #### {#api-mlgraphbuilder-binary-pow}
+Compute the values of the values of the first input tensor to the power of the values of the second input tensor, element-wise. See [[#api-mlgraphbuilder-binary]] for more detail.
+
+#### sub #### {#api-mlgraphbuilder-binary-sub}
+Subtract the values of the second input tensor from the values of the first input tensor, element-wise. See [[#api-mlgraphbuilder-binary]] for more detail.
+
+### Element-wise logical operations ### {#api-mlgraphbuilder-logical}
+Compare two input tensors element-wise, if the operation requires two inputs, and return a tensor of Boolean values 0 or 1 for the specified input values.
+
+The two input tensors will be broadcasted according to [[!numpy-broadcasting-rule]]. The [=rank=] of the output tensor is the maximum
+[=rank=] of the input tensors.
+
+<script type=idl>
+partial interface MLGraphBuilder {
+  MLOperand equal(MLOperand a, MLOperand b);
+  MLOperand greater(MLOperand a, MLOperand b);
+  MLOperand greaterOrEqual(MLOperand a, MLOperand b);
+  MLOperand lesser(MLOperand a, MLOperand b);
+  MLOperand lesserOrEqual(MLOperand a, MLOperand b);
+  MLOperand not(MLOperand a);
+};
+</script>
+
+<div>
+    **Arguments:**
+        - *a*: an {{MLOperand}}. The first input tensor.
+        - *b*: an {{MLOperand}}. The second input tensor.
+
+    **Returns:** an {{MLOperand}}. The output tensor that contains the result of
+    element-wise comparison of the two input tensors.
+</div>
+
+<details open algorithm>
   <summary>
-    The element-wise binary operation algorithms invoke the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] steps as follows.
+    To <dfn for="MLGraphBuilder" data-lt="element-wise-logical-op">create element-wise logical operation</dfn> given |op|, |a| and |b|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>add(|a|, |b|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "add", |a| and |b|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
-
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>sub(|a|, |b|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "sub", |a| and |b|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
-
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>mul(|a|, |b|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "mul", |a| and |b|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
-
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>div(|a|, |b|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "div", |a| and |b|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
-
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>max(|a|, |b|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "max", |a| and |b|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
-
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>min(|a|, |b|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "min", |a| and |b|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
-
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>pow(|a|, |b|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "pow", |a| and |b|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
-</div>
+    1. [=Assert=]: |op| is one of "equal", "greater", "greaterOrEqual", "lesser", "lesserOrEqual", "not".
+    1. [=Assert=]: the type of |a| and |b| if available is {{MLOperand}}.
+    1. If |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not equal to |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} if available, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Let |descriptor| be a new {{MLOperandDescriptor}}.
+    1. Set |descriptor|.{{MLOperandDescriptor/type}} to "uint8".
+    1. Let |descriptor|.{{MLOperandDescriptor/dimensions}} be the result of running the [=MLGraphBuilder/broadcast-shapes=] steps given |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
+        1. Make a request to the underlying platform to:
+            1. Let |opImpl| be an [=implementation-defined=] platform operator for the binary operation |op|, given |a| and |b|.
+            1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
+            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Store a reference to |outputImpl| in |output|.{{MLOperand/[[operand]]}}.
+        1. Connect |a|.{{MLOperand/[[operand]]}} and |b|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
+        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+    1. Return |output|.
+  </div>
 </details>
+
+<div class="note">
+Although operations {{MLGraphBuilder/greaterOrEqual}} and {{MLGraphBuilder/lesserOrEqual}} can each be implemented in terms of operations {{MLGraphBuilder/not}}, {{MLGraphBuilder/lesser}}, and {{MLGraphBuilder/greater}} in other words `greater-or-equal(a, b)` is `not(lesser(a, b))`, they are specifically defined for performance reason to avoid double comparisons in each element-wise test.
+</div>
+
+#### equal #### {#api-mlgraphbuilder-logical-equal}
+Compare if the values of the two input tensors are equal, element-wise. See [[#api-mlgraphbuilder-logical]] for more detail.
+
+#### greater #### {#api-mlgraphbuilder-logical-greater}
+Compare if the values of the first input tensor is greater, element-wise. See [[#api-mlgraphbuilder-logical]] for more detail.
+
+#### greaterOrEqual #### {#api-mlgraphbuilder-logical-greater-or-equal}
+Compare if the values of the first input tensor is greater or equal, element-wise. See [[#api-mlgraphbuilder-logical]] for more detail.
+
+#### lesser #### {#api-mlgraphbuilder-logical-lesser}
+Compare if the values of the first input tensor is lesser, element-wise. See [[#api-mlgraphbuilder-logical]] for more detail.
+
+#### lesserOrEqual #### {#api-mlgraphbuilder-logical-lesser-or-equal}
+Compare if the values of the first input tensor is lesser or equal, element-wise. See [[#api-mlgraphbuilder-logical]] for more detail.
+
+#### not #### {#api-mlgraphbuilder-logical-not}
+Invert the values of the input tensor to Boolean values 0 or 1, element-wise. See [[#api-mlgraphbuilder-logical]] for more detail.
 
 ### Element-wise unary operations ### {#api-mlgraphbuilder-unary}
 Compute the element-wise unary operation for input tensor.
@@ -2505,12 +2375,16 @@ Compute the element-wise unary operation for input tensor.
 partial interface MLGraphBuilder {
   MLOperand abs(MLOperand input);
   MLOperand ceil(MLOperand input);
+  MLOperand copy(MLOperand input);
   MLOperand cos(MLOperand input);
+  MLOperand erf(MLOperand input);
   MLOperand exp(MLOperand input);
   MLOperand floor(MLOperand input);
   MLOperand log(MLOperand input);
   MLOperand neg(MLOperand input);
+  MLOperand reciprocal(MLOperand input);
   MLOperand sin(MLOperand input);
+  MLOperand sqrt(MLOperand input);
   MLOperand tan(MLOperand input);
 };
 </script>
@@ -2523,26 +2397,12 @@ partial interface MLGraphBuilder {
     element-wise unary operation of the input tensor. The shape of the output
     tensor is the same as the shape of input tensor.
 </div>
-<div>
-    **Operation types:**
-        - *abs*: Compute the absolute value of the input tensor, element-wise.
-        - *ceil*: Compute the ceiling of the input tensor, element-wise.
-        - *cos*: Compute the cosine of the input tensor, element-wise.
-        - *exp*: Compute the exponential of the input tensor, element-wise.
-        - *floor*: Compute the floor of the input tensor, element-wise.
-        - *log*: Compute the natural logarithm of the input tensor, element-wise.
-        - *neg*: Compute the numerical negative value of the input tensor, element-wise.
-        - *sin*: Compute the sine of the input tensor, element-wise.
-        - *tan*: Compute the tangent of the input tensor, element-wise.
-</div>
-
 <details open algorithm>
-
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="element-wise-unary-op">create element-wise unary operation</dfn> given |op| and |input|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. [=Assert=]: |op| is one of "abs", "ceil", "cos", "exp", "floor", "log", "neg", "sin", "tan".
+    1. [=Assert=]: |op| is one of "abs", "ceil", "copy", "cos", "exp", "floor", "log", "neg", "reciprocal", "sin", "sqrt", "tan".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
@@ -2557,77 +2417,46 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-<details open>
-  <summary>
-    The element-wise unary operation algorithms invoke the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] steps as follows.
-  </summary>
-  <div class=algorithm-steps>
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>abs(|input|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "abs" and |input|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
+#### abs #### {#api-mlgraphbuilder-unary-abs}
+Compute the absolute value of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
 
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>ceil(|input|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "ceil" and |input|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
+#### ceil #### {#api-mlgraphbuilder-unary-ceil}
+Compute the ceiling of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
 
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>cos(|input|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "cos" and |input|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
+#### copy #### {#api-mlgraphbuilder-unary-copy}
+Copy the value of the input tensor to the output tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
 
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>exp(|input|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "exp" and |input|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
+#### cos #### {#api-mlgraphbuilder-unary-cos}
+Compute the cosine of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
 
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>floor(|input|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "floor" and |input|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
+#### erf #### {#api-mlgraphbuilder-unary-erf}
+Compute the error function [[Error-Function]] of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
 
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>log(|input|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "log" and |input|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
+#### exp #### {#api-mlgraphbuilder-unary-exp}
+Compute the exponential of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
 
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>neg(|input|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "neg" and |input|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
+#### floor #### {#api-mlgraphbuilder-unary-floor}
+Compute the floor of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
 
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>sin(|input|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "sin" and |input|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
+#### log #### {#api-mlgraphbuilder-unary-log}
+Compute the natural logarithm of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
 
-    <div algorithm>
-    The <dfn method for=MLGraphBuilder>tan(|input|)</dfn> method steps are:
-        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "tan" and |input|.
-            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
-        1. Return |output|.
-    </div>
-  </div>
-</details>
+#### neg #### {#api-mlgraphbuilder-unary-neg}
+Compute the numerical negative value of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
 
-### The elu() method ### {#api-mlgraphbuilder-elu}
+#### reciprocal #### {#api-mlgraphbuilder-unary-reciprocal}
+Compute the reciprocal of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
+
+#### sin #### {#api-mlgraphbuilder-unary-sin}
+Compute the sine of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
+
+#### sqrt #### {#api-mlgraphbuilder-unary-sqrt}
+Compute the square root of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
+
+#### tan #### {#api-mlgraphbuilder-unary-tan}
+Compute the tangent of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
+
+### {{MLGraphBuilder/elu}} ### {#api-mlgraphbuilder-elu}
 Calculate the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)#ELU"> exponential linear unit function</a> (ELU) on the input tensor element-wise. The calculation follows the expression `max(0, x) + alpha * (exp(min(0, x)) - 1)`.
 
 <script type=idl>
@@ -2661,7 +2490,7 @@ partial interface MLGraphBuilder {
   </details>
 </div>
 
-#### The {{MLGraphBuilder/elu(input, options)}} method #### {#api-mlgraphbuilder-elu-input-options}
+#### {{MLGraphBuilder/elu(input, options)}} #### {#api-mlgraphbuilder-elu-input-options}
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input tensor.
@@ -2691,7 +2520,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-#### The {{MLGraphBuilder/elu(options)}} method #### {#api-mlgraphbuilder-elu-options}
+#### {{MLGraphBuilder/elu(options)}} #### {#api-mlgraphbuilder-elu-options}
 <div>
     **Arguments:**
         - *options*: an optional {{MLEluOptions}}. The optional parameters of the operation.
@@ -2712,7 +2541,174 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The gemm() method ### {#api-mlgraphbuilder-gemm}
+### {{MLGraphBuilder/expand}} ### {#api-mlgraphbuilder-expand}
+Expand any dimension of size 1 of the input tensor to a larger size according to the new shape. The expansion is consistent with [[!numpy-broadcasting-rule]]. The input dimensions must have the size of 1 or match the sizes of the corresponding output dimensions according to the new shape.
+<script type=idl>
+partial interface MLGraphBuilder {
+  MLOperand expand(MLOperand input, sequence<unsigned long> newShape);
+};
+</script>
+<div>
+    **Arguments:**
+        - *input*: an {{MLOperand}}. An input tensor
+        - *newShape*: a sequence of {{unsigned long}}. The new shape the input tensor is expanded to.
+
+    **Returns:** an {{MLOperand}}. The tensor with expanded size dimensions.
+</div>
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLGraphBuilder>expand(|input|, |newShape|)</dfn> method steps are:
+  </summary>
+  <div class=algorithm-steps>
+    <div class="note">
+        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
+    </div>
+    1. [=Assert=]: the type of |input| is {{MLOperand}} object.
+    1. [=Assert=]: the type of |newShape| is a `sequence of unsigned long`.
+    1. If any of the following steps fail, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. Let |desc| be |input|.{{MLOperand/[[descriptor]]}}.
+        1. If the sequence length of |newShape| is greater than the [=rank=] of |desc|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. [=map/For each=] |index| in [=the range=] 0 to the [=rank=] of |input|, exclusive:
+            1. Let |size| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[index].
+            1. If |size| is not equal to 1 and not equal to |newShape|[index], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
+        1. Make a request to the underlying platform to:
+            1. Create an [=implementation-defined=] platform operator |expandImpl| for this method, given |input| and |newShape|.
+            1. Store a reference of |expandImpl| in |output|.{{MLOperand/[[operator]]}}.
+            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent output,given |output| and |expandImpl|.
+            1. Store a reference to |outputImpl| in |output|.{{MLOperand/[[operand]]}}.
+        1. Connect |input| as input to |expandImpl|.
+        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |expandImpl|.
+    1. Return |output|.
+  </div>
+</details>
+
+### {{MLGraphBuilder/gather}} ### {#api-mlgraphbuilder-gather}
+Gather values of the input tensor along an axis according to the indices.
+<script type=idl>
+dictionary MLGatherOptions {
+  unsigned long axis = 0;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand gather(MLOperand input, MLOperand indices, optional MLGatherOptions options = {});
+};
+</script>
+
+{{MLGatherOptions}} has the following members:
+<dl dfn-type=dict-member dfn-for=MLGatherOptions>
+    : <dfn>axis</dfn>
+    ::
+        An {{unsigned long}} scalar specifying the axis along which the gathered values are obtained. Its value must be in the range [0, N-1] where N is the [=rank=] of the input tensor.
+</dl>
+
+<div>
+    **Arguments:**
+        - *input*: an {{MLOperand}}. The input N-D tensor from which the values are gathered.
+        - *indices*: an {{MLOperand}}. The indices N-D tensor of the input values to gather. The values must be in the range [0, N] where N is the value of the input shape indexed by *options.axis*.
+        - *options*: an optional {{MLGatherOptions}}. The optional parameters of the operation.
+
+    **Returns:** an {{MLOperand}}. The output N-D tensor of [=rank=] equal to M + N - 1 where M and N are the [=rank=] of the *input* and *indices* tensor respectively.
+</div>
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLGraphBuilder>gather(|input|, |indices|, |options|)</dfn> method steps are:
+  </summary>
+  <div class=algorithm-steps>
+    1. [=Assert=]: the type of |input| and |indices| is {{MLOperand}}.
+    1. Let |shapeInput| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |rankInput| the [=list/size=] of |shapeInput|.
+    1. Let |shapeIndices| be |indices|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+    1. Let |axis| be |options|.{{MLGatherOptions/axis}}.
+    1. Let |axisSize| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|axis|]
+    1. If |axis| is greater than or equal to |rankInput|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. [=map/For each=] |index| &rarr; |value| of |indices|:
+        1. If |index| is greater than or equal to |axisSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Let |dimCount| be zero.
+    1. Let |rankOutput| be zero.
+    1. Let |shapeOutput| be an empty list.
+    1. [=map/For each=] |size| &rarr; |value| of |shapeInput|:
+        1. If |dimCount| is equal to |axis| then [=break=].
+        1. Set |shapeOutput|[|dimCount|] to |size|.
+        1. Increment |dimCount| by one.
+    1. Set |rankOutput| to |dimCount|.
+    1. Let |dimCount| be zero.
+    1. [=map/For each=] |size| &rarr; |value| of |shapeIndices|:
+        1. Set |shapeOutput|[|rankOutput| + |dimCount|] to |size|.
+        1. Increment |dimCount| by one.
+    1. Set |rankOutput| to |rankOutput| + |dimCount|.
+    1. Let |dimCount| be zero.
+    1. [=map/For each=] |size| &rarr; |value| of |shapeInput|:
+        1. If |dimCount| is less than or equal to |axis| then [=continue=].
+        1. Set |shapeOutput|[|rankOutput| + |dimCount|] to |size|.
+        1. Increment |dimCount| by one.
+    1. Let |desc| a new {{MLOperandDescriptor}}.
+    1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |shapeOutput|.
+    1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given |desc|.
+        1. Make a request to the underlying platform to:
+            1. Let |opImpl| be an [=implementation-defined=] platform operator for the Gather operation, given |input|, |indices|, and |options|.
+            1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
+            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Store a reference to |outputImpl| in |output|.{{MLOperand/[[operand]]}}.
+        1. Connect |input|.{{MLOperand/[[operand]]}} and |indices|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
+        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+    1. Return |output|.
+  </div>
+</details>
+
+<div class="example">
+<details open>
+  <summary>
+    Examples of how gather works in different slicing schemes.
+  </summary>
+  <pre highlight="js">
+    // input of shape [4,3]: [
+    //    [0,1,2], [10,11,12], [20,21,22], [30,31,32]
+    // ]
+    const input = builder.constant(
+    { dimensions: [4,3] }, new Float32Array([0,1,2,10,11,12,20,21,22,30,31,32]));
+
+    const indices1 = builder.constant(
+    { type: 'uint32', dimensions: [2] }, new Uint32Array([3,1]));
+
+    const indices2 = builder.constant(
+    { type: 'uint32', dimensions: [3] }, new Uint32Array([2,1,1]));
+
+    const indices3 = builder.constant(
+    { type: 'uint32', dimensions: [2,2] }, new Uint32Array([0,1,1,2]));
+
+    // axis = 0 (default)
+    // indices of shape [2]: [3,1]
+    // output of shape [2,3]: [
+    //    [30,31,32], [10,11,12]
+    // ]
+    const output1 = builder.gather(input, indices1);
+
+    // axis = 1
+    // indices of shape [3]: [2,1,1]
+    // output of shape [4,3]: [
+    //    [2,1,1], [12,11,11], [22,21,21], [32,31,31]
+    // ]
+    const output2 = builder.gather(input, indices2, { axis: 1 });
+
+    // axis = 1
+    // indices of shape [2,2]: [[0,1], [1,2]]
+    // output of shape [4,2,2]: [
+    //    [[0,1], [1,2]],
+    //    [[10,11], [11,12]],
+    //    [[20,21], [21,22]],
+    //    [[30,31], [31,32]]
+    // ]
+    const output3 = builder.gather(input, indices3, { axis: 1 });
+  </pre>
+</details>
+</div>
+
+### {{MLGraphBuilder/gemm}} ### {#api-mlgraphbuilder-gemm}
 Calculate the [general matrix multiplication of the Basic Linear Algebra Subprograms](https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms#Level_3). The calculation follows the expression `alpha * A * B + beta * C`, where `A` is a 2-D tensor with shape [M, K] or [K, M], `B` is a 2-D tensor with shape [K, N] or [N, K], and `C` is broadcastable to the shape [M, N]. `A` and `B` may optionally be transposed prior to the calculation.
 
 <script type=idl>
@@ -2780,7 +2776,7 @@ partial interface MLGraphBuilder {
         </div>
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [|shapeA|[0], |shapeB|[1]].
-    1. Set |desc|.{{MLOperandDescriptor/dataType}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
+    1. Set |desc|.{{MLOperandDescriptor/type}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
@@ -2812,7 +2808,7 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-### The gru() method ### {#api-mlgraphbuilder-gru}
+### {{MLGraphBuilder/gru}} ### {#api-mlgraphbuilder-gru}
 Gated Recurrent Unit [[GRU]] recurrent network uses an update, reset, and new gate to compute the output state that rolls into the output across the temporal sequence of the network.
 <script type=idl>
 enum MLGruWeightLayout {
@@ -2928,11 +2924,15 @@ partial interface MLGraphBuilder {
     The behavior of this operation can be generically emulated from the usage of other operations as follows. However, user agents typically have a more efficient implementation for it, therefore its usage is encouraged from the performance standpoint.
   </summary>
   <pre highlight="js">
+    function squeeze(builder, op) {
+      return builder.reshape(op, op.shape().remove(0));
+    }
+
     const numDirections = (options.direction == "both" ? 2 : 1);
     let hiddenState = options.initialHiddenState;
 
     if (!hiddenState) {
-      const desc = { dataType: 'float32', dimensions: [numDirections, 1, hiddenSize] };
+      const desc = { type: 'float32', dimensions: [numDirections, 1, hiddenSize] };
       const totalSize = numDirections * hiddenSize;
       hiddenState = builder.constant(desc, new Float32Array(totalSize).fill(0));
     }
@@ -2944,11 +2944,11 @@ partial interface MLGraphBuilder {
     let currentRecurrentBias = [];
 
     for (let dir = 0; dir < numDirections; ++dir) {
-      currentWeight.push(builder.squeeze(builder.slice(weight, [dir, 0, 0], [1, 3 * hiddenSize, inputSize]), { axes: [0] }));
-      currentRecurrentWeight.push(builder.squeeze(builder.slice(recurrentWeight, [dir, 0, 0], [1, 3 * hiddenSize, hiddenSize]), { axes: [0] }));
-      currentBias.push(options.bias ? (builder.squeeze(builder.slice(options.bias, [dir, 0], [1, 3 * hiddenSize]), { axes: [0] })) : null);
+      currentWeight.push(squeeze(builder, builder.slice(weight, [dir, 0, 0], [1, 3 * hiddenSize, inputSize])));
+      currentRecurrentWeight.push(squeeze(builder, builder.slice(recurrentWeight, [dir, 0, 0], [1, 3 * hiddenSize, hiddenSize])));
+      currentBias.push(options.bias ? (squeeze(builder, builder.slice(options.bias, [dir, 0], [1, 3 * hiddenSize]))) : null);
       currentRecurrentBias.push(options.recurrentBias ?
-        (builder.squeeze(builder.slice(options.recurrentBias, [dir, 0], [1, 3 * hiddenSize]), { axes: [0] })) : null);
+        (squeeze(builder, builder.slice(options.recurrentBias, [dir, 0], [1, 3 * hiddenSize]))) : null);
     }
 
     for (let step = 0; step < steps; ++step) {
@@ -2956,12 +2956,12 @@ partial interface MLGraphBuilder {
       let currentOutput = null;
 
       for (let dir = 0; dir < numDirections; ++dir) {
-        currentHidden.push(builder.squeeze(builder.slice(hiddenState, [dir, 0, 0], [1, batchSize, hiddenSize]), { axes: [0] }));
+        currentHidden.push(squeeze(builder, builder.slice(hiddenState, [dir, 0, 0], [1, batchSize, hiddenSize])));
       }
 
       for (let dir = 0; dir < numDirections; ++dir) {
         let slice = (dir == 1 || options.direction == "backward" ? steps - step - 1 : step);
-        let currentInput = builder.squeeze(builder.slice(input, [slice, 0, 0], [1, batchSize, inputSize]), { axes: [0] });
+        let currentInput = squeeze(builder, builder.slice(input, [slice, 0, 0], [1, batchSize, inputSize]));
 
         let result = builder.reshape(
           builder.gruCell(
@@ -2987,7 +2987,7 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-### The gruCell() method ### {#api-mlgraphbuilder-grucell}
+### {{MLGraphBuilder/gruCell}} ### {#api-mlgraphbuilder-grucell}
 A single time step of the Gated Recurrent Unit [[GRU]] recurrent network using an update gate and a reset gate to compute the hidden state that rolls into the output across the temporal sequence of a recurrent network.
 
 <script type=idl>
@@ -3060,7 +3060,7 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and its [=list/size=] is not 2, then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |input|.{{MLOperandDescriptor/dimensions}}[0], |hiddenSize| ].
-    1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
+    1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
@@ -3175,7 +3175,7 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-### The hardSigmoid() method ### {#api-mlgraphbuilder-hard-sigmoid}
+### {{MLGraphBuilder/hardSigmoid}} ### {#api-mlgraphbuilder-hard-sigmoid}
 Calculate the non-smooth <a href="https://en.wikipedia.org/wiki/Hard_sigmoid">hard sigmoid function</a> on the input tensor, used instead of the sigmoid function for faster computation.
 <script type=idl>
 dictionary MLHardSigmoidOptions {
@@ -3221,7 +3221,7 @@ partial interface MLGraphBuilder {
          The default value is 0.5.
 </dl>
 
-#### The {{MLGraphBuilder/hardSigmoid(input, options)}} method #### {#api-mlgraphbuilder-hardsigmoid-input-options}
+#### {{MLGraphBuilder/hardSigmoid(input, options)}} #### {#api-mlgraphbuilder-hardsigmoid-input-options}
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input tensor.
@@ -3251,7 +3251,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-#### The {{MLGraphBuilder/hardSigmoid(options)}} method #### {#api-mlgraphbuilder-hardsigmoid-options}
+#### {{MLGraphBuilder/hardSigmoid(options)}} #### {#api-mlgraphbuilder-hardsigmoid-options}
 <div>
     **Arguments:**
         - *options*: an optional {{MLHardSigmoidOptions}}. The optional parameters of the operation.
@@ -3272,7 +3272,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The hardSwish() method ### {#api-mlgraphbuilder-hard-swish}
+### {{MLGraphBuilder/hardSwish}} ### {#api-mlgraphbuilder-hard-swish}
 Computes the nonlinear function `y = x * max(0, min(6, (x + 3))) / 6` that is introduced by [[MobileNetV3]] on the input tensor element-wise.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -3303,7 +3303,7 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-#### The {{MLGraphBuilder/hardSwish(input)}} method #### {#api-mlgraphbuilder-hardswish-input}
+#### {{MLGraphBuilder/hardSwish(input)}} #### {#api-mlgraphbuilder-hardswish-input}
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input tensor.
@@ -3331,7 +3331,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-#### The {{MLGraphBuilder/hardSwish()}} method #### {#api-mlgraphbuilder-hardswish}
+#### {{MLGraphBuilder/hardSwish()}} #### {#api-mlgraphbuilder-hardswish}
 <div>
     **Arguments:**
         - None.
@@ -3351,8 +3351,43 @@ partial interface MLGraphBuilder {
  </div>
 </details>
 
-### The instanceNormalization() method ### {#api-mlgraphbuilder-instancenorm}
-Normalize the input features using [[Instance-Normalization]]. Unlike [[#api-mlgraphbuilder-batchnorm]] where the mean and variance values used in the calculation are previously computed across the batch dimension during the model training phase, the mean and variance values used in the calculation of an instance normalization are computed internally on the fly per input feature.
+### {{MLGraphBuilder/input}} ### {#api-mlgraphbuilder-input}
+Create a named {{MLOperand}} based on a descriptor, that can be used as an input.
+
+<div>
+    **Arguments:**
+        - *name*: a [=string=] name of the input.
+        - *descriptor*: an {{MLOperandDescriptor}} object.
+    **Returns:**: an {{MLOperand}} object.
+</div>
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLGraphBuilder>input(|name|, |descriptor|)</dfn> method steps are:
+  </summary>
+  <div class=algorithm-steps>
+    <div class="note">
+        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
+    </div>
+    1. If |name| is empty, then [=exception/throw=] a {{TypeError}}.
+    1. [=Assert=]: the type of |descriptor| is {{MLOperandDescriptor}}.
+    1. [=Assert=]: If |descriptor|.{{MLOperandDescriptor/dimensions}} does not [=map/exist=], then |descriptor| defines a scalar input.
+    1. If |descriptor|.{{MLOperandDescriptor/dimensions}} [=map/exists=]:
+        1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+        1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
+        1. Set |operand|.{{MLOperand/[[name]]}} to |name|.
+        1. Make a request to the underlying platform to:
+            1. Create an [=implementation-defined=] platform input operand |operandImpl| given |descriptor|.
+            1. Store a reference of |operandImpl| in |operand|.{{MLOperand/[[operand]]}}.
+            1. Register |operand| as an input.
+    1. Return |operand|.
+  </div>
+</details>
+
+### {{MLGraphBuilder/instanceNormalization}} ### {#api-mlgraphbuilder-instancenorm}
+Normalize the input using [[Instance-Normalization]]. Unlike [[#api-mlgraphbuilder-batchnorm]] where the mean and variance values used in the normalization are computed across all the samples in the batch dimension while the model is trained, the mean and variance values used in the instance normalization are computed on the fly for each input feature of each individual sample in the batch.
 
 <script type=idl>
 dictionary MLInstanceNormalizationOptions {
@@ -3397,7 +3432,6 @@ The {{MLInstanceNormalizationOptions}} members are:
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>instanceNormalization(|input|, |options|)</dfn> method steps are:
   </summary>
@@ -3405,9 +3439,9 @@ The {{MLInstanceNormalizationOptions}} members are:
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If the [=rank=] of |input| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=Assert=]:  the type of |options|.{{MLInstanceNormalizationOptions/scale}} is {{MLOperand}}.
-    1. If the [=rank=] of |options|.{{MLInstanceNormalizationOptions/scale}} is not equal to the [=list/size=] of the channel dimension of |input|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |options|.{{MLInstanceNormalizationOptions/scale}} is not equal to 1, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=Assert=]: the type of |options|.{{MLInstanceNormalizationOptions/bias}} is  {{MLOperand}}.
-    1. If the [=rank=] of |options|.{{MLInstanceNormalizationOptions/bias}} is not equal to the [=list/size=] of the channel dimension of |input|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=rank=] of |options|.{{MLInstanceNormalizationOptions/bias}} is not equal to 1, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
@@ -3429,7 +3463,7 @@ The {{MLInstanceNormalizationOptions}} members are:
     therefore its usage is encouraged from the performance standpoint.
   </summary>
   <pre highlight="js">
-    // The mean reductions happen over the spatial dimensions of the input
+    // The reduction of the mean and variance values happens over the spatial dimensions of the input
     // e.g. axis 2 and 3 of the input tensor.
     const reduceOptions = { axes: [2,3], keepDimensions: true };
     const mean = builder.reduceMean(input, reduceOptions);
@@ -3448,9 +3482,7 @@ The {{MLInstanceNormalizationOptions}} members are:
         builder.reshape(options.scale, shape),
         builder.div(
           builder.sub(input, mean),
-          buidler.pow(
-            builder.add(variance, options.epsilon),
-            builder.constant(0.5))
+          buidler.sqrt(builder.add(variance, options.epsilon))
           )
         ),
       builder.reshape(options.bias, shape)
@@ -3459,7 +3491,117 @@ The {{MLInstanceNormalizationOptions}} members are:
 </details>
 </div>
 
-### The leakyRelu() method ### {#api-mlgraphbuilder-leakyrelu}
+### {{MLGraphBuilder/layerNormalization}} ### {#api-mlgraphbuilder-layernorm}
+Normalize the input using [[Layer-Normalization]]. Unlike [[#api-mlgraphbuilder-batchnorm]] where the mean and variance values are computed across all the samples in the batch dimension while the model is trained, and in [[#api-mlgraphbuilder-instancenorm]] where the mean and variance values are computed on the fly for each input feature of each individual sample in the batch, the means and variance values of the layer normalization are computed on the fly across all the input features of each individual sample in the batch.
+
+<script type=idl>
+dictionary MLLayerNormalizationOptions {
+  MLOperand scale;
+  MLOperand bias;
+  sequence<unsigned long> axes;
+  float epsilon = 1e-5;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand layerNormalization(MLOperand input, optional MLLayerNormalizationOptions options = {});
+};
+</script>
+
+The {{MLLayerNormalizationOptions}} members are:
+<dl dfn-type=dict-member dfn-for=MLLayerNormalizationOptions>
+    : <dfn>scale</dfn>
+    ::
+        An {{MLOperand}}. Specifies the N-D tensor of the scaling values whose shape is determined by the |axes| member in that each value in |axes| indicates the dimension of the input tensor with scaling values. For example, for an |axes| values of [1,2,3], the shape of this tensor is the list of the corresponding sizes of the input dimension 1, 2 and 3. When this member is not present, the scaling value is assumed to be 1.
+
+    : <dfn>bias</dfn>
+    ::
+        An {{MLOperand}}. Specifies the N-D tensor of the bias values whose shape is determined by the |axes| member in that each value in |axes| indicates the dimension of the input tensor with bias values. For example, for an |axes| values of [1,2,3], the shape of this tensor is the list of the corresponding sizes of the input dimension 1, 2 and 3. When this member is not present, the scaling value is assumed to be 0.
+
+    : <dfn>axes</dfn>
+    ::  
+        A sequence of {{unsigned long}}. The indices to the input dimensions to reduce. When this member is not present, it is assumed to be [1,2,3] that is, the reduction for the mean and variance values are calculated across all the input features for each individual sample in the batch.
+
+    : <dfn>epsilon</dfn>
+    ::
+        A {{float}} scalar. Specifies a small value to prevent computational error due to divide-by-zero.
+</dl>
+
+<div>
+    **Arguments:**
+        - *input*: an {{MLOperand}}. The input 4-D tensor.
+        - *options*: an optional {{MLLayerNormalizationOptions}}. The optional parameters of the operation.
+
+    **Returns:** an {{MLOperand}}. The layer-normalized 4-D tensor of the same shape as *input*.
+</div>
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLGraphBuilder>layerNormalization(|input|, |options|)</dfn> method steps are:
+  </summary>
+  <div class=algorithm-steps>
+    1. [=Assert=]: the type of |input| is {{MLOperand}}.
+    1. If the [=rank=] of |input| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. [=Assert=]:  the type of |options|.{{MLLayerNormalizationOptions/scale}} is {{MLOperand}}.
+    1. If the [=rank=] of |options|.{{MLLayerNormalizationOptions/scale}} is not equal to the [=list/size=] of |options|.{{MLBatchNormalizationOptions/axes}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. [=Assert=]: the type of |options|.{{MLLayerNormalizationOptions/bias}} is  {{MLOperand}}.
+    1. If the [=rank=] of |options|.{{MLLayerNormalizationOptions/bias}} is not equal to the [=list/size=] of |options|.{{MLBatchNormalizationOptions/axes}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
+        1. Make a request to the underlying platform to:
+            1. Let |opImpl| be an [=implementation-defined=] platform operator for the instance normalization operation, given |options|.
+            1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
+            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Store a reference to |outputImpl| in |output|.{{MLOperand/[[operand]]}}.
+        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
+        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+    1. Return |output|.
+  </div>
+</details>
+
+<div class="note">
+<details open>
+  <summary>
+    The behavior of this operation when the axes parameter is set to [1,2,3] can be generically emulated from
+    the usage of other operations as follow. However, user agents typically have a more efficient implementation for it,
+    therefore its usage is encouraged from the performance standpoint.
+  </summary>
+  <pre highlight="js">
+    // The reduction of the mean and variance values happens over the spatial dimensions 
+    // across all the input features (i.e. all channels) of the input tensor.
+    const reduceOptions = { axes: [1,2,3], keepDimensions: true };
+    const mean = builder.reduceMean(input, reduceOptions);
+    const variance = builder.reduceMean(
+      builder.pow(
+        builder.sub(input, mean),
+        buider.constant(2)),
+      reduceOptions
+      );
+
+    // Returns a new tensor with a dimension of size one inserted at the specified position.
+    function unsqueeze(input, axes) {
+      shape = Array.from(input.shape());
+      for(let axis in axes.sort())
+        shape.splice(axis, 0, 1);
+      return builder.reshape(input, shape);
+    }
+
+    // The scale and bias tensors are of the shape of the input dimensions specified 
+    // by the values in the axes parameter (i.e. [1,2,3]).
+    return builder.add(
+      builder.mul(
+        unsqueeze(options.scale, 0),
+        builder.div(
+          builder.sub(input, mean),
+          buidler.sqrt(builder.add(variance, options.epsilon))
+          )
+        ),
+      unsqueeze(options.bias, 0)
+      );
+  </pre>
+</details>
+</div>
+
+### {{MLGraphBuilder/leakyRelu}} ### {#api-mlgraphbuilder-leakyrelu}
 Calculate the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)#Leaky_ReLU"> leaky version of rectified linear function</a> on the input tensor element-wise. The calculation follows the expression `max(0, x) + alpha ∗ min(0, x)`.
 
 <script type=idl>
@@ -3496,7 +3638,7 @@ partial interface MLGraphBuilder {
          The default value is 0.01.
 </dl>
 
-#### The {{MLGraphBuilder/leakyRelu(input, options)}} method #### {#api-mlgraphbuilder-leaky-relu-input-options}
+#### {{MLGraphBuilder/leakyRelu(input, options)}} #### {#api-mlgraphbuilder-leaky-relu-input-options}
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input tensor.
@@ -3525,7 +3667,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-#### The {{MLGraphBuilder/leakyRelu(options)}} method #### {#api-mlgraphbuilder-leaky-relu-options}
+#### {{MLGraphBuilder/leakyRelu(options)}} #### {#api-mlgraphbuilder-leaky-relu-options}
 <div>
     **Arguments:**
         - *options*: an optional {{MLLeakyReluOptions}}. The optional parameters of the operation.
@@ -3546,7 +3688,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The linear() method ### {#api-mlgraphbuilder-linear}
+### {{MLGraphBuilder/linear}} ### {#api-mlgraphbuilder-linear}
 Calculate a linear function `y = alpha * x + beta` on the input tensor.
 
 <script type=idl>
@@ -3589,7 +3731,7 @@ partial interface MLGraphBuilder {
          The default value is 0.
 </dl>
 
-#### The {{MLGraphBuilder/linear(input, options)}} method #### {#api-mlgraphbuilder-linear-input-options}
+#### {{MLGraphBuilder/linear(input, options)}} #### {#api-mlgraphbuilder-linear-input-options}
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input tensor.
@@ -3618,7 +3760,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-#### The {{MLGraphBuilder/linear(options)}} method #### {#api-mlgraphbuilder-linear-options}
+#### {{MLGraphBuilder/linear(options)}} #### {#api-mlgraphbuilder-linear-options}
 <div>
     **Arguments:**
         - *options*: an optional {{MLLinearOptions}}. The optional parameters of the operation.
@@ -3639,7 +3781,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The lstm() method ### {#api-mlgraphbuilder-lstm}
+### {{MLGraphBuilder/lstm}} ### {#api-mlgraphbuilder-lstm}
 Long Short-Term Memory [[LSTM]] recurrent network uses an input, output, forget, and cell gate to compute the output state that rolls into the output across the temporal sequence of the network.
 
 <script type=idl>
@@ -3764,7 +3906,7 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |desc| a new {{MLOperandDescriptor}}.
         1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |numDirections|, |batchSize|, |hiddenSize| ].
-        1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
+        1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
         1. Let |output0| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Let |output1| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |steps|, |numDirections|, |batchSize|, |hiddenSize| ].
@@ -3789,18 +3931,22 @@ partial interface MLGraphBuilder {
     The behavior of this operation can be generically emulated from the usage of other operations as follow. However, user agents typically have a more efficient implementation for it, therefore its usage is encouraged from the performance standpoint.
   </summary>
   <pre highlight="js">
+    function squeeze(builder, op) {
+      return builder.reshape(op, op.shape().remove(0));
+    }
+
     const numDirections = (options.direction == "both" ? 2 : 1);
     let hiddenState = options.initialHiddenState;
     let cellState = options.initialCellState;
 
     if (!hiddenState) {
-      const desc = { dataType: 'float32', dimensions: [numDirections, 1, hiddenSize] };
+      const desc = { type: 'float32', dimensions: [numDirections, 1, hiddenSize] };
       const totalSize = numDirections * hiddenSize;
       hiddenState = builder.constant(desc, new Float32Array(totalSize).fill(0));
     }
 
     if (!cellState) {
-      const desc = { dataType: 'float32', dimensions: [numDirections, 1, hiddenSize] };
+      const desc = { type: 'float32', dimensions: [numDirections, 1, hiddenSize] };
       const totalSize = numDirections * hiddenSize;
       cellState = builder.constant(desc, new Float32Array(totalSize).fill(0));
     }
@@ -3813,13 +3959,13 @@ partial interface MLGraphBuilder {
     let currentPeepholeWeight = [];
 
     for (let dir = 0; dir < numDirections; ++dir) {
-      currentWeight.push(builder.squeeze(builder.slice(weight, [dir, 0, 0], [1, 4 * hiddenSize, inputSize]), { axes: [0] }));
-      currentRecurrentWeight.push(builder.squeeze(builder.slice(recurrentWeight, [dir, 0, 0], [1, 4 * hiddenSize, hiddenSize]), { axes: [0] }));
-      currentBias.push(options.bias ? (builder.squeeze(builder.slice(options.bias, [dir, 0], [1, 4 * hiddenSize]), { axes: [0] })) : null);
+      currentWeight.push(squeeze(builder, builder.slice(weight, [dir, 0, 0], [1, 4 * hiddenSize, inputSize])));
+      currentRecurrentWeight.push(squeeze(builder, builder.slice(recurrentWeight, [dir, 0, 0], [1, 4 * hiddenSize, hiddenSize])));
+      currentBias.push(options.bias ? (squeeze(builder, builder.slice(options.bias, [dir, 0], [1, 4 * hiddenSize]))) : null);
       currentRecurrentBias.push(options.recurrentBias ?
-        (builder.squeeze(builder.slice(options.recurrentBias, [dir, 0], [1, 4 * hiddenSize]), { axes: [0] })) : null);
+        (squeeze(builder, builder.slice(options.recurrentBias, [dir, 0], [1, 4 * hiddenSize]))) : null);
       currentPeepholeWeight.push(options.peepholeWeight ?
-        (builder.squeeze(builder.slice(options.peepholeWeight, [dir, 0], [1, 3 * hiddenSize]), { axes: [0] })) : null);
+        (squeeze(builder, builder.slice(options.peepholeWeight, [dir, 0], [1, 3 * hiddenSize]))) : null);
     }
 
     for (let step = 0; step < steps; ++step) {
@@ -3829,13 +3975,13 @@ partial interface MLGraphBuilder {
       let nextCell = null;
 
       for (let dir = 0; dir < numDirections; ++dir) {
-        currentHidden.push(builder.squeeze(builder.slice(hiddenState, [dir, 0, 0], [1, batchSize, hiddenSize]), { axes: [0] }));
-        currentCell.push(builder.squeeze(builder.slice(cellState, [dir, 0, 0], [1, batchSize, hiddenSize]), { axes: [0] }));
+        currentHidden.push(squeeze(builder, builder.slice(hiddenState, [dir, 0, 0], [1, batchSize, hiddenSize])));
+        currentCell.push(squeeze(builder, builder.slice(cellState, [dir, 0, 0], [1, batchSize, hiddenSize])));
       }
 
       for (let dir = 0; dir < numDirections; ++dir) {
         let slice = (dir == 1 || options.direction == "backward" ? steps - step - 1 : step);
-        let currentInput = builder.squeeze(builder.slice(input, [slice, 0, 0], [1, batchSize, inputSize]), { axes: [0] });
+        let currentInput = squeeze(builder, builder.slice(input, [slice, 0, 0], [1, batchSize, inputSize]));
 
         let results = builder.lstmCell(
           currentInput, currentWeight[dir], currentRecurrentWeight[dir],
@@ -3864,7 +4010,7 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-### The lstmCell() method ### {#api-mlgraphbuilder-lstmcell}
+### {{MLGraphBuilder/lstmCell}} ### {#api-mlgraphbuilder-lstmcell}
 A single time step of the Long Short-Term Memory [[LSTM]] recurrent network using a cell state, an input, output, and forget gate to compute the cell state and the hidden state of the next time step that rolls into the output across the temporal sequence of the network.
 
 <script type=idl>
@@ -3945,7 +4091,7 @@ partial interface MLGraphBuilder {
         1. [=Assert=]: the type of its elements is {{MLActivation}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |batchSize|, |hiddenSize| ].
-    1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
+    1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output0| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Let |output1| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
@@ -4078,7 +4224,7 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-### The matmul() method ### {#api-mlgraphbuilder-matmul}
+### {{MLGraphBuilder/matmul}} ### {#api-mlgraphbuilder-matmul}
 Compute the matrix product of two input tensors.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -4133,7 +4279,7 @@ partial interface MLGraphBuilder {
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of invoking the <a>calculate matmul output sizes</a> steps given |a| and |b|.
     1. If that throws an error, re-[=exception/throw=] the error.
-    1. Set |desc|.{{MLOperandDescriptor/dataType}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
+    1. Set |desc|.{{MLOperandDescriptor/type}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
@@ -4147,7 +4293,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The pad() method ### {#api-mlgraphbuilder-pad}
+### {{MLGraphBuilder/pad}} ### {#api-mlgraphbuilder-pad}
 Inflate the tensor with constant or mirrored values on the edges.
 <script type=idl>
 enum MLPaddingMode {
@@ -4241,7 +4387,7 @@ partial interface MLGraphBuilder {
   <pre highlight="js">
     // input: [[1,2,3], [4,5,6]]
     const input = builder.constant(
-      { dataType: 'float32', dimensions: [2,3] }, new Float32Array([1,2,3,4,5,6]));
+      { type: 'float32', dimensions: [2,3] }, new Float32Array([1,2,3,4,5,6]));
 
     const beginningPadding = [1,2];
     const endingPadding = [1,2];
@@ -4278,7 +4424,7 @@ partial interface MLGraphBuilder {
 </div>
 
 ### Pooling operations ### {#api-mlgraphbuilder-pool2d}
-Compute a *mean*, *L2 norm*, or *max* reduction operation across all the elements within the moving window over the input tensor. See the description of each type of reduction in [[#api-mlgraphbuilder-reduce]].
+Compute a reduction operation across all the elements within the moving window over the input tensor. See the description of each type of reduction in [[#api-mlgraphbuilder-reduce]].
 <script type=idl>
 enum MLRoundingType {
   "floor",
@@ -4302,31 +4448,6 @@ partial interface MLGraphBuilder {
   MLOperand maxPool2d(MLOperand input, optional MLPool2dOptions options = {});
 };
 </script>
-
-<div>
-    **Arguments:**
-        - *input*: an {{MLOperand}}. The input 4-D tensor. The logical shape
-            is interpreted according to the value of *options.layout*.
-        - *options*: an optional {{MLPool2dOptions}}. The optional parameters of the operation.
-
-    **Returns:** an {{MLOperand}}. The output 4-D tensor that contains the
-    result of the reduction. The logical shape is interpreted according to the
-    value of *layout*. More specifically, if the *options.roundingType* is *"floor"*, the spatial dimensions of the output tensor can be calculated as follow:
-
-    *output size = floor(1 + (input size - filter size + beginning padding + ending padding) / stride)*
-
-    or if *options.roundingType* is *"ceil"*:
-
-    *output size = ceil(1 + (input size - filter size + beginning padding + ending padding) / stride)*
-</div>
-
-<div class="note">
-    A *global* pooling operation such as one for the max pooling operation is a variant of pooling where the window dimensions is the spatial dimensions (last two dimensions) of the input shape, as follow.
-    <pre highlight="js">
-    // 'global' max pooling
-    builder.maxPool2d(input);
-    </pre>
-</div>
 
 {{MLPool2dOptions}} has the following members:
 <dl dfn-type=dict-member dfn-for=MLPool2dOptions>
@@ -4387,11 +4508,34 @@ partial interface MLGraphBuilder {
         Specifies the sizes of the two spacial dimensions of the output tensor. When the output sizes are explicitly specified, the {{MLPool2dOptions/roundingType}} is ignored.
 
         If not specified, the output sizes are automatically computed.
-
 </dl>
 
-<details open algorithm>
+<div>
+    **Arguments:**
+        - *input*: an {{MLOperand}}. The input 4-D tensor. The logical shape
+            is interpreted according to the value of *options.layout*.
+        - *options*: an optional {{MLPool2dOptions}}. The optional parameters of the operation.
 
+    **Returns:** an {{MLOperand}}. The output 4-D tensor that contains the
+    result of the reduction. The logical shape is interpreted according to the
+    value of *layout*. More specifically, if the *options.roundingType* is *"floor"*, the spatial dimensions of the output tensor can be calculated as follow:
+
+    *output size = floor(1 + (input size - filter size + beginning padding + ending padding) / stride)*
+
+    or if *options.roundingType* is *"ceil"*:
+
+    *output size = ceil(1 + (input size - filter size + beginning padding + ending padding) / stride)*
+</div>
+
+<div class="note">
+    A *global* pooling operation such as one for the max pooling operation is a variant of pooling where the window dimensions is the spatial dimensions (last two dimensions) of the input shape, as follow.
+    <pre highlight="js">
+    // 'global' max pooling
+    builder.maxPool2d(input);
+    </pre>
+</div>
+
+<details open algorithm>
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="pooling-op">create pooling operation</dfn> given |op|, |input| and |options|, run the following steps:
   </summary>
@@ -4454,7 +4598,16 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The prelu() method ### {#api-mlgraphbuilder-prelu}
+#### {{MLGraphBuilder/averagePool2d}} #### {#api-mlgraphbuilder-pool2d-average}
+Calculate the average value for patches of a feature map, and use it to create a pooled feature map. See [[#api-mlgraphbuilder-pool2d]] for more detail.
+
+#### {{MLGraphBuilder/l2Pool2d}} #### {#api-mlgraphbuilder-pool2d-l2}
+Apply the L2 norm function to a region of the input feature map. The L2 norm is the square root of the sum of the squares of its elements. See [[#api-mlgraphbuilder-pool2d]] for more detail.
+
+#### {{MLGraphBuilder/maxPool2d}} #### {#api-mlgraphbuilder-pool2d-max}
+Calculate the maximum value for patches of a feature map, and use it to create a pooled feature map. See [[#api-mlgraphbuilder-pool2d]] for more detail.
+
+### {{MLGraphBuilder/prelu}} ### {#api-mlgraphbuilder-prelu}
 Calculate the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)#Parametric_ReLU">parametric version of rectified linear function (Parametric ReLU)</a> on the input tensor element-wise. Parametric ReLU is a type of leaky ReLU that, instead of having a scalar slope like 0.01, making the slope (coefficient of leakage) into a parameter that is learned during the model training phase of this operation. The calculation follows the expression `max(0, x) + slope ∗ min(0, x)`.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -4479,7 +4632,7 @@ partial interface MLGraphBuilder {
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| and |slope| is {{MLOperand}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
-    1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
+    1. Set |descriptor|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
     1. Let |descriptor|.{{MLOperandDescriptor/dimensions}} be the result of running the [=MLGraphBuilder/broadcast-shapes=] steps given |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |slope|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -4519,6 +4672,8 @@ dictionary MLReduceOptions {
 };
 
 partial interface MLGraphBuilder {
+  MLOperand reduceArgMax(MLOperand input, optional MLReduceOptions options = {});
+  MLOperand reduceArgMin(MLOperand input, optional MLReduceOptions options = {});
   MLOperand reduceL1(MLOperand input, optional MLReduceOptions options = {});
   MLOperand reduceL2(MLOperand input, optional MLReduceOptions options = {});
   MLOperand reduceLogSum(MLOperand input, optional MLReduceOptions options = {});
@@ -4532,39 +4687,31 @@ partial interface MLGraphBuilder {
 };
 </script>
 
+{{MLReduceOptions}} has the following members:
+<dl dfn-type=dict-member dfn-for=MLReduceOptions>
+    : <dfn>axes</dfn>
+    ::
+        A sequence of {{unsigned long}}. The dimensions to reduce. The values in the sequence must be in the range [0, N-1] where N is the [=rank=] of the input tensor. If not present, all dimensions are reduced.
+
+    : <dfn>keepDimensions</dfn>
+    ::
+        A {{boolean}}. If true, retains reduced dimensions with [=list/size=] 1. The default value is false.
+</dl>
+
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input tensor.
         - *options*: an optional {{MLReduceOptions}}. The optional parameters of the operation.
-            - *axes*: a sequence of {{unsigned long}}. The dimensions to reduce. The values in the sequence must be in the range [0, N-1] where N is the [=rank=] of the input tensor.
-                If not present, all dimensions are reduced.
-            - *keepDimensions*: a {{boolean}}. If true, retains reduced dimensions with [=list/size=] 1.
-                The default value is false.
 
     **Returns:** an {{MLOperand}}. The reduced output tensor.
 </div>
 
-<div class="note">
-    **Reduction types:**
-        - *L1*: Compute the <a href="https://mathworld.wolfram.com/L1-Norm.html">L1 norm</a> of all the input values along the axes.
-        - *L2*: Compute the <a href="https://mathworld.wolfram.com/L2-Norm.html">L2 norm</a> of all the input values along the axes.
-        - *LogSum*: Compute the log value of the sum of all the input values along the axes.
-        - *LogSumExp*: Compute the log value of the sum of the exponent of all the input values along the axes.
-        - *Max*: Compute the maximum value of all the input values along the axes.
-        - *Mean*: Compute the average value of all the input values along the axes.
-        - *Min*: Compute the minimum value of all the input values along the axes.
-        - *Product*: Compute the product of all the input values along the axes.
-        - *Sum*: Compute the sum of all the input values along the axes.
-        - *SumSquare*: Compute the sum of the square of all the input values along the axes.
-</div>
-
 <details open algorithm>
-
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="reduce-op">create reduce operation</dfn> given |op|, |input| and |options|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. [=Assert=]: |op| is one of "reduceL1", "reduceL2", "reduceLogSum", "reduceLogSumExp", "reduceMax", "reduceMean", "reduceMin", "reduceProduct", "reduceSum", "reduceSumSquare".
+    1. [=Assert=]: |op| is one of "reduceArgMax", "reduceArgMin", "reduceL1", "reduceL2", "reduceLogSum", "reduceLogSumExp", "reduceMax", "reduceMean", "reduceMin", "reduceProduct", "reduceSum", "reduceSumSquare".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If |options|.{{MLReduceOptions/axes}} [=map/exists=], if any of its elements is not in [=the range=] 0 to the [=rank=] of |input|, exclusive, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -4584,6 +4731,20 @@ partial interface MLGraphBuilder {
   <summary>
     The following reduce algorithms are supported.
   </summary>
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>reduceArgMax(|input|, |options|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceArgMax", |input| and |options|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
+
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>reduceArgMin(|input|, |options|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceArgMin", |input| and |options|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
+
     <div algorithm>
     The <dfn method for=MLGraphBuilder>reduceL1(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceL1", |input| and |options|.
@@ -4655,7 +4816,43 @@ partial interface MLGraphBuilder {
     </div>
 </details>
 
-### The relu() method ### {#api-mlgraphbuilder-relu-method}
+#### reduceArgMax #### {#api-mlgraphbuilder-reduce-argmax}
+Return the index location of the maxmium value of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
+
+#### reduceArgMin #### {#api-mlgraphbuilder-reduce-argmin}
+Return the index location of the minimum value of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
+
+#### reduceL1 #### {#api-mlgraphbuilder-reduce-l1}
+Compute the <a href="https://mathworld.wolfram.com/L1-Norm.html">L1 norm</a> of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
+
+#### reduceL2 #### {#api-mlgraphbuilder-reduce-l2}
+Compute the <a href="https://mathworld.wolfram.com/L2-Norm.html">L2 norm</a> of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
+
+#### reduceLogSum #### {#api-mlgraphbuilder-reduce-logsum}
+Compute the log value of the sum of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
+
+#### reduceLogSumExp #### {#api-mlgraphbuilder-reduce-logSumExp}
+Compute the log value of the sum of the exponent of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
+
+#### reduceMax #### {#api-mlgraphbuilder-reduce-max}
+Compute the maximum value of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
+
+#### reduceMean #### {#api-mlgraphbuilder-reduce-mean}
+Compute the average value of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
+
+#### reduceMin #### {#api-mlgraphbuilder-reduce-min}
+Compute the minimum value of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
+
+#### reduceProduct #### {#api-mlgraphbuilder-reduce-product}
+Compute the product of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
+
+#### reduceSum #### {#api-mlgraphbuilder-reduce-sum}
+Compute the sum of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
+
+#### reduceSumSquare #### {#api-mlgraphbuilder-reduce-sumsquare}
+Compute the sum of the square of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
+
+### {{MLGraphBuilder/relu}} ### {#api-mlgraphbuilder-relu-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)">rectified linear function</a> of the input tensor.
 
 <script type=idl>
@@ -4679,7 +4876,7 @@ partial interface MLGraphBuilder {
   </details>
 </div>
 
-#### The {{MLGraphBuilder/relu(input)}} method #### {#api-mlgraphbuilder-relu-input}
+#### {{MLGraphBuilder/relu(input)}} #### {#api-mlgraphbuilder-relu-input}
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input tensor.
@@ -4708,7 +4905,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-#### The {{MLGraphBuilder/relu()}} method #### {#api-mlgraphbuilder-relu}
+#### {{MLGraphBuilder/relu()}} #### {#api-mlgraphbuilder-relu}
 <div>
     **Arguments:**
         - None.
@@ -4728,7 +4925,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The resample2d() method ### {#api-mlgraphbuilder-resample2d-method}
+### {{MLGraphBuilder/resample2d}} ### {#api-mlgraphbuilder-resample2d-method}
 Resample the tensor values from the source to the destination spatial dimensions according to the scaling factors.
 <script type=idl>
 enum MLInterpolationMode {
@@ -4833,7 +5030,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The reshape() method ### {#api-mlgraphbuilder-reshape-method}
+### {{MLGraphBuilder/reshape}} ### {#api-mlgraphbuilder-reshape-method}
 Alter the shape of a tensor to a new shape. Reshape does not copy or change the content of the tensor. It just changes the tensor's logical dimensions for the subsequent operations.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -4856,7 +5053,6 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>reshape(|input|, |newShape|)</dfn> method steps are:
   </summary>
@@ -4887,7 +5083,44 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The sigmoid() method ### {#api-mlgraphbuilder-sigmoid-method}
+<div class="note">
+  <details open>
+    <summary>
+    Many shape-related operations such as [squeeze](https://pytorch.org/docs/stable/generated/torch.squeeze.html), [unsqueeze](https://pytorch.org/docs/stable/generated/torch.unsqueeze.html), and [flatten](https://pytorch.org/docs/stable/generated/torch.flatten.html) can be generically implemented using the {{MLGraphBuilder/reshape}} operation as follows:
+    </summary>
+    <pre highlight="js">
+    // Returns a tensor with all specified dimensions of input of size 1 removed.
+    function squeeze(input, axes) {
+      if (!axes) axes = [];
+      if (!axes.length)
+        input.shape().forEach((item, i) => { axes.push(i); });
+      shape = Array.from(input.shape());
+      for (let axis in axes.sort().reverse())
+        if (axis < shape.length && shape[axis] == 1)
+          shape.splice(axis, 1);
+      return builder.reshape(input, shape);
+    }
+
+    // Returns a new tensor with a dimension of size one inserted at the specified position.
+    function unsqueeze(input, axes) {
+      shape = Array.from(input.shape());
+      for(let axis in axes.sort())
+        shape.splice(axis, 0, 1);
+      return builder.reshape(input, shape);
+    }
+
+    // Flattens input by reshaping it into a one-dimensional tensor. 
+    function flatten(input, axis) {
+      if (axis > input.shape().length) return input;
+      let before = axis.slice(0, axis).reduce((a, b) => { a*b; });
+      let after = axis.slice(axis, input.shape().length).reduce((a, b) => { a*b; });
+      return builder.reshape(input, [before, after]);
+    }
+    </pre>
+  </details>
+</div>
+
+### {{MLGraphBuilder/sigmoid}} ### {#api-mlgraphbuilder-sigmoid-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Sigmoid_function">sigmoid function</a> of the input tensor. The calculation follows the expression `1 / (exp(-x) + 1)`.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -4914,7 +5147,7 @@ partial interface MLGraphBuilder {
   </details>
 </div>
 
-#### The {{MLGraphBuilder/sigmoid(input)}} method #### {#api-mlgraphbuilder-sigmoid-input}
+#### {{MLGraphBuilder/sigmoid(input)}} #### {#api-mlgraphbuilder-sigmoid-input}
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input tensor.
@@ -4943,7 +5176,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-#### The {{MLGraphBuilder/sigmoid()}} method #### {#api-mlgraphbuilder-sigmoid}
+#### {{MLGraphBuilder/sigmoid()}} #### {#api-mlgraphbuilder-sigmoid}
 <div>
     **Arguments:**
         - None.
@@ -4963,7 +5196,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The slice() method ### {#api-mlgraphbuilder-slice}
+### {{MLGraphBuilder/slice}} ### {#api-mlgraphbuilder-slice}
 Produce a slice of the input tensor.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -5001,7 +5234,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The softmax() method ### {#api-mlgraphbuilder-softmax-method}
+### {{MLGraphBuilder/softmax}} ### {#api-mlgraphbuilder-softmax-method}
 Compute the [softmax](https://en.wikipedia.org/wiki/Softmax_function) values of
 the 2-D input tensor along axis 1.
 <script type=idl>
@@ -5032,7 +5265,7 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-#### The {{MLGraphBuilder/softmax(input)}} method #### {#api-mlgraphbuilder-softmax-input}
+#### {{MLGraphBuilder/softmax(input)}} #### {#api-mlgraphbuilder-softmax-input}
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input 2-D tensor.
@@ -5062,7 +5295,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-#### The {{MLGraphBuilder/softmax()}} method #### {#api-mlgraphbuilder-softmax}
+#### {{MLGraphBuilder/softmax()}} #### {#api-mlgraphbuilder-softmax}
 <div>
     **Arguments:**
         - None.
@@ -5082,7 +5315,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The softplus() method ### {#api-mlgraphbuilder-softplus-method}
+### {{MLGraphBuilder/softplus}} ### {#api-mlgraphbuilder-softplus-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)#Softplus">softplus function</a> of the input tensor. The calculation follows the expression `ln(1 + exp(steepness * x)) / steepness`.
 <script type=idl>
 dictionary MLSoftplusOptions {
@@ -5122,7 +5355,7 @@ partial interface MLGraphBuilder {
          The default value is 1.
 </dl>
 
-#### The {{MLGraphBuilder/softplus(input, options)}} method #### {#api-mlgraphbuilder-softplus-input-options}
+#### {{MLGraphBuilder/softplus(input, options)}} #### {#api-mlgraphbuilder-softplus-input-options}
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input tensor.
@@ -5151,7 +5384,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-#### The {{MLGraphBuilder/softplus(options)}} method #### {#api-mlgraphbuilder-softplus-options}
+#### {{MLGraphBuilder/softplus(options)}} #### {#api-mlgraphbuilder-softplus-options}
 <div>
     **Arguments:**
         - *options*: an optional {{MLSoftplusOptions}}. The optional parameters of the operation.
@@ -5172,7 +5405,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The softsign() method ### {#api-mlgraphbuilder-softsign-method}
+### {{MLGraphBuilder/softsign}} ### {#api-mlgraphbuilder-softsign-method}
 Compute the <a href="https://pytorch.org/docs/stable/generated/torch.nn.Softsign.html">softsign function</a> of the input tensor. The calculation follows the expression `x / (1 + |x|)`.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -5195,7 +5428,7 @@ partial interface MLGraphBuilder {
   </details>
 </div>
 
-#### The {{MLGraphBuilder/softsign(input)}} method #### {#api-mlgraphbuilder-softsign-input}
+#### {{MLGraphBuilder/softsign(input)}} #### {#api-mlgraphbuilder-softsign-input}
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input tensor.
@@ -5224,7 +5457,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-#### The {{MLGraphBuilder/softsign()}} method #### {#api-mlgraphbuilder-softsign}
+#### {{MLGraphBuilder/softsign()}} #### {#api-mlgraphbuilder-softsign}
 <div>
     **Arguments:**
         - None.
@@ -5244,7 +5477,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The split() method ### {#api-mlgraphbuilder-split}
+### {{MLGraphBuilder/split}} ### {#api-mlgraphbuilder-split}
 Split the input tensor into a number of sub tensors along the given axis.
 <script type=idl>
 dictionary MLSplitOptions {
@@ -5322,63 +5555,7 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-### The squeeze() method ### {#api-mlgraphbuilder-squeeze}
-Reduce the [=rank=] of a tensor by eliminating dimensions with size 1 of the tensor shape. Squeeze only affects the tensor's logical dimensions. It does not copy or change the content in the tensor.
-<script type=idl>
-dictionary MLSqueezeOptions {
-  sequence<unsigned long> axes;
-};
-
-partial interface MLGraphBuilder {
-  MLOperand squeeze(MLOperand input, optional MLSqueezeOptions options = {});
-};
-</script>
-
-<div>
-    **Arguments:**
-        - *input*: an {{MLOperand}}. The input tensor.
-        - *options*: an optional {{MLSqueezeOptions}}. The optional parameters of the operation.
-
-    **Returns:** an {{MLOperand}}. The output tensor of the same or reduced rank with the shape dimensions of size 1 eliminated.
-</div>
-
-{{MLSqueezeOptions}} has the following members:
-<dl dfn-type=dict-member dfn-for=MLSqueezeOptions>
-    : <dfn>axes</dfn>
-    ::
-        A sequence of {{unsigned long}}.
-        Specifies the indices to the shape dimensions of size 1 to eliminate. The values in the sequence must be in the range [0, N-1] where N is the [=rank=] of the input tensor.
-        When not specified, every shape dimensions of size 1 in the tensor are eliminated.
-</dl>
-
-<details open algorithm>
-
-  <summary>
-    The <dfn method for=MLGraphBuilder>squeeze(|input|, |options|)</dfn> method steps are:
-  </summary>
-  <div class=algorithm-steps>
-    1. [=Assert=]: the type of |input| is {{MLOperand}}.
-    1. If |options|.{{MLSqueezeOptions/axes}} [=map/exists=], then:
-        1. Let |dimensions| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-        1. Let |axesLength| be the [=list/size=] of |options|.{{MLSqueezeOptions/axes}}.
-        1. If |axesLength| is not smaller than the <a>rank</a> of |dimensions|,
-        1. For |index| in [=the range=] 0 to |axesLength|, exclusive:
-            1. Let |oneDimIndex| be |options|.{{MLSqueezeOptions/axes}}[|index|].
-            1. If |dimensions|[|oneDimIndex|] is not 1, then [=exception/throw=] a {{TypeError}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the squeeze operation, given |options|.
-            1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Store a reference to |outputImpl| in |output|.{{MLOperand/[[operand]]}}.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
-    1. Return |output|.
-  </div>
-</details>
-
-### The tanh() method ### {#api-mlgraphbuilder-tanh-method}
+### {{MLGraphBuilder/tanh}} ### {#api-mlgraphbuilder-tanh-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Hyperbolic_functions">hyperbolic tangent function</a> of the input tensor. The calculation follows the expression `(exp(2 * x) - 1) / (exp(2 * x) + 1)`.
 <script type=idl>
 partial interface MLGraphBuilder {
@@ -5403,7 +5580,7 @@ partial interface MLGraphBuilder {
   </details>
 </div>
 
-#### The {{MLGraphBuilder/tanh(input)}} method #### {#api-mlgraphbuilder-tanh-input}
+#### {{MLGraphBuilder/tanh(input)}} #### {#api-mlgraphbuilder-tanh-input}
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input tensor.
@@ -5432,7 +5609,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-#### The {{MLGraphBuilder/tanh()}} method #### {#api-mlgraphbuilder-tanh}
+#### {{MLGraphBuilder/tanh()}} #### {#api-mlgraphbuilder-tanh}
 <div>
     **Arguments:**
         - None.
@@ -5452,7 +5629,7 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### The transpose() method ### {#api-mlgraphbuilder-transpose}
+### {{MLGraphBuilder/transpose}} ### {#api-mlgraphbuilder-transpose}
 Permute the dimensions of the input tensor according to the *permutation* argument.
 <script type=idl>
 dictionary MLTransposeOptions {
@@ -5506,6 +5683,227 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
+### {{MLGraphBuilder/where}} ### {#api-mlgraphbuilder-where}
+Select the values from the input or the other tensor depending on the corresponding Boolean values of the condition tensor. The condition tensor is often the output of one of the element-wise logical operations.
+
+The input tensors will be broadcasted according to [[!numpy-broadcasting-rule]] to the final output shape. The [=rank=] of the output tensor is the maximum [=rank=] of the input tensors.
+For each dimension of the output tensor, its size is the maximum size along that dimension of the input tensors.
+
+<script type=idl>
+partial interface MLGraphBuilder {
+  MLOperand where(MLOperand condition, MLOperand input, MLOperand other);
+};
+</script>
+
+<div>
+    **Arguments:**
+        - *condition*: an {{MLOperand}}. The condition tensor.
+        - *input*: an {{MLOperand}}. The input tensor from which the value is selected when the condition of the corresponding element is set to true.
+        - *other*: an {{MLOperand}}. The other tensor from which the value is selected when the condition of the corresponding element is set to false.
+
+    **Returns:** an {{MLOperand}}. The output tensor that contains the values selected element-wise from either the input or the other tensor.
+</div>
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLGraphBuilder>where(|condition|, |input|, |other|)</dfn> method steps are:
+  </summary>
+  <div class=algorithm-steps>
+    1. [=Assert=]: the type of |condition|, |input| and |other| is {{MLOperand}}.
+    1. If |condition|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not equal to "uint8", then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not equal to |other|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Let |descriptor| be a new {{MLOperandDescriptor}}.
+    1. Set |descriptor|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
+    1. Let |descriptor|.{{MLOperandDescriptor/dimensions}} be the result of running the [=MLGraphBuilder/broadcast-shapes=] steps given |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |other|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
+        1. Make a request to the underlying platform to:
+            1. Let |opImpl| be an [=implementation-defined=] platform operator for |where|, given |condition|, |input| and |other|.
+            1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
+            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Store a reference to |outputImpl| in |output|.{{MLOperand/[[operand]]}}.
+        1. Connect |condition|.{{MLOperand/[[operand]]}}, |input| and |other|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
+        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+    1. Return |output|.
+  </div>
+</details>
+
+<div class="note">
+  <details open>
+    <summary>
+    The behavior of this operation can be generically emulated from the usage of other operations as follow. However, user agents typically have a more efficient implementation for it, therefore its usage is encouraged from the performance standpoint.
+    </summary>
+    <pre highlight="js">
+    builder.add(
+      builder.mul(
+        input,
+        builder.cast(condition, input.type())),
+      builder.mul(
+        other,
+        builder.cast(builder.not(condition), other.type())));
+    </pre>
+  </details>
+</div>
+
+## {{MLOperand}} interface ## {#api-mloperand}
+
+An {{MLOperand}} represents an intermediary graph being constructed as a result of compositing parts of an operation into a fully composed operation.
+
+For instance, an {{MLOperand}} may represent a constant feeding to an operation or the result from combining multiple constants together into an operation. See also [[#programming-model]].
+
+<script type=idl>
+[SecureContext, Exposed=(Window, DedicatedWorker)]
+interface MLOperand {
+  MLOperandDataType type();
+  sequence<unsigned long> shape();
+};
+</script>
+
+<div class=internal-slots>
+{{MLOperand}} has the following internal slots:
+  <dl dfn-type=attribute dfn-for="MLOperand">
+    : <dfn>\[[builder]]</dfn> of type {{MLGraphBuilder}}
+    ::
+        The {{MLOperand}}'s associated builder object.
+
+    : <dfn>\[[descriptor]]</dfn> of type {{MLOperandDescriptor}}
+    ::
+        The {{MLOperand}}'s descriptor.
+
+    : <dfn>\[[name]]</dfn> of type [=string=]
+    ::
+        The {{MLOperand}}'s name (only for input operands).
+
+    : <dfn>\[[operand]]</dfn> of type [=object=]
+    ::
+        Reference to {{MLOperand}}'s corresponding [=implementation-defined=] platform operand object.
+
+    : <dfn>\[[operator]]</dfn> of type [=object=]
+    ::
+        Reference to {{MLOperand}}'s corresponding [=implementation-defined=] platform operator object.
+  </dl>
+</div>
+
+<div algorithm>
+To get the <dfn for="MLOperand">type</dfn> of an {{MLOperand}} |operand|, run the following steps:
+<div class=algorithm-steps>
+    1. Return |operand|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
+</div>
+</div>
+
+<div algorithm>
+To get the <dfn for="MLOperand">shape</dfn> of an {{MLOperand}} |operand|, run the following steps:
+<div class=algorithm-steps>
+    1. Return |operand|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+</div>
+</div>
+
+<div algorithm>
+To get the <dfn for="MLOperand">rank</dfn> of an {{MLOperand}} |operand|, run the following steps:
+<div class=algorithm-steps>
+    1. Return the [=list/size=] of |operand|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
+</div>
+</div>
+
+Since the {{MLOperand/[[builder]]}} object is bound by the {{MLGraphBuilder/constructor()}} constructor to an {{MLContext}} object, an {{MLOperand}} is also always bound to the same {{MLContext}} object.
+
+### Creating {{MLOperand}} ### {#api-mloperand-create}
+The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, internally using the following algorithms.
+
+<details open algorithm>
+  <summary>
+    To <dfn>create an MLOperand</dfn> given |builder| and |desc|, run the following steps:
+  </summary>
+  <div class=algorithm-steps>
+    1. [=Assert=]: the type of |builder| is {{MLGraphBuilder}}.
+    1. [=Assert=]: the type of |desc| is {{MLOperandDescriptor}}.
+    1. Let |operand| be a new [=object=].
+    1. Set |operand|.{{MLOperand/[[builder]]}} to |builder|.
+    1. Set |operand|.{{MLOperand/[[descriptor]]}} to |desc|.
+    1. Return |operand|.
+  </div>
+</details>
+
+<details open algorithm>
+  <summary>
+    To <dfn>copy an MLOperand</dfn> given |operand|, run the following steps:
+  </summary>
+  <div class=algorithm-steps>
+    1. [=Assert=]: the type of |operand| is {{MLOperand}}.
+    1. Let |result| be a new [=object=].
+    1. Set |result|.{{MLOperand/[[builder]]}} to |operand|.{{MLOperand/[[builder]]}}.
+    1. Set |result|.{{MLOperand/[[descriptor]]}} to |operand|.{{MLOperand/[[descriptor]]}}.
+    1. If |operand|.{{MLOperand/[[name]]}} [=map/exists=], then set |result|.{{MLOperand/[[name]]}} to |operand|.{{MLOperand/[[name]]}}.
+    1. Return |result|.
+  </div>
+</details>
+
+<details open algorithm>
+  <summary>
+    To <dfn>check dimensions</dfn> given |dimensions| and |type|, run the following steps:
+  </summary>
+  <div class=algorithm-steps>
+    1. If the [=list/size=] of |dimensions| is 0, return false.
+    1. If the [=list/size=] of |dimensions| is too large to be supported by the implementation, return false.
+    1. If any element of |dimensions| is not a positive number, or it is too large to be supported by the implementation given |type|, return false.
+    1. Return true.
+  </div>
+</details>
+
+<details open algorithm>
+  <summary>
+    To <dfn for="MLOperand">validate MLOperand</dfn> given |operand| and |builder|, run the following steps:
+  </summary>
+  <div class=algorithm-steps>
+    1. [=Assert=]: the type of |operand|.{{MLOperand/[[builder]]}} is {{MLGraphBuilder}}.
+    1. If |builder| is not equal to |operand|.{{MLOperand/[[builder]]}}, return false.
+    1. Let |desc| be |operand|.{{MLOperand/[[descriptor]]}}.
+    1. If |desc|.{{MLOperandDescriptor/dimensions}} [=map/exists=] and invoking <a>check dimensions</a> given |desc|.{{MLOperandDescriptor/dimensions}} and |desc|.{{MLOperandDescriptor/type}} returns false, then return false.
+    1. Return true.
+  </div>
+</details>
+
+## {{MLOperandDescriptor}} dictionary ## {#api-mloperanddescriptor}
+<script type=idl>
+enum MLInputOperandLayout {
+  "nchw",
+  "nhwc"
+};
+
+enum MLOperandDataType {
+  "float32",
+  "float16",
+  "int32",
+  "uint32",
+  "int64",
+  "uint64",
+  "int8",
+  "uint8"
+};
+
+dictionary MLOperandDescriptor {
+  // The operand type.
+  required MLOperandDataType type;
+
+  // The dimensions field is only required for tensor operands.
+  sequence<unsigned long> dimensions;
+};
+</script>
+
+<details open algorithm>
+  <summary>
+    The <dfn for="MLOperandDescriptor">byte length</dfn> of an {{MLOperandDescriptor}} |desc| is the value returned by the following steps:
+  </summary>
+  <div class=algorithm-steps>
+    1. Let |elementLength| be 1.
+    1. [=map/For each=] |dimension| of |desc|.{{MLOperandDescriptor/dimensions}}:
+        1. Set |elementLength| to |elementLength| × |dimension|.
+    1. Let |elementSize| be the [=element size=] of one of the {{ArrayBufferView}} types that matches |desc|.{{MLOperandDescriptor/type}} according to [this table](#appendices-mloperanddatatype-arraybufferview-compatibility).
+    1. Return |elementLength| × |elementSize|.
+  </div>
+</details>
+
 Examples {#examples}
 =====================
 
@@ -5539,7 +5937,7 @@ Given the following build graph:
     const builder = new MLGraphBuilder(context);
 
     // Create MLOperandDescriptor object.
-    const desc = {dataType: 'float32', dimensions: TENSOR_DIMS};
+    const desc = {type: 'float32', dimensions: TENSOR_DIMS};
 
     // constant1 is a constant MLOperand with the value 0.5.
     const constantBuffer1 = new Float32Array(TENSOR_SIZE).fill(0.5);
@@ -5910,6 +6308,24 @@ Thanks to Jiewei Qian for Chromium implementation review and feedback.
       "Victor Lempitsky"
     ],
     "date": "July 2016"
+  },
+  "Layer-Normalization": {
+    "href": "https://arxiv.org/abs/1607.06450",
+    "title": "Layer Normalization",
+    "authors": [
+      "Jimmy Lei Ba",
+      "Jamie Ryan Kiros",
+      "Geoffrey E. Hinton"
+    ],
+    "date": "July 2016"
+  },
+  "Error-Function": {
+    "href": "https://books.google.com/books?id=2CAqsF-RebgC&pg=PA110",
+    "title": "Special functions of mathematics for engineers",
+    "authors": [
+      "Larry C. Andrews"
+    ],
+    "date": "1998"
   },
   "FaceForensics++": {
     "href": "https://github.com/ondyari/FaceForensics",

--- a/index.bs
+++ b/index.bs
@@ -1792,15 +1792,17 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-### {{MLGraphBuilder/constant}} ### {#api-mlgraphbuilder-constant-method}
+### {{MLGraphBuilder/constant}} ### {#api-mlgraphbuilder-constant}
 Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
 
-#### {{MLGraphBuilder/constant(descriptor, bufferView)}} method  #### {#api-mlgraphbuilder-constant}
+#### {{MLGraphBuilder/constant(descriptor, bufferView)}} #### {#api-mlgraphbuilder-constant-bufferview}
+Create a constant {{MLOperand}} of the specified data type and shape that contains the initializing data.
+
 <div>
     **Arguments:**
-        - *descriptor*: an {{MLOperandDescriptor}} object
-        - *bufferView*: an {{MLBufferView}}
-    **Returns:**: an {{MLOperand}} object.
+        - *descriptor*: an {{MLOperandDescriptor}}. The descriptor of the output tensor.
+        - *bufferView*: an {{MLBufferView}}. The view of the buffer containing the initializing data.
+    **Returns:**: an {{MLOperand}}. The constant output tensor.
 </div>
 
 <details open algorithm>
@@ -1826,13 +1828,18 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
   </div>
 </details>
 
-#### {{MLGraphBuilder/constant(value, type)}} method  #### {#api-mlgraphbuilder-constant-value-type}
+#### {{MLGraphBuilder/constant(value, type)}} #### {#api-mlgraphbuilder-constant-value-type}
+Create a constant {{MLOperand}} of the specified value and data type.
+
+<div class="note">
+Data truncation will occur when the specified value exceeds the range of the specified output data type e.g. when a float value is assigned to an *"int8"* data type, etc.
+</div>
 
 <div>
     **Arguments:**
-        - *value*: a number
-        - *type*: an optional {{MLOperandDataType}}, by default *"float32"*.
-    **Returns:**: an {{MLOperand}} object.
+        - *value*: a {{float}} number. The value of the constant.
+        - *type*: an optional {{MLOperandDataType}}. If not specified, it is assumed to be *"float32"*.
+    **Returns:**: an {{MLOperand}}. The constant output.
 </div>
 
 <details open algorithm>
@@ -1855,6 +1862,49 @@ Create a constant {{MLOperand}} that can be used in {{MLGraphBuilder}} methods.
             1. Create an [=implementation-defined=] platform operand |constantImpl| to represent a constant, given |descriptor|.
             1. Store a reference of |constantImpl| in |operand|.{{MLOperand/[[operand]]}}.
             1. Register |operand| as a scalar constant with |value| as value.
+    1. Return |operand|.
+  </div>
+</details>
+
+#### {{MLGraphBuilder/constant(start, end, step, type)}} #### {#api-mlgraphbuilder-constant-range}
+Create a constant {{MLOperand}} of the specified data type and shape that contains the data as specified by the range. 
+
+<div class="note">
+Data truncation will occur when the values in the range exceed the range of the specified output data type e.g. when a float value is assigned to an *"int8"* data type, etc.
+</div>
+
+<div>
+    **Arguments:**
+        - *start*: a {{float}} scalar. The starting value of the range.
+        - *end*: a {{float}} scalar. The ending value of the range.
+        - *step*: a {{float}} scalar. The gap value between two data points in the range.
+        - *type*: an optional {{MLOperandDataType}}. If not specified, it is assumed to be *"float32"*.
+    **Returns:**: an {{MLOperand}}. The constant 1-D output tensor of size `max(0, ceil((end - start)/step))`. 
+</div>
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLGraphBuilder>constant(|start|, |end|, |step|, |type|)</dfn> method steps are:
+  </summary>
+  <div class=algorithm-steps>
+    <div class="note">
+        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
+    </div>
+    1. Let |descriptor| be a new {{MLOperandDescriptor}}.
+        1. Set |descriptor|.{{MLOperandDescriptor/type}} to |type|.
+        1. Let |size| be *max(0, ceil((end - start)/step))*.
+        1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to [|size|].
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+        1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
+        1. Make a request to the underlying platform to:
+            1. Create an [=implementation-defined=] platform memory buffer the size of |size| multiplied by sizeof(|descriptor|.{{MLOperandDescriptor/type}}).
+            2. Store the beginning address to that memory buffer as a pointer |buffer| of the corresponding data type.
+        1. [=map/For each=] |index| in [=the range=] 0 to |size|, exclusive:
+            1. Set |buffer|[|index|] to |start| + (|index| * |step|).
+        1. Make a request to the underlying platform to:
+            1. Create an [=implementation-defined=] platform operand |constantImpl| to represent a constant operand, given |descriptor|.
+            1. Store a reference of |constantImpl| in |operand|.{{MLOperand/[[operand]]}}.
+            1. Register |operand| as a constant with |buffer| as value.
     1. Return |operand|.
   </div>
 </details>
@@ -2666,9 +2716,11 @@ partial interface MLGraphBuilder {
     Examples of how gather works in different slicing schemes.
   </summary>
   <pre highlight="js">
-    // input of shape [4,3]: [
-    //    [0,1,2], [10,11,12], [20,21,22], [30,31,32]
-    // ]
+    // input of shape [4,3]:
+    //   [[ 0,  1,  2],
+    //    [10, 11, 12], 
+    //    [20, 21, 22], 
+    //    [30, 31, 32]]
     const input = builder.constant(
     { dimensions: [4,3] }, new Float32Array([0,1,2,10,11,12,20,21,22,30,31,32]));
 
@@ -2682,27 +2734,32 @@ partial interface MLGraphBuilder {
     { type: 'uint32', dimensions: [2,2] }, new Uint32Array([0,1,1,2]));
 
     // axis = 0 (default)
-    // indices of shape [2]: [3,1]
-    // output of shape [2,3]: [
-    //    [30,31,32], [10,11,12]
-    // ]
+    // indices of shape [2]: 
+    //   [3,1]
+    // output of shape [2,3]:
+    //   [[30, 31, 32], 
+    //    [10, 11, 12]]
     const output1 = builder.gather(input, indices1);
 
     // axis = 1
-    // indices of shape [3]: [2,1,1]
-    // output of shape [4,3]: [
-    //    [2,1,1], [12,11,11], [22,21,21], [32,31,31]
-    // ]
+    // indices of shape [3]:
+    //   [2,1,1]
+    // output of shape [4,3]:
+    //   [[ 2,  1,  1],
+    //    [12, 11, 11], 
+    //    [22, 21, 21],
+    //    [32, 31, 31]]
     const output2 = builder.gather(input, indices2, { axis: 1 });
 
     // axis = 1
-    // indices of shape [2,2]: [[0,1], [1,2]]
-    // output of shape [4,2,2]: [
-    //    [[0,1], [1,2]],
-    //    [[10,11], [11,12]],
-    //    [[20,21], [21,22]],
-    //    [[30,31], [31,32]]
-    // ]
+    // indices of shape [2,2]: 
+    //   [[0, 1], 
+    //    [1, 2]]
+    // output of shape [4,2,2]:
+    //   [[[ 0,  1], [ 1,  2]],
+    //    [[10, 11], [11, 12]],
+    //    [[20, 21], [21, 22]],
+    //    [[30, 31], [31, 32]]]
     const output3 = builder.gather(input, indices3, { axis: 1 });
   </pre>
 </details>
@@ -3742,7 +3799,6 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>linear(|input|, |options|)</dfn> method steps are:
   </summary>
@@ -5275,7 +5331,6 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>softmax(|input|)</dfn> method steps are:
   </summary>
@@ -5509,7 +5564,6 @@ partial interface MLGraphBuilder {
 </dl>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>split(|input|, |splits|, |options|)</dfn> method steps are:
   </summary>
@@ -5641,14 +5695,6 @@ partial interface MLGraphBuilder {
 };
 </script>
 
-<div>
-    **Arguments:**
-        - *input*: an {{MLOperand}}. The input N-D tensor.
-        - *options*: an optional {{MLTransposeOptions}}. The optional parameters of the operation.
-
-    **Returns:** an {{MLOperand}}. The permuted or transposed N-D tensor.
-</div>
-
 {{MLTransposeOptions}} has the following members:
 <dl dfn-type=dict-member dfn-for=MLTransposeOptions>
     : <dfn>permutation</dfn>
@@ -5658,6 +5704,14 @@ partial interface MLGraphBuilder {
         The default value is [N-1, ..., 0], where N is the [=rank=] of the input tensor, e.g. [2,1,0] for a 3-D tensor.
         These default values cause the output to become a transposed tensor of the input. When specified, the number of values in the sequence must be the same as the [=rank=] of the input tensor, and the values in the sequence must be within the range from 0 to N-1 with no two or more same values found in the sequence.
 </dl>
+
+<div>
+    **Arguments:**
+        - *input*: an {{MLOperand}}. The input N-D tensor.
+        - *options*: an optional {{MLTransposeOptions}}. The optional parameters of the operation.
+
+    **Returns:** an {{MLOperand}}. The permuted or transposed N-D tensor.
+</div>
 
 <details open algorithm>
   <summary>
@@ -5682,6 +5736,108 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+
+### {{MLGraphBuilder/tri}} ### {#api-mlgraphbuilder-tri}
+Given a 2-D tensor (matrix), return a 2-D tensor containing either the upper or lower triangular part of the input tensor.
+
+<script type=idl>
+dictionary MLTriOptions {
+  boolean upper = true;
+  long diagonal = 0;
+};
+
+partial interface MLGraphBuilder {
+  MLOperand tri(MLOperand input, optional MLTriOptions options = {});
+};
+</script>
+
+{{MLTriOptions}} has the following members:
+<dl dfn-type=dict-member dfn-for=MLTriOptions>
+    : <dfn>upper</dfn>
+    ::
+        A {{boolean}} value. Indicate whether the output the upper or the lower part of the input matrix is retained. If not set, it is assumed to be true, indicating that the upper part is retained.
+    : <dfn>diagonal</dfn>
+    ::
+        A {{long}} value. Specify how many diagonals above or below the main diagonals of the input matrix are retained or excluded. If not set, this value is assumed to be 0, which means no diagonals other than the main diagonals are affected. 
+</dl>
+
+<div>
+    **Arguments:**
+        - *input*: an {{MLOperand}}. The input 2-D tensor.
+        - *options*: an optional {{MLTriOptions}}. The optional parameters of the operation.
+
+    **Returns:** an {{MLOperand}}. The output 2-D tensor representing a triangular matrix.
+</div>
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLGraphBuilder>tri(|input|, |options|)</dfn> method steps are:
+  </summary>
+  <div class=algorithm-steps>
+    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+        1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
+        1. Make a request to the underlying platform to:
+            1. Let |opImpl| be an [=implementation-defined=] platform operator for the tri operation, given |options|.
+            1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
+            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Store a reference to |outputImpl| in |output|.{{MLOperand/[[operand]]}}.
+        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
+        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+    1. Return |output|.
+  </div>
+</details>
+
+<div class="example">
+<details open>
+  <summary>
+    Examples of how tri works in different diagonal settings.
+  </summary>
+  <pre highlight="js">
+    // input:
+    //   [[7, 1, 2],
+    //    [9, 4, 8],
+    //    [2, 6, 3]]
+    const input = builder.constant(
+    { dimensions: [3,3] }, new Float32Array([7,1,2,9,4,8,2,6,3]));
+
+    // upper triangular matrix:
+    //   [[7, 1, 2], 
+    //    [0, 4, 8],
+    //    [0, 0, 3]]
+    const upper = builder.tri(input);
+
+    // upper triangular matrix with one additional set of diagonals excluded:
+    //   [[0, 1, 2], 
+    //    [0, 0, 8],
+    //    [0, 0, 0]]
+    const upperPositive = builder.tri(input, { diagonal: 1 });
+
+    // upper triangular matrix with one additional set of diagonals retained:
+    //   [[7, 1, 2], 
+    //    [9, 4, 8],
+    //    [0, 6, 3]]
+    const upperNegative = builder.tri(input, { diagonal: -1 });
+
+    // lower triangular matrix:
+    //   [[7, 0, 0],
+    //    [9, 4, 0],
+    //    [2, 6, 3]]
+    const lower = builder.tri(input, { upper: false });
+
+    // lower triangular matrix with one additional set of diagonals retained:
+    //   [[7, 1, 0],
+    //    [9, 4, 8],
+    //    [2, 6, 3]]
+    const lowerPositive = builder.tri(input, { upper: false, diagonal: 1 });
+
+    // lower triangular matrix with one additional set of diagonals excluded:
+    //   [[0, 0, 0],
+    //    [9, 0, 0],
+    //    [2, 6, 0]]
+    const lowerNegative = builder.tri(input, { upper: false, diagonal: -1 });
+  </pre>
+</details>
+</div>
 
 ### {{MLGraphBuilder/where}} ### {#api-mlgraphbuilder-where}
 Select the values from the input or the other tensor depending on the corresponding Boolean values of the condition tensor. The condition tensor is often the output of one of the element-wise logical operations.

--- a/index.bs
+++ b/index.bs
@@ -3736,7 +3736,7 @@ The {{MLLayerNormalizationOptions}} members are:
 
     : <dfn>bias</dfn>
     ::
-        An {{MLOperand}}. Specifies the N-D tensor of the bias values whose shape is determined by the |axes| member in that each value in |axes| indicates the dimension of the input tensor with bias values. For example, for an |axes| values of [1,2,3], the shape of this tensor is the list of the corresponding sizes of the input dimension 1, 2 and 3. When this member is not present, the scaling value is assumed to be 0.
+        An {{MLOperand}}. Specifies the N-D tensor of the bias values whose shape is determined by the |axes| member in that each value in |axes| indicates the dimension of the input tensor with bias values. For example, for an |axes| values of [1,2,3], the shape of this tensor is the list of the corresponding sizes of the input dimension 1, 2 and 3. When this member is not present, the bias value is assumed to be 0.
 
     : <dfn>axes</dfn>
     ::  
@@ -5310,8 +5310,8 @@ partial interface MLGraphBuilder {
     // Flattens input by reshaping it into a one-dimensional tensor. 
     function flatten(input, axis) {
       if (axis > input.shape().length) return input;
-      let before = axis.slice(0, axis).reduce((a, b) => { a*b; });
-      let after = axis.slice(axis, input.shape().length).reduce((a, b) => { a*b; });
+      let before = axis.slice(0, axis).reduce((a, b) => { a * b; });
+      let after = axis.slice(axis, input.shape().length).reduce((a, b) => { a * b; });
       return builder.reshape(input, [before, after]);
     }
     </pre>

--- a/index.bs
+++ b/index.bs
@@ -1459,6 +1459,7 @@ Return the index location of the minium or maxmium values of all the input value
 dictionary MLArgMinMaxOptions {
   sequence<unsigned long> axes = null;
   boolean keepDimensions = false;
+  boolean selectLastIndex = false;
 };
 
 partial interface MLGraphBuilder {
@@ -1476,6 +1477,10 @@ partial interface MLGraphBuilder {
     : <dfn>keepDimensions</dfn>
     ::
         A {{boolean}}. If true, retains reduced dimensions with [=list/size=] 1. The default value is false.
+
+    : <dfn>selectLastIndex</dfn>
+    ::
+        A {{boolean}}. If true, select the last index instead of the first found along the axes. The default value is false.
 </dl>
 
 <div>
@@ -1483,7 +1488,7 @@ partial interface MLGraphBuilder {
         - *input*: an {{MLOperand}}. The input N-D tensor.
         - *options*: an optional {{MLArgMinMaxOptions}}. The optional parameters of the operation.
 
-    **Returns:** an {{MLOperand}}. The N-D tensor of the reduced shape. The values must be of type "uint32" in the range [0, N-1] where N is the corresponding size of each of the input dimensions specified by options.axes.
+    **Returns:** an {{MLOperand}}. The N-D tensor of the reduced shape. The values must be of type "int64" in the range [0, N-1] where N is the corresponding size of each of the input dimensions specified by options.axes.
 </div>
 
 <details open algorithm>
@@ -1496,7 +1501,7 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLArgMinMaxOptions/axes}} [=map/exists=], if any of its elements is not in [=the range=] 0 to the [=rank=] of |input|, exclusive, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |outputShape| be the result of invoking the underlying implementation for calculating reduction output dimensions, given |options|.
     1. Let |desc| be a new {{MLOperandDescriptor}}.
-    1. Set |desc|.{{MLOperandDescriptor/dataType}} to "uint32".
+    1. Set |desc|.{{MLOperandDescriptor/dataType}} to "int64".
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |outputShape|.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
@@ -2505,8 +2510,7 @@ partial interface MLGraphBuilder {
         - *a*: an {{MLOperand}}. The first input tensor.
         - *b*: an {{MLOperand}}. The second input tensor when specified.
 
-    **Returns:** an {{MLOperand}}. The output tensor that contains the result of
-    element-wise comparison of the two input tensors.
+    **Returns:** an {{MLOperand}}. The output tensor that contains the result of element-wise comparison of the two input tensors.
 </div>
 <div>
     **Operation types:**
@@ -2529,7 +2533,10 @@ Although operations *greaterOrEqual* and *lesserOrEqual* can each be implemented
   <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "equal", "greater", "greaterOrEqual", "lesser", "lesserOrEqual", "not".
     1. [=Assert=]: the type of |a| and |b| if available is {{MLOperand}}.
-    1. If either |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} or |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} (when available) isn't "uint8", then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |op| is "not".
+        1. If |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} isn't "uint8", then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |op| is anything else but "not".
+        1. If |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} is not equal to |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
     1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to "uint8".
     1. Let |descriptor|.{{MLOperandDescriptor/dimensions}} be the result of running the [=MLGraphBuilder/broadcast-shapes=] steps given |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
@@ -2874,7 +2881,7 @@ partial interface MLGraphBuilder {
         1. If the sequence length of |newShape| is not equal to the [=rank=] of |inputDesc|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Let |outputDesc| be a copy of |inputDesc|.
         1. [=map/For each=] |index| in [=the range=] 0 to the [=rank=] of |input|, exclusive:
-            1. Let |size| be the [=operand-shape=][|index|] of |input|.
+            1. Let |size| be the |input|.{{MLOperand/shape()}}[|index|].
             1. If |size| is not equal to 1 and not equal to |newShape|[index], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
             1. If |size| is equal to 1, then let |outputDesc|.{{MLOperandDescriptor/dimensions}}[|index|] be |newShape|[|index|].
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -6129,10 +6136,7 @@ For instance, an {{MLOperand}} may represent a constant feeding to an operation 
 
 <script type=idl>
 [SecureContext, Exposed=(Window, DedicatedWorker)]
-interface MLOperand {
-  MLOperandDataType dataType();
-  sequence<unsigned long> shape();
-};
+interface MLOperand {};
 </script>
 
 <div class=internal-slots>
@@ -6158,13 +6162,6 @@ interface MLOperand {
     ::
         Reference to {{MLOperand}}'s corresponding [=implementation-defined=] platform operator object.
   </dl>
-</div>
-
-<div algorithm>
-To get the <dfn for="MLOperand">operand-shape</dfn> of an {{MLOperand}} |operand|, run the following steps:
-<div class=algorithm-steps>
-    1. Return |operand|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-</div>
 </div>
 
 <div algorithm>
@@ -6229,6 +6226,50 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
     1. Let |desc| be |operand|.{{MLOperand/[[descriptor]]}}.
     1. If |desc|.{{MLOperandDescriptor/dimensions}} [=map/exists=] and invoking <a>check dimensions</a> given |desc|.{{MLOperandDescriptor/dimensions}} and |desc|.{{MLOperandDescriptor/dataType}} returns false, then return false.
     1. Return true.
+  </div>
+</details>
+
+### dataType ### {#api-mloperand-datatype}
+Return a data type of the {{MLOperand}}.
+
+<script type=idl>
+partial interface MLOperand {
+  MLOperandDataType dataType();
+};
+</script>
+
+<div>
+    **Returns:** an {{MLOperandDataType}}. The data type of the operand.
+</div>
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLOperand>dataType()</dfn> method steps are:
+  </summary>
+  <div class=algorithm-steps>
+    1. Return [=this=].{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
+  </div>
+</details>
+
+### shape ### {#api-mloperand-shape}
+Return a shape of the {{MLOperand}}.
+
+<script type=idl>
+partial interface MLOperand {
+  sequence<unsigned long> shape();
+};
+</script>
+
+<div>
+    **Returns:** a sequence of {{unsigned long}}. The shape of the operand.
+</div>
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLOperand>shape()</dfn> method steps are:
+  </summary>
+  <div class=algorithm-steps>
+    1. Return [=this=].{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
   </div>
 </details>
 

--- a/index.bs
+++ b/index.bs
@@ -3864,7 +3864,7 @@ The {{MLLayerNormalizationOptions}} members are:
     1. If the [=rank=] of |options|.{{MLLayerNormalizationOptions/scale}} is not equal to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=Assert=]: the type of |options|.{{MLLayerNormalizationOptions/bias}} is  {{MLOperand}}.
     1. If the [=rank=] of |options|.{{MLLayerNormalizationOptions/bias}} is not equal to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. [=map/For each=] |index| in [=the range=] 0 to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}, exclusive:
+    1. [=map/For each=] |index| in [=the range=] 0 to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, exclusive:
         1. Let |axis| be |options|.{{MLLayerNormalizationOptions/axes}}[|index|].
         1. If |axis| is greater or equal to the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Let |size| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|axis|].

--- a/index.bs
+++ b/index.bs
@@ -1146,7 +1146,7 @@ partial interface MLContext {
   </summary>
   <div class=algorithm-steps>
     1. If |bufferView| is not an {{MLBufferView}}, return false.
-    1. If |bufferView|'s [=element type=] does not match to |descriptor|.{{MLOperandDescriptor/type}}  according to [this table](#appendices-mloperanddatatype-arraybufferview-compatibility), return false.
+    1. If |bufferView|'s [=element type=] does not match to |descriptor|.{{MLOperandDescriptor/dataType}}  according to [this table](#appendices-mloperanddatatype-arraybufferview-compatibility), return false.
     1. If |bufferView|.\[[ByteLength]] is not equal to the [=byte length=] of |descriptor|, return false.
   </div>
 </details>
@@ -1615,11 +1615,12 @@ partial interface MLGraphBuilder {
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+        1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=], |input| and |type|.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform operator |castImpl| for this method, given |type|.
             1. Store a reference of |castImpl| in |output|.{{MLOperand/[[operator]]}}.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent clamp output, given |output| and |castImpl|.
+            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent an output, given |output| and |castImpl|.
             1. Store a reference to |outputImpl| in |output|.{{MLOperand/[[operand]]}}.
         1. Connect |operand|.{{MLOperand/[[operand]]}} as input to |castImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |castImpl|.
@@ -1764,7 +1765,7 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |inputs| is sequence of {{MLOperand}} objects.
     1. [=Assert=]: the type of |axis| is `unsigned long`.
     1. [=Assert=]: the shape, i.e. {{MLOperandDescriptor/dimensions}} of each operand in |inputs| is the same, except on the dimension given by |axis| on which they are concatenated.
-    1. [=Assert=]: the {{MLOperandDescriptor/type}} of each operand in |inputs| is the same.
+    1. [=Assert=]: the {{MLOperandDescriptor/dataType}} of each operand in |inputs| is the same.
     1. If any of the following steps fail, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Let |desc| be |inputs|[0].{{MLOperand/[[descriptor]]}}.
         1. If |axis| is greater than or equal to the [=rank=] of |desc|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
@@ -1772,7 +1773,7 @@ partial interface MLGraphBuilder {
         1. [=map/For each=] |index| in [=the range=] 0 to the [=rank=] of |inputs|, exclusive:
             1. Let |input| be |inputs|[|index|].
             1. If <a>validating MLOperand</a> given |input| and [=this=] returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-            1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not equal to |inputs|[0].{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+            1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} is not equal to |inputs|[0].{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
             1. [=map/For each=] |dim| in [=the range=] 0 to the [=rank=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, exclusive:
                 <div class="note">
                     If the shape of each corresponding dimension and type of the operands, except for those of the dimension given by |axis|, is not the same, fail.
@@ -1815,7 +1816,7 @@ Create a constant {{MLOperand}} of the specified data type and shape that contai
     </div>
     1. [=Assert=]: the type of |descriptor| is {{MLOperandDescriptor}}.
     1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/dataType}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If <a>validating buffer with descriptor</a> given |bufferView| and |descriptor| returns false, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
@@ -1851,7 +1852,7 @@ Data truncation will occur when the specified value exceeds the range of the spe
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
-        1. Set |descriptor|.{{MLOperandDescriptor/type}} to |type|.
+        1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |type|.
         1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to `undefined`.
             <div class="note">
                 In the case of a scalar constant, |descriptor|.{{MLOperandDescriptor/dimensions}} is ignored.
@@ -1891,13 +1892,13 @@ Data truncation will occur when the values in the range exceed the range of the 
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
-        1. Set |descriptor|.{{MLOperandDescriptor/type}} to |type|.
+        1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |type|.
         1. Let |size| be *max(0, ceil((end - start)/step))*.
         1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to [|size|].
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-        1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
+        1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=], |start|, |end|, |step|, and |type|.
         1. Make a request to the underlying platform to:
-            1. Create an [=implementation-defined=] platform memory buffer the size of |size| multiplied by sizeof(|descriptor|.{{MLOperandDescriptor/type}}).
+            1. Create an [=implementation-defined=] platform memory buffer the size of |size| multiplied by sizeof(|descriptor|.{{MLOperandDescriptor/dataType}}).
             2. Store the beginning address to that memory buffer as a pointer |buffer| of the corresponding data type.
         1. [=map/For each=] |index| in [=the range=] 0 to |size|, exclusive:
             1. Set |buffer|[|index|] to |start| + (|index| * |step|).
@@ -2040,7 +2041,7 @@ partial interface MLGraphBuilder {
     1. Let |filterSize| be the [=list/size=] of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. If |inputSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |filterSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
+    1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} is not the same as |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/padding}} does not [=map/exist=], set it to `« 0, 0, 0, 0 »`.
     1. Else if the [=list/size=] of |options|.{{MLConv2dOptions/padding}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConv2dOptions/strides}} does not [=map/exist=], set it to `« 1, 1 »`.
@@ -2055,13 +2056,13 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLConv2dOptions/bias}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConv2dOptions/bias}} is {{MLOperand}}.
     1. If the [=list/size=] of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}}.
-    1. If |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/activation}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConv2dOptions/activation}} is {{MLActivation}}.
     1. Let |outputShape| be the result of invoking the underlying implementation for calculating output dimensions, given |options|.
     1. If |outputShape| is not the same as the shape of |options|.{{MLConv2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
-    1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
+    1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |outputShape|.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
@@ -2216,7 +2217,7 @@ partial interface MLGraphBuilder {
     1. Let |filterSize| be the [=list/size=] of |filter|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
     1. If |inputSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |filterSize| is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as {{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
+    1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} is not the same as {{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/padding}} does not [=map/exist=], set it to `« 0, 0, 0, 0 »`.
     1. Else if the [=list/size=] of |options|.{{MLConvTranspose2dOptions/padding}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLConvTranspose2dOptions/strides}} does not [=map/exist=], set it to `« 1, 1 »`.
@@ -2234,13 +2235,13 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLConvTranspose2dOptions/bias}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConvTranspose2dOptions/bias}} is {{MLOperand}}.
     1. If the [=list/size=] of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 1, then [=exception/throw=] a {{TypeError}}.
-    1. If |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} is not the same as |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/activation}} [=map/exists=]:
         1. [=Assert=]: the type of |options|.{{MLConvTranspose2dOptions/activation}} is {{MLActivation}}.
     1. Let |outputShape| be the result of invoking the underlying implementation for calculating output dimensions, given |options|.
     1. If |outputShape| is not the same as the shape of |options|.{{MLConvTranspose2dOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
-    1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
+    1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |outputShape|.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
@@ -2284,6 +2285,16 @@ partial interface MLGraphBuilder {
     **Returns:** an {{MLOperand}}. The output tensor that contains the result of
     element-wise binary operation of the two input tensors.
 </div>
+<div>
+    **Operation types:**
+        - *add*: Add the values of the two input tensors, element-wise.
+        - *sub*: Subtract the values of the second input tensor from the values of the first input tensor, element-wise.
+        - *mul*: Multiply the values of the two input tensors, element-wise.
+        - *div*: Divide the values of the first input tensor with the values of the second tensor, element-wise.
+        - *max*: Select the greater values of the two input tensors, element-wise.
+        - *min*: Select the lesser values of the two input tensors, element-wise.
+        - *pow*: Compute the values of the values of the first input tensor to the power of the values of the second input tensor, element-wise.
+</div>
 
 <details open algorithm>
   <summary>
@@ -2292,9 +2303,9 @@ partial interface MLGraphBuilder {
   <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "add", "sub", "mul", "div", "max", "min", "pow".
     1. [=Assert=]: the type of |a| and |b| is {{MLOperand}}.
-    1. If |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not equal to |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} is not equal to |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
-    1. Set |descriptor|.{{MLOperandDescriptor/type}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
+    1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
     1. Let |descriptor|.{{MLOperandDescriptor/dimensions}} be the result of running the [=MLGraphBuilder/broadcast-shapes=] steps given |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -2325,29 +2336,64 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-#### add #### {#api-mlgraphbuilder-binary-add}
-Add the values of the two input tensors, element-wise. See [[#api-mlgraphbuilder-binary]] for more detail.
+<details open>
+  <summary>
+    The element-wise binary operation algorithms invoke the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] steps as follows.
+  </summary>
+  <div class=algorithm-steps>
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>add(|a|, |b|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "add", |a| and |b|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### div #### {#api-mlgraphbuilder-binary-div}
-Divide the values of the first input tensor with the values of the second tensor, element-wise. See [[#api-mlgraphbuilder-binary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>sub(|a|, |b|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "sub", |a| and |b|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### max #### {#api-mlgraphbuilder-binary-max}
-Select the greater values of the two input tensors, element-wise. See [[#api-mlgraphbuilder-binary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>mul(|a|, |b|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "mul", |a| and |b|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### min #### {#api-mlgraphbuilder-binary-min}
-Select the lesser values of the two input tensors, element-wise. See [[#api-mlgraphbuilder-binary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>div(|a|, |b|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "div", |a| and |b|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### mul #### {#api-mlgraphbuilder-binary-mul}
-Multiply the values of the two input tensors, element-wise. See [[#api-mlgraphbuilder-binary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>max(|a|, |b|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "max", |a| and |b|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### pow #### {#api-mlgraphbuilder-binary-pow}
-Compute the values of the values of the first input tensor to the power of the values of the second input tensor, element-wise. See [[#api-mlgraphbuilder-binary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>min(|a|, |b|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "min", |a| and |b|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### sub #### {#api-mlgraphbuilder-binary-sub}
-Subtract the values of the second input tensor from the values of the first input tensor, element-wise. See [[#api-mlgraphbuilder-binary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>pow(|a|, |b|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "pow", |a| and |b|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
+</div>
+</details>
 
 ### Element-wise logical operations ### {#api-mlgraphbuilder-logical}
-Compare two input tensors element-wise, if the operation requires two inputs, and return a tensor of Boolean values 0 or 1 for the specified input values.
+Compare two input tensors element-wise, if the operation requires two inputs, and return a tensor of {{boolean}} values 0 or 1 for the specified input values.
 
 The two input tensors will be broadcasted according to [[!numpy-broadcasting-rule]]. The [=rank=] of the output tensor is the maximum
 [=rank=] of the input tensors.
@@ -2366,10 +2412,23 @@ partial interface MLGraphBuilder {
 <div>
     **Arguments:**
         - *a*: an {{MLOperand}}. The first input tensor.
-        - *b*: an {{MLOperand}}. The second input tensor.
+        - *b*: an {{MLOperand}}. The second input tensor when specified.
 
     **Returns:** an {{MLOperand}}. The output tensor that contains the result of
     element-wise comparison of the two input tensors.
+</div>
+<div>
+    **Operation types:**
+        - *equal*: Compare if the values of the two input tensors are equal, element-wise.
+        - *greater*: Compare if the values of the first input tensor is greater, element-wise.
+        - *greaterOrEqual*: Compare if the values of the first input tensor is greater or equal, element-wise.
+        - *lesser*: Compare if the values of the first input tensor is lesser, element-wise.
+        - *lesserOrEqual*: Compare if the values of the first input tensor is lesser or equal, element-wise.
+        - *not*: Invert the values of the input tensor to {{boolean}} values 0 or 1, element-wise. Specifically, when the input value is non-zero, invert it to a {{boolean}} value 0. Conversely, for a zero input value, invert it to a {{boolean}} value. 
+</div>
+
+<div class="note">
+Although operations *greaterOrEqual* and *lesserOrEqual* can each be implemented in terms of operations *not*, *lesser*, and *greater* in other words `greater-or-equal(a, b)` is `not(lesser(a, b))`, they are specifically defined for performance reason to avoid double comparisons in each element-wise test.
 </div>
 
 <details open algorithm>
@@ -2379,9 +2438,9 @@ partial interface MLGraphBuilder {
   <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "equal", "greater", "greaterOrEqual", "lesser", "lesserOrEqual", "not".
     1. [=Assert=]: the type of |a| and |b| if available is {{MLOperand}}.
-    1. If |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not equal to |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} if available, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If either |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} or |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} isn't "uint8", then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
-    1. Set |descriptor|.{{MLOperandDescriptor/type}} to "uint8".
+    1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to "uint8".
     1. Let |descriptor|.{{MLOperandDescriptor/dimensions}} be the result of running the [=MLGraphBuilder/broadcast-shapes=] steps given |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |b|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -2397,27 +2456,54 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-<div class="note">
-Although operations *greaterOrEqual* and *lesserOrEqual* can each be implemented in terms of operations *not*, *lesser*, and *greater* in other words `greater-or-equal(a, b)` is `not(lesser(a, b))`, they are specifically defined for performance reason to avoid double comparisons in each element-wise test.
+<details open>
+  <summary>
+    The element-wise logical operation algorithms invoke the [=MLGraphBuilder/element-wise-logical-op | create element-wise logical operation=] steps as follows.
+  </summary>
+  <div class=algorithm-steps>
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>equal(|a|, |b|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-logical-op | create element-wise logical operation=] given "equal", |a| and |b|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
+
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>greater(|a|, |b|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-logical-op | create element-wise logical operation=] given "greater", |a| and |b|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
+
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>greaterOrEqual(|a|, |b|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-logical-op | create element-wise logical operation=] given "greaterOrEqual", |a| and |b|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
+
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>lesser(|a|, |b|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-logical-op | create element-wise logical operation=] given "lesser", |a| and |b|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
+
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>lesserOrEqual(|a|, |b|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-logical-op | create element-wise logical operation=] given "lesserOrEqual", |a| and |b|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
+
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>not(|a|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-logical-op | create element-wise logical operation=] given "not" and |a|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 </div>
-
-#### equal #### {#api-mlgraphbuilder-logical-equal}
-Compare if the values of the two input tensors are equal, element-wise. See [[#api-mlgraphbuilder-logical]] for more detail.
-
-#### greater #### {#api-mlgraphbuilder-logical-greater}
-Compare if the values of the first input tensor is greater, element-wise. See [[#api-mlgraphbuilder-logical]] for more detail.
-
-#### greaterOrEqual #### {#api-mlgraphbuilder-logical-greater-or-equal}
-Compare if the values of the first input tensor is greater or equal, element-wise. See [[#api-mlgraphbuilder-logical]] for more detail.
-
-#### lesser #### {#api-mlgraphbuilder-logical-lesser}
-Compare if the values of the first input tensor is lesser, element-wise. See [[#api-mlgraphbuilder-logical]] for more detail.
-
-#### lesserOrEqual #### {#api-mlgraphbuilder-logical-lesser-or-equal}
-Compare if the values of the first input tensor is lesser or equal, element-wise. See [[#api-mlgraphbuilder-logical]] for more detail.
-
-#### not #### {#api-mlgraphbuilder-logical-not}
-Invert the values of the input tensor to Boolean values 0 or 1, element-wise. See [[#api-mlgraphbuilder-logical]] for more detail.
+</details>
 
 ### Element-wise unary operations ### {#api-mlgraphbuilder-unary}
 Compute the element-wise unary operation for input tensor.
@@ -2425,11 +2511,11 @@ Compute the element-wise unary operation for input tensor.
 partial interface MLGraphBuilder {
   MLOperand abs(MLOperand input);
   MLOperand ceil(MLOperand input);
-  MLOperand copy(MLOperand input);
   MLOperand cos(MLOperand input);
   MLOperand erf(MLOperand input);
   MLOperand exp(MLOperand input);
   MLOperand floor(MLOperand input);
+  MLOperand identity(MLOperand input);
   MLOperand log(MLOperand input);
   MLOperand neg(MLOperand input);
   MLOperand reciprocal(MLOperand input);
@@ -2447,12 +2533,30 @@ partial interface MLGraphBuilder {
     element-wise unary operation of the input tensor. The shape of the output
     tensor is the same as the shape of input tensor.
 </div>
+
+<div>
+    **Operation types:**
+        - *abs*: Compute the absolute value of the input tensor, element-wise.
+        - *ceil*: Compute the ceiling of the input tensor, element-wise.
+        - *cos*: Compute the cosine of the input tensor, element-wise.
+        - *erf*: Compute the error function [[Error-Function]] of the input tensor, element-wise.
+        - *exp*: Compute the exponential of the input tensor, element-wise.
+        - *floor*: Compute the floor of the input tensor, element-wise.
+        - *identity*: Copy the value of the input tensor to the output tensor, element-wise.
+        - *log*: Compute the natural logarithm of the input tensor, element-wise.
+        - *neg*: Compute the numerical negative value of the input tensor, element-wise.
+        - *reciprocal*: Compute the reciprocal of the input tensor, element-wise.
+        - *sin*: Compute the sine of the input tensor, element-wise.
+        - *sqrt*: Compute the square root of the input tensor, element-wise.
+        - *tan*: Compute the tangent of the input tensor, element-wise.
+</div>
+
 <details open algorithm>
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="element-wise-unary-op">create element-wise unary operation</dfn> given |op| and |input|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. [=Assert=]: |op| is one of "abs", "ceil", "copy", "cos", "exp", "floor", "log", "neg", "reciprocal", "sin", "sqrt", "tan".
+    1. [=Assert=]: |op| is one of "abs", "ceil", "cos", "erf", "exp", "floor", "identity", "log", "neg", "reciprocal", "sin", "sqrt", "tan".
     1. [=Assert=]: the type of |input| is {{MLOperand}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
@@ -2466,45 +2570,103 @@ partial interface MLGraphBuilder {
     1. Return |output|.
   </div>
 </details>
+<details open>
+  <summary>
+    The element-wise unary operation algorithms invoke the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] steps as follows.
+  </summary>
+  <div class=algorithm-steps>
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>abs(|input|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "abs" and |input|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### abs #### {#api-mlgraphbuilder-unary-abs}
-Compute the absolute value of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>ceil(|input|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "ceil" and |input|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### ceil #### {#api-mlgraphbuilder-unary-ceil}
-Compute the ceiling of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>cos(|input|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "cos" and |input|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### copy #### {#api-mlgraphbuilder-unary-copy}
-Copy the value of the input tensor to the output tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>erf(|input|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "erf" and |input|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### cos #### {#api-mlgraphbuilder-unary-cos}
-Compute the cosine of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>exp(|input|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "exp" and |input|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### erf #### {#api-mlgraphbuilder-unary-erf}
-Compute the error function [[Error-Function]] of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>floor(|input|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "floor" and |input|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### exp #### {#api-mlgraphbuilder-unary-exp}
-Compute the exponential of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>identity(|input|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "identity" and |input|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### floor #### {#api-mlgraphbuilder-unary-floor}
-Compute the floor of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>log(|input|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "log" and |input|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### log #### {#api-mlgraphbuilder-unary-log}
-Compute the natural logarithm of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>neg(|input|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "neg" and |input|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### neg #### {#api-mlgraphbuilder-unary-neg}
-Compute the numerical negative value of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>reciprocal(|input|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "reciprocal" and |input|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### reciprocal #### {#api-mlgraphbuilder-unary-reciprocal}
-Compute the reciprocal of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>sin(|input|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "sin" and |input|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### sin #### {#api-mlgraphbuilder-unary-sin}
-Compute the sine of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>sqrt(|input|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "sqrt" and |input|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
 
-#### sqrt #### {#api-mlgraphbuilder-unary-sqrt}
-Compute the square root of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
-
-#### tan #### {#api-mlgraphbuilder-unary-tan}
-Compute the tangent of the input tensor, element-wise. See [[#api-mlgraphbuilder-unary]] for more detail.
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>tan(|input|)</dfn> method steps are:
+        1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "tan" and |input|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
+  </div>
+</details>
 
 ### elu ### {#api-mlgraphbuilder-elu}
 Calculate the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)#ELU"> exponential linear unit function</a> (ELU) on the input tensor element-wise. The calculation follows the expression `max(0, x) + alpha * (exp(min(0, x)) - 1)`.
@@ -2617,13 +2779,15 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: the type of |input| is {{MLOperand}} object.
     1. [=Assert=]: the type of |newShape| is a `sequence of unsigned long`.
     1. If any of the following steps fail, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. Let |desc| be |input|.{{MLOperand/[[descriptor]]}}.
-        1. If the sequence length of |newShape| is greater than the [=rank=] of |desc|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. Let |inputDesc| be |input|.{{MLOperand/[[descriptor]]}}.
+        1. If the sequence length of |newShape| is not equal to the [=rank=] of |inputDesc|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. Let |outputDesc| be a copy of |inputDesc|.
         1. [=map/For each=] |index| in [=the range=] 0 to the [=rank=] of |input|, exclusive:
-            1. Let |size| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[index].
+            1. Let |size| be the [=operand-shape=][|index|] of |input|.
             1. If |size| is not equal to 1 and not equal to |newShape|[index], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+            1. If |size| is equal to 1, then let |outputDesc|.{{MLOperandDescriptor/dimensions}}[|index|] be |newShape|[|index|].
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
+        1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |outputDesc|.
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform operator |expandImpl| for this method, given |input| and |newShape|.
             1. Store a reference of |expandImpl| in |output|.{{MLOperand/[[operator]]}}.
@@ -2657,7 +2821,7 @@ partial interface MLGraphBuilder {
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input N-D tensor from which the values are gathered.
-        - *indices*: an {{MLOperand}}. The indices N-D tensor of the input values to gather. The values must be in the range [0, N] where N is the value of the input shape indexed by *options.axis*.
+        - *indices*: an {{MLOperand}}. The indices N-D tensor of the input values to gather. The values must be of type "uint32" in the range [0, N-1] where N is the size of the input dimension indexed by *options.axis*.
         - *options*: an optional {{MLGatherOptions}}. The optional parameters of the operation.
 
     **Returns:** an {{MLOperand}}. The output N-D tensor of [=rank=] equal to M + N - 1 where M and N are the [=rank=] of the *input* and *indices* tensor respectively.
@@ -2696,7 +2860,7 @@ partial interface MLGraphBuilder {
         1. Increment |dimCount| by one.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |shapeOutput|.
-    1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
+    1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given |desc|.
         1. Make a request to the underlying platform to:
@@ -2833,7 +2997,7 @@ partial interface MLGraphBuilder {
         </div>
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [|shapeA|[0], |shapeB|[1]].
-    1. Set |desc|.{{MLOperandDescriptor/type}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
+    1. Set |desc|.{{MLOperandDescriptor/dataType}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
@@ -3117,7 +3281,7 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and its [=list/size=] is not 2, then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |input|.{{MLOperandDescriptor/dimensions}}[0], |hiddenSize| ].
-    1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
+    1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
@@ -3430,7 +3594,7 @@ Create a named {{MLOperand}} based on a descriptor, that can be used as an input
     1. [=Assert=]: the type of |descriptor| is {{MLOperandDescriptor}}.
     1. [=Assert=]: If |descriptor|.{{MLOperandDescriptor/dimensions}} does not [=map/exist=], then |descriptor| defines a scalar input.
     1. If |descriptor|.{{MLOperandDescriptor/dimensions}} [=map/exists=]:
-        1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/type}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If the [=check dimensions=] steps given |descriptor|.{{MLOperandDescriptor/dataType}} and |descriptor|.{{MLOperandDescriptor/dimensions}} return false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If the [=byte length=] of |descriptor| is not supported by the underlying platform, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |operand| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
@@ -3602,6 +3766,12 @@ The {{MLLayerNormalizationOptions}} members are:
     1. If the [=rank=] of |options|.{{MLLayerNormalizationOptions/scale}} is not equal to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=Assert=]: the type of |options|.{{MLLayerNormalizationOptions/bias}} is  {{MLOperand}}.
     1. If the [=rank=] of |options|.{{MLLayerNormalizationOptions/bias}} is not equal to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. [=map/For each=] |index| in [=the range=] 0 to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}, exclusive:
+        1. Let |axis| be |options|.{{MLLayerNormalizationOptions/axes}}[|index|].
+        1. If |axis| is greater or equal to the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. Let |size| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|axis|].
+        1. If |options|.{{MLLayerNormalizationOptions/scale}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|index] is not equal to |size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |options|.{{MLLayerNormalizationOptions/bias}}.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|index] is not equal to |size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of  <a>copying an MLOperand</a> given |input|.
         1. Make a request to the underlying platform to:
@@ -3954,7 +4124,7 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |desc| a new {{MLOperandDescriptor}}.
         1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |numDirections|, |batchSize|, |hiddenSize| ].
-        1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
+        1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
         1. Let |output0| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Let |output1| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |steps|, |numDirections|, |batchSize|, |hiddenSize| ].
@@ -4139,7 +4309,7 @@ partial interface MLGraphBuilder {
         1. [=Assert=]: the type of its elements is {{MLActivation}}.
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to [ |batchSize|, |hiddenSize| ].
-    1. Set |desc|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
+    1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output0| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Let |output1| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
@@ -4327,7 +4497,7 @@ partial interface MLGraphBuilder {
     1. Let |desc| a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of invoking the <a>calculate matmul output sizes</a> steps given |a| and |b|.
     1. If that throws an error, re-[=exception/throw=] the error.
-    1. Set |desc|.{{MLOperandDescriptor/type}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
+    1. Set |desc|.{{MLOperandDescriptor/dataType}} to |a|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
@@ -4680,7 +4850,7 @@ partial interface MLGraphBuilder {
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |input| and |slope| is {{MLOperand}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
-    1. Set |descriptor|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
+    1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
     1. Let |descriptor|.{{MLOperandDescriptor/dimensions}} be the result of running the [=MLGraphBuilder/broadcast-shapes=] steps given |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |slope|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -4752,6 +4922,22 @@ partial interface MLGraphBuilder {
         - *options*: an optional {{MLReduceOptions}}. The optional parameters of the operation.
 
     **Returns:** an {{MLOperand}}. The reduced output tensor.
+</div>
+
+<div class="note">
+    **Reduction types:**
+        - *ArgMax*: Return the index location of the maxmium value of all the input values along the axes.
+        - *ArgMin*: Return the index location of the minimum value of all the input values along the axes.
+        - *L1*: Compute the <a href="https://mathworld.wolfram.com/L1-Norm.html">L1 norm</a> of all the input values along the axes.
+        - *L2*: Compute the <a href="https://mathworld.wolfram.com/L2-Norm.html">L2 norm</a> of all the input values along the axes.
+        - *LogSum*: Compute the log value of the sum of all the input values along the axes.
+        - *LogSumExp*: Compute the log value of the sum of the exponent of all the input values along the axes.
+        - *Max*: Compute the maximum value of all the input values along the axes.
+        - *Mean*: Compute the average value of all the input values along the axes.
+        - *Min*: Compute the minimum value of all the input values along the axes.
+        - *Product*: Compute the product of all the input values along the axes.
+        - *Sum*: Compute the sum of all the input values along the axes.
+        - *SumSquare*: Compute the sum of the square of all the input values along the axes.
 </div>
 
 <details open algorithm>
@@ -4863,42 +5049,6 @@ partial interface MLGraphBuilder {
         1. Return |output|.
     </div>
 </details>
-
-#### reduceArgMax #### {#api-mlgraphbuilder-reduce-argmax}
-Return the index location of the maxmium value of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
-
-#### reduceArgMin #### {#api-mlgraphbuilder-reduce-argmin}
-Return the index location of the minimum value of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
-
-#### reduceL1 #### {#api-mlgraphbuilder-reduce-l1}
-Compute the <a href="https://mathworld.wolfram.com/L1-Norm.html">L1 norm</a> of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
-
-#### reduceL2 #### {#api-mlgraphbuilder-reduce-l2}
-Compute the <a href="https://mathworld.wolfram.com/L2-Norm.html">L2 norm</a> of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
-
-#### reduceLogSum #### {#api-mlgraphbuilder-reduce-logsum}
-Compute the log value of the sum of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
-
-#### reduceLogSumExp #### {#api-mlgraphbuilder-reduce-logSumExp}
-Compute the log value of the sum of the exponent of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
-
-#### reduceMax #### {#api-mlgraphbuilder-reduce-max}
-Compute the maximum value of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
-
-#### reduceMean #### {#api-mlgraphbuilder-reduce-mean}
-Compute the average value of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
-
-#### reduceMin #### {#api-mlgraphbuilder-reduce-min}
-Compute the minimum value of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
-
-#### reduceProduct #### {#api-mlgraphbuilder-reduce-product}
-Compute the product of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
-
-#### reduceSum #### {#api-mlgraphbuilder-reduce-sum}
-Compute the sum of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
-
-#### reduceSumSquare #### {#api-mlgraphbuilder-reduce-sumsquare}
-Compute the sum of the square of all the input values along the axes. See [[#api-mlgraphbuilder-reduce]] for more detail.
 
 ### relu ### {#api-mlgraphbuilder-relu-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)">rectified linear function</a> of the input tensor.
@@ -5832,7 +5982,7 @@ partial interface MLGraphBuilder {
 </div>
 
 ### where ### {#api-mlgraphbuilder-where}
-Select the values from the input or the other tensor depending on the corresponding Boolean values of the condition tensor. The condition tensor is often the output of one of the element-wise logical operations.
+Select the values from the input or the other tensor depending on the corresponding {{boolean}} values of the condition tensor. The condition tensor is often the output of one of the element-wise logical operations.
 
 The input tensors will be broadcasted according to [[!numpy-broadcasting-rule]] to the final output shape. The [=rank=] of the output tensor is the maximum [=rank=] of the input tensors.
 For each dimension of the output tensor, its size is the maximum size along that dimension of the input tensors.
@@ -5858,16 +6008,17 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: the type of |condition|, |input| and |other| is {{MLOperand}}.
-    1. If |condition|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not equal to "uint8", then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}} is not equal to |other|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |condition|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} is not equal to "uint8", then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} is not equal to |other|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
-    1. Set |descriptor|.{{MLOperandDescriptor/type}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
+    1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}.
     1. Let |descriptor|.{{MLOperandDescriptor/dimensions}} be the result of running the [=MLGraphBuilder/broadcast-shapes=] steps given |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} and |other|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
+    1. If |condition| is not unidirectionally broadcastable to |descriptor|.{{MLOperandDescriptor/dimensions}} according to the [[!numpy-broadcasting-rule]], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of <a>creating an MLOperand</a> given [=this=] and |descriptor|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for |where|, given |condition|, |input| and |other|.
+            1. Let |opImpl| be an [=implementation-defined=] platform operator for the where operation, given |condition|, |input| and |other|.
             1. Store a reference of |opImpl| in |output|.{{MLOperand/[[operator]]}}.
             1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Store a reference to |outputImpl| in |output|.{{MLOperand/[[operand]]}}.
@@ -5934,14 +6085,7 @@ interface MLOperand {
 </div>
 
 <div algorithm>
-To get the <dfn for="MLOperand">type</dfn> of an {{MLOperand}} |operand|, run the following steps:
-<div class=algorithm-steps>
-    1. Return |operand|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/type}}.
-</div>
-</div>
-
-<div algorithm>
-To get the <dfn for="MLOperand">shape</dfn> of an {{MLOperand}} |operand|, run the following steps:
+To get the <dfn for="MLOperand">operand-shape</dfn> of an {{MLOperand}} |operand|, run the following steps:
 <div class=algorithm-steps>
     1. Return |operand|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
 </div>
@@ -6007,7 +6151,7 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
     1. [=Assert=]: the type of |operand|.{{MLOperand/[[builder]]}} is {{MLGraphBuilder}}.
     1. If |builder| is not equal to |operand|.{{MLOperand/[[builder]]}}, return false.
     1. Let |desc| be |operand|.{{MLOperand/[[descriptor]]}}.
-    1. If |desc|.{{MLOperandDescriptor/dimensions}} [=map/exists=] and invoking <a>check dimensions</a> given |desc|.{{MLOperandDescriptor/dimensions}} and |desc|.{{MLOperandDescriptor/type}} returns false, then return false.
+    1. If |desc|.{{MLOperandDescriptor/dimensions}} [=map/exists=] and invoking <a>check dimensions</a> given |desc|.{{MLOperandDescriptor/dimensions}} and |desc|.{{MLOperandDescriptor/dataType}} returns false, then return false.
     1. Return true.
   </div>
 </details>
@@ -6032,7 +6176,7 @@ enum MLOperandDataType {
 
 dictionary MLOperandDescriptor {
   // The operand type.
-  required MLOperandDataType type;
+  required MLOperandDataType dataType;
 
   // The dimensions field is only required for tensor operands.
   sequence<unsigned long> dimensions;
@@ -6047,7 +6191,7 @@ dictionary MLOperandDescriptor {
     1. Let |elementLength| be 1.
     1. [=map/For each=] |dimension| of |desc|.{{MLOperandDescriptor/dimensions}}:
         1. Set |elementLength| to |elementLength| × |dimension|.
-    1. Let |elementSize| be the [=element size=] of one of the {{ArrayBufferView}} types that matches |desc|.{{MLOperandDescriptor/type}} according to [this table](#appendices-mloperanddatatype-arraybufferview-compatibility).
+    1. Let |elementSize| be the [=element size=] of one of the {{ArrayBufferView}} types that matches |desc|.{{MLOperandDescriptor/dataType}} according to [this table](#appendices-mloperanddatatype-arraybufferview-compatibility).
     1. Return |elementLength| × |elementSize|.
   </div>
 </details>

--- a/index.bs
+++ b/index.bs
@@ -3634,25 +3634,17 @@ The {{MLLayerNormalizationOptions}} members are:
       reduceOptions
       );
 
-    // Returns a new tensor with a dimension of size one inserted at the specified position.
-    function unsqueeze(input, axes) {
-      shape = Array.from(input.shape());
-      for(let axis in axes.sort())
-        shape.splice(axis, 0, 1);
-      return builder.reshape(input, shape);
-    }
-
     // The scale and bias tensors are of the shape of the input dimensions specified 
     // by the values in the axes parameter (i.e. [1,2,3]).
     return builder.add(
       builder.mul(
-        unsqueeze(options.scale, 0),
+        options.scale,
         builder.div(
           builder.sub(input, mean),
           buidler.sqrt(builder.add(variance, options.epsilon))
           )
         ),
-      unsqueeze(options.bias, 0)
+      options.bias
       );
   </pre>
 </details>

--- a/index.bs
+++ b/index.bs
@@ -4654,13 +4654,13 @@ partial interface MLGraphBuilder {
   </div>
 </details>
 
-#### {{MLGraphBuilder/averagePool2d(input, options)}} #### {#api-mlgraphbuilder-pool2d-average}
+#### averagePool2d #### {#api-mlgraphbuilder-pool2d-average}
 Calculate the average value for patches of a feature map, and use it to create a pooled feature map. See [[#api-mlgraphbuilder-pool2d]] for more detail.
 
-#### {{MLGraphBuilder/l2Pool2d(input, options)}} #### {#api-mlgraphbuilder-pool2d-l2}
+#### l2Pool2d #### {#api-mlgraphbuilder-pool2d-l2}
 Apply the L2 norm function to a region of the input feature map. The L2 norm is the square root of the sum of the squares of its elements. See [[#api-mlgraphbuilder-pool2d]] for more detail.
 
-#### {{MLGraphBuilder/maxPool2d(input, options)}} #### {#api-mlgraphbuilder-pool2d-max}
+#### maxPool2d #### {#api-mlgraphbuilder-pool2d-max}
 Calculate the maximum value for patches of a feature map, and use it to create a pooled feature map. See [[#api-mlgraphbuilder-pool2d]] for more detail.
 
 ### prelu ### {#api-mlgraphbuilder-prelu}


### PR DESCRIPTION
Issue #375. 

1. Add the following ops: `equal, lesser, greater, greaterOrEqual, lesserOrEqual, not, where, copy, sqrt, erf, expand, gather, layerNormalization, reduceArgMin, reduceArgMax, cast, triangular`
2. Remove `squeeze`
3. Add a `constant` overload that accepts `start, end, step`.
4. Add `shape` method in `MLOperand` for runtime tensor shape query.
5. Add new data type `int64` and `uint64` for `reduceArgMin` and `reduceArgMax`.

Notes:
- The proposed `identity` op is named `copy` to denote explicit action.
- The proposed `elementwiseIf` is named `where` to be consistent with PyTorch and ONNX.
- The proposed `triangularMatrix` is named `triangular` for brevity.
- `squeeze` is removed. Framework seeking `squeeze`, `unsqueeze`, `flatten` should just use `reshape`. See canonical implementations of these ops as `reshape` in the `reshape` section. 
- Instead of the proposed unification of all normalizations under one new normalization operation, a new `layerNormalization` op is added. There are enough subtleties in the way affine parameters (e.g. scale, bias) are expected across batchNorm, instanceNorm, and layerNorm that could become ambiguous under the unified op. Additionally, downstream implementations of these normalizations have already been done in various platforms. The unification at the WebNN level could potentially confuse framework developers and affects currently defined platform-specific optimizations.
- The proposed `fillSequence` op is added as a `constant` overload due to its nature of resource allocation activity. 
- The new sidebar loosens up the crowded *MLGraphBuilder interface* section for better op discoverability. 

Big thanks to @fdwr for the thoughtful and thorough proposal.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/pull/478.html" title="Last updated on Dec 7, 2023, 3:05 AM UTC (e8c9864)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/478/c6ed2ca...e8c9864.html" title="Last updated on Dec 7, 2023, 3:05 AM UTC (e8c9864)">Diff</a>