### PR TITLE
Wording change: Define power prefs & device type using WebIDL enums

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -795,12 +795,12 @@ Its <a>default allowlist</a> is <code>'self'</code>.
     1. Let |context| be a new {{MLContext}} object.
     1. If |options| is a {{GPUDevice}} object,
         1. Set |context|.{{[[contextType]]}} to "[=webgpu-context|webgpu=]".
-        1. Set |context|.{{[[deviceType]]}} to "[=device-type-gpu|gpu=]".
-        1. Set |context|.{{[[powerPreference]]}} to "[=power-preference-default|default=]".
+        1. Set |context|.{{[[deviceType]]}} to {{MLDeviceType/"gpu"}}.
+        1. Set |context|.{{[[powerPreference]]}} to {{MLPowerPreference/"default"}}.
     1. Otherwise,
         1. Set |context|.{{[[contextType]]}} to "[=default-context|default=]".
-        1. If |options|["{{deviceType}}"] [=map/exists=], then set |context|.{{[[deviceType]]}} to |options|["{{deviceType}}"]. Otherwise, set |context|.{{[[deviceType]]}} to "[=device-type-cpu|cpu=]".
-        1. If |options|["{{powerPreference}}"] [=map/exists=], then set |context|.{{[[powerPreference]]}} to |options|["{{powerPreference}}"]. Otherwise, set |context|.{{[[powerPreference]]}} to "[=power-preference-default|default=]".
+        1. If |options|["{{deviceType}}"] [=map/exists=], then set |context|.{{[[deviceType]]}} to |options|["{{deviceType}}"]. Otherwise, set |context|.{{[[deviceType]]}} to {{MLDeviceType/"cpu"}}.
+        1. If |options|["{{powerPreference}}"] [=map/exists=], then set |context|.{{[[powerPreference]]}} to |options|["{{powerPreference}}"]. Otherwise, set |context|.{{[[powerPreference]]}} to {{MLPowerPreference/"default"}}.
     1. Return |context|.
 </div>
 </details>
@@ -1057,19 +1057,19 @@ The <dfn>context type</dfn> is the type of the execution context that manages th
 
 The <dfn>device type</dfn> indicates the kind of device used for the context. It is one of the following:
 <dl>
-<dt>"<code><dfn data-lt="device-type-cpu">cpu</dfn></code>"</dt>
+<dt>"<code><dfn dfn-for="MLDeviceType" enum-value>cpu</dfn></code>"</dt>
 <dd>Provides the broadest compatibility and usability across all client devices with varying degrees of performance.</dd>
-<dt>"<code><dfn data-lt="device-type-gpu">gpu</dfn></code>"</dt>
+<dt>"<code><dfn dfn-for="MLDeviceType" enum-value>gpu</dfn></code>"</dt>
 <dd>Provides the broadest range of achievable performance across graphics hardware platforms from consumer devices to professional workstations.</dd>
 </dl>
 
 The <dfn>power preference</dfn> indicates preference as related to power consumption. It is one of the following:
 <dl>
-<dt>"<code><dfn data-lt="power-preference-default">default</dfn></code>"</dt>
+<dt>"<code><dfn dfn-for="MLPowerPreference" enum-value>default</dfn></code>"</dt>
 <dd>Let the user agent select the most suitable behavior.</dd>
-<dt>"<code><dfn data-lt="power-preference-high-performance">high-performance</dfn></code>"</dt>
+<dt>"<code><dfn dfn-for="MLPowerPreference" enum-value>high-performance</dfn></code>"</dt>
 <dd>Prioritizes execution speed over power consumption.</dd>
-<dt>"<code><dfn data-lt="power-preference-low-power">low-power</dfn></code>"</dt>
+<dt>"<code><dfn dfn-for="MLPowerPreference" enum-value>low-power</dfn></code>"</dt>
 <dd>Prioritizes power consumption over other considerations such as execution speed.</dd>
 </dl>
 
@@ -1096,7 +1096,7 @@ interface MLContext {};
 </div>
 
 <div class="note">
-When the {{[[contextType]]}} is set to [=default-context|default=] with the {{MLContextOptions}}.{{deviceType}} set to [=device-type-gpu|gpu=], the user agent is responsible for creating an internal GPU device that operates within the context and is capable of ML workload submission on behalf of the calling application. In this setting however, only {{ArrayBufferView}} inputs and outputs are allowed in and out of the graph execution since the application has no way to know what type of internal GPU device is being created on their behalf. In this case, the user agent is responsible for automatic uploads and downloads of the inputs and outputs to and from the GPU memory using this said internal device.
+When the {{[[contextType]]}} is set to [=default-context|default=] with the {{MLContextOptions}}.{{deviceType}} set to {{MLDeviceType/"gpu"}}, the user agent is responsible for creating an internal GPU device that operates within the context and is capable of ML workload submission on behalf of the calling application. In this setting however, only {{ArrayBufferView}} inputs and outputs are allowed in and out of the graph execution since the application has no way to know what type of internal GPU device is being created on their behalf. In this case, the user agent is responsible for automatic uploads and downloads of the inputs and outputs to and from the GPU memory using this said internal device.
 </div>
 
 ### {{MLContext}} validation algorithm ### {#api-mlcontext-validate}
@@ -1107,8 +1107,8 @@ When the {{[[contextType]]}} is set to [=default-context|default=] with the {{ML
   </summary>
   <div class=algorithm-steps>
     1. If |context|.{{[[contextType]]}} is not "[=webgpu-context|webgpu=]" or "[=default-context|default=]", return false.
-    1. If |context|.{{[[deviceType]]}} is not "[=device-type-cpu|cpu=]" or "[=device-type-gpu|gpu=]", return false.
-    1. If |context|.{{[[powerPreference]]}} is not "[=power-preference-default|default=]" or "[=power-preference-high-performance|high-performance=]" or "[=power-preference-low-power|low-power=]", return false.
+    1. If |context|.{{[[deviceType]]}} is not {{MLDeviceType/"cpu"}} or {{MLDeviceType/"gpu"}}, return false.
+    1. If |context|.{{[[powerPreference]]}} is not {{MLPowerPreference/"default"}} or {{MLPowerPreference/"high-performance"}} or {{MLPowerPreference/"low-power"}}, return false.
     1. If the user agent cannot support |context|.{{[[contextType]]}}, |context|.{{[[deviceType]]}} and |context|.{{[[powerPreference]]}}, return false.
     1. Return true;
   </div>


### PR DESCRIPTION
Replace definitions for MLContext's device type and power preference which are used internally only, with the identical WebIDL-defined MLDeviceType and MLPowerPreference enums.

Fixes #497


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 17, 2024, 8:38 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fwebmachinelearning%2Fwebnn%2F69aeffa6d777f6a025f05a1edd028a6d3f9fe351%2Findex.bs&force=1&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20webmachinelearning/webnn%23511.)._
</details>
