### PR TITLE
Bug fix: Correct indentation of an iteration substep

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4580,7 +4580,7 @@ partial interface MLGraphBuilder {
     1. If |shapeA|[|sizeA| - 1] is not equal to |shapeB|[0], then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
     1. Let |shape| be an array whose size |size| is the maximum of |sizeA| and |sizeB|.
     1. [=map/For each=] |index| in [=the range=] 0 to |size|, exclusive:
-       1. Set |shape|[|index|] to the maximum of |shapeA|[|index|] and |shapeB|[|index|].
+        1. Set |shape|[|index|] to the maximum of |shapeA|[|index|] and |shapeB|[|index|].
     1. Return |shape|.
   </div>
 </details>


### PR DESCRIPTION
Bikeshed markdown requires the indentation to be at least 4 spaces.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/522.html" title="Last updated on Jan 19, 2024, 11:28 PM UTC (5f67a6d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/522/50a00b9...inexorabletash:5f67a6d.html" title="Last updated on Jan 19, 2024, 11:28 PM UTC (5f67a6d)">Diff</a>