### PR TITLE
Bug fix: resample2d output size calculation algorithm and usage

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5278,10 +5278,10 @@ partial interface MLGraphBuilder {
 <details open algorithm>
 
   <summary>
-    To <dfn for="MLGraphBuilder">resample output sizes</dfn> given |input| and |options|, run the following steps:
+    To <dfn for="MLGraphBuilder">calculate resample output sizes</dfn> given {{MLOperand}} |input| and {{MLResample2dOptions}} |options|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. Let |desc| be an {{MLOperandDescriptor}} initialized to |input|.{{MLOperand/[[descriptor]]}}.
+    1. Let |desc| be a new {{MLOperandDescriptor}} initialized to |input|.{{MLOperand/[[descriptor]]}}.
     1. For |index| in [=the range=] 0 to the [=list/size=] of |options|.{{MLResample2dOptions/axes}}, exclusive:
         1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], set |desc|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLResample2dOptions/axes}}[|index|]] to |options|.{{MLResample2dOptions/sizes}}[|index|] and return |desc|.
         1. Otherwise, set |desc|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|options|.{{MLResample2dOptions/axes}}[|index|]] to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|index|] multiplied by |options|.{{MLResample2dOptions/scales}}.
@@ -5297,8 +5297,7 @@ partial interface MLGraphBuilder {
   <div class=algorithm-steps>
     1. If the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If [=checking resample options=] given |options| returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. Let |desc| be the result of [=resampling output sizes=] given |options|.
-        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
+    1. Let |desc| be the result of [=calculating resample output sizes=] given |input| and |options|.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
         1. Make a request to the underlying platform to:


### PR DESCRIPTION
* Per #395 make it clearer that the algorithm is working on a new descriptor (a copy of the input's)

* When invoking the algorithm, pass the required input argument.

* Rename algorithm from "resample output sizes" to "calculate resample output sizes" which more clearly descripts what is happening and aligns with similar algorithms in the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/520.html" title="Last updated on Jan 24, 2024, 8:20 PM UTC (111172a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/520/fa91851...inexorabletash:111172a.html" title="Last updated on Jan 24, 2024, 8:20 PM UTC (111172a)">Diff</a>