### PR TITLE
Wording change: Remove arg type test for internal validation algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1165,7 +1165,6 @@ partial interface MLContext {
     To <dfn>validate buffer with descriptor</dfn> given |bufferView| and |descriptor|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. If |bufferView| is not an {{MLBufferView}}, return false.
     1. If |bufferView|'s [=element type=] does not match to |descriptor|.{{MLOperandDescriptor/dataType}}  according to [this table](#appendices-mloperanddatatype-arraybufferview-compatibility), return false.
     1. If |bufferView|.\[[ByteLength]] is not equal to the [=byte length=] of |descriptor|, return false.
   </div>


### PR DESCRIPTION
The "validate buffer with descriptor given bufferView and descriptor" was validating that the type of the buffer was MLBufferView. This is not necessary, as all invokers (directly, and indirectly via "validate graph resources") only accept MLBufferViews via the WebIDL signatures.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 17, 2024, 5:35 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Finexorabletash%2Fwebnn%2F6643ce273bfa93ae6b9357ae232110da4f814537%2Findex.bs&force=1&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20webmachinelearning/webnn%23510.)._
</details>
