### PR TITLE
Bug fix: Remove null value support in reshape()'s newShape parameter

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5316,7 +5316,7 @@ partial interface MLGraphBuilder {
 Alter the shape of a tensor to a new shape. Reshape does not copy or change the content of the tensor. It just changes the tensor's logical dimensions for the subsequent operations.
 <script type=idl>
 partial interface MLGraphBuilder {
-  MLOperand reshape(MLOperand input, sequence<unsigned long?> newShape);
+  MLOperand reshape(MLOperand input, sequence<unsigned long> newShape);
 };
 </script>
 <div>
@@ -5324,10 +5324,7 @@ partial interface MLGraphBuilder {
         - *input*: an {{MLOperand}}. The input tensor.
         - *newShape*: a sequence of [=nullable type|nullable=] {{unsigned long}}. The shape of the output tensor.
             The number of elements implied by *newShape* must be the same as the
-            number of elements in the input tensor. Only one component of
-            *newShape* can be the special value of `null`. The size of the dimension
-            with the value `null` is computed so that the total size remains
-            constant.
+            number of elements in the input tensor.
 
     **Returns:** an {{MLOperand}}. The output tensor. The values of the output
     tensor are the same as values of the input tensor. The shape of the output
@@ -5344,11 +5341,8 @@ partial interface MLGraphBuilder {
     1. If |newShape| is a scalar [=number=], set |outputShape| to «  1  ».
     1. Otherwise, if |newShape| is an array of {{unsigned long}}:
         1. If the [=list/size=] of |newShape| is 0, set |outputShape| to «  1  » (reshaping to scalar).
-        1. If |newShape| contains more than one `null` value, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If any value in |newShape| is 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Let |inputElementCount| be the product of all elements in |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}.
-        1. If |newShape| contains a `null` value, set that value to |inputElementCount| divided by the product of all other values in |newShape|.
-            1. If that value is too large for {{unsigned long}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If product of all values in |newShape| is not equal to |inputElementCount|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |newShape|.


### PR DESCRIPTION
As noted in issue #388, the reshape op build method currently supports a special null value in newShape array that instructs the implementation to compute the size of the dimension with the value null so that the total size remains constant. @fwdr proposed WebNN should only support the concrete values in newShape because this can be easily handled by framework through shape inference

It appears this change has already landed in the Chromium implementation and WPTs.

Fixes #388


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/505.html" title="Last updated on Jan 18, 2024, 6:49 PM UTC (ab36f0d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/505/50a00b9...inexorabletash:ab36f0d.html" title="Last updated on Jan 18, 2024, 6:49 PM UTC (ab36f0d)">Diff</a>