### PR TITLE
Wording change: Dedupe dictionary member type and default definitions

### DIFF
--- a/SpecCodingConventions.md
+++ b/SpecCodingConventions.md
@@ -76,6 +76,7 @@ Example:
 * Bikeshed will automatically style linked terms appropriately, for example Web IDL types show up as `code`. Try to avoid manual styling wherever possible; if you're not getting the style you expect, you may have incorrect definitions or links.
 * Outside of examples, which should be appropriately styled automatically, literals such as numbers within spec prose are not JavaScript values and should not be styled as code.
 * Strings used internally (e.g. operator names) should not be styled as code.
+* When concisely defining a list's members or a tensor's layout, use the syntax `*[ ... ]*` (e.g. _"nchw" means the input tensor has the layout *[batches, inputChannels, height, width]*_)
 
 
 ### Algorithms

--- a/index.bs
+++ b/index.bs
@@ -1443,15 +1443,15 @@ Both {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} and {{MLGraphBuilder}}.{{MLGr
 <dl dfn-type=dict-member dfn-for=MLBufferResourceView>
     : <dfn>resource</dfn>
     ::
-        A {{GPUBuffer}} object. Specifies the GPU buffer source.
+        The GPU buffer source.
 
     : <dfn>offset</dfn>
     ::
-        Specifies an {{unsigned long long}} offset in the buffer source.
+        The offset in the buffer source.
 
     : <dfn>size</dfn>
     ::
-        Specifies the {{unsigned long long}} size of the buffer view.
+        The size of the buffer view.
 </dl>
 
 <div class=internal-slots>
@@ -1495,15 +1495,15 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLArgMinMaxOptions>
     : <dfn>axes</dfn>
     ::
-        A sequence of {{unsigned long}}. The dimensions to reduce. The values in the sequence must be in the range [0, N-1] where N is the [=rank=] of the input tensor. If not present, all dimensions are reduced.
+        The dimensions to reduce. The values must be in the range [0, N-1] where N is the [=rank=] of the input tensor. If not present, all dimensions are reduced.
 
     : <dfn>keepDimensions</dfn>
     ::
-        A {{boolean}}. If true, retains reduced dimensions with [=list/size=] 1. The default value is false.
+        If true, retains reduced dimensions with [=list/size=] 1.
 
     : <dfn>selectLastIndex</dfn>
     ::
-        A {{boolean}}. If true, select the last index instead of the first found along the axes. The default value is false.
+        If true, select the last index instead of the first found along the axes.
 </dl>
 
 <div>
@@ -1579,23 +1579,23 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLBatchNormalizationOptions>
     : <dfn>scale</dfn>
     ::
-        An {{MLOperand}}. Specifies the 1-D tensor of the scaling values whose is equal to the size of the input dimension denoted by {{MLBatchNormalizationOptions/axis}}.
+        The 1-D tensor of the scaling values whose [=list/size=] is equal to the size of the input dimension denoted by {{MLBatchNormalizationOptions/axis}}.
 
     : <dfn>bias</dfn>
     ::
-        An {{MLOperand}}. Specifies the 1-D tensor of the bias values whose [=list/size=] is equal to the size of the input dimension denoted by {{MLBatchNormalizationOptions/axis}}.
+        The 1-D tensor of the bias values whose [=list/size=] is equal to the size of the input dimension denoted by {{MLBatchNormalizationOptions/axis}}.
 
     : <dfn>axis</dfn>
     ::
-        An {{unsigned long}} scalar. Specifies the index to the feature count dimension of the input shape for which the mean and variance values are. Its value must be in the range [0, N-1] where N is the [=rank=] of the input tensor. The default value is 1, corresponding to the channel (*"c"*) dimension in the {{MLInputOperandLayout/"nchw"}} data layout.
+        The index to the feature count dimension of the input shape for which the mean and variance values are. Its value must be in the range [0, N-1] where N is the [=rank=] of the input tensor. The default value is 1, corresponding to the channel (*"c"*) dimension in the {{MLInputOperandLayout/"nchw"}} data layout.
 
     : <dfn>epsilon</dfn>
     ::
-        A {{float}} scalar. Specifies A small value to prevent computational error due to divide-by-zero.
+        A small value to prevent computational error due to divide-by-zero.
 
     : <dfn>activation</dfn>
     ::
-        An {{MLActivation}} object. Specifies the optional activation function that immediately follows the normalization operation.
+        An optional activation function that immediately follows the normalization operation.
 </dl>
 
 <div>
@@ -2056,27 +2056,26 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLConv2dOptions>
     : <dfn>padding</dfn>
     ::
-        A sequence of {{unsigned long}} of length 4: [beginningHeight, endingHeight, beginningWidth, endingWidth].
+        A list of length 4: *[beginningHeight, endingHeight, beginningWidth, endingWidth]*.
         Specifies the additional rows and columns added to the beginning and ending of each spatial dimension of the convolution input.
         The default value is [0, 0, 0, 0].
 
     : <dfn>strides</dfn>
     ::
-        A sequence of {{unsigned long}} of length 2: [strideHeight, strideWidth].
+        A list of length 2: *[strideHeight, strideWidth]*.
         Specifies the stride of the sliding window for each spatial dimension of the convolution input.
         The default value is [1, 1].
 
     : <dfn>dilations</dfn>
     ::
-        A sequence of {{unsigned long}} of length 2: [dilationHeight, dilationWidth]. Specifies the dilation factor for each spatial dimension applied on the convolution filter (kernel).
+        A list of length 2: *[dilationHeight, dilationWidth]*. Specifies the dilation factor for each spatial dimension applied on the convolution filter (kernel).
         The default value is [1, 1].
 
     : <dfn>autoPad</dfn>
     ::
-        An {{MLAutoPad}} [=string=].
-        Specifies the automatic input padding options.
-        The default value is {{MLAutoPad/"explicit"}}, which means that the values in the {{MLConv2dOptions/padding}} array should be used for input padding.
-        When the option is set other than {{MLAutoPad/"explicit"}}, the values in the {{MLConv2dOptions/padding}} array are ignored.
+        The automatic input padding options.
+        The default value is {{MLAutoPad/"explicit"}}, which means that the values in {{MLConv2dOptions/padding}} should be used for input padding.
+        When the option is set other than {{MLAutoPad/"explicit"}}, the values in {{MLConv2dOptions/padding}} are ignored.
 
         With the {{MLAutoPad/"same-upper"}} option, the padding values are automatically computed such that the additional ending padding of the spatial input dimensions would allow all of the input values in the corresponding dimension to be filtered.
 
@@ -2084,13 +2083,10 @@ partial interface MLGraphBuilder {
 
     : <dfn>groups</dfn>
     ::
-        An {{unsigned long}} scalar.
-        Specifies the number of groups that input channels and output channels are divided into.
-        The default value is 1.
+        The number of groups that input channels and output channels are divided into.
 
     : <dfn>inputLayout</dfn>
     ::
-        An {{MLInputOperandLayout}} [=string=].
         Specifies the layout format of the input and output tensor as follows:
             - {{MLInputOperandLayout/"nchw"}}
                 - input tensor: *[batches, inputChannels, height, width]*
@@ -2098,27 +2094,22 @@ partial interface MLGraphBuilder {
             - {{MLInputOperandLayout/"nhwc"}}:
                 - input tensor: *[batches, height, width, inputChannels]*
                 - output tensor: *[batches, height, width, outputChannels]*
-        The default value is {{MLInputOperandLayout/"nchw"}}.
 
     : <dfn>filterLayout</dfn>
     ::
-          An {{MLConv2dFilterOperandLayout}} [=string=].
-          Specifies the layout format of the filter tensor as follow:
+          Specifies the layout format of the filter tensor as follows:
               - {{MLConv2dFilterOperandLayout/"oihw"}}: *[outputChannels, inputChannels/groups, height, width]*
               - {{MLConv2dFilterOperandLayout/"hwio"}}: *[height, width, inputChannels/groups, outputChannels]*
               - {{MLConv2dFilterOperandLayout/"ohwi"}}: *[outputChannels, height, width, inputChannels/groups]*
               - {{MLConv2dFilterOperandLayout/"ihwo"}}: *[inputChannels/groups, height, width, outputChannels]*
-          The default value is {{MLConv2dFilterOperandLayout/"oihw"}}.
 
     : <dfn>bias</dfn>
     ::
-          An {{MLOperand}} object.
-          Specifies the additional 1-D tensor with the shape of *[outputChannels]* whose values are to be added to the convolution result.
+          An additional 1-D tensor with the shape of *[outputChannels]* whose values are to be added to the convolution result.
 
     : <dfn>activation</dfn>
     ::
-            An {{MLActivation}} object.
-            Specifies the optional activation function that immediately follows the convolution operation.
+          An optional activation function that immediately follows the convolution operation.
 </dl>
 
 <div>
@@ -2217,44 +2208,42 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLConvTranspose2dOptions>
     : <dfn>padding</dfn>
     ::
-        A sequence of {{unsigned long}} of length 4: [beginningHeight, endingHeight, beginningWidth, endingWidth].
+        A list of length 4: *[beginningHeight, endingHeight, beginningWidth, endingWidth]*.
         Specifies the additional rows and columns added to the beginning and ending of each spatial dimension of the convolution input.
         The default value is [0, 0, 0, 0].
 
     : <dfn>strides</dfn>
     ::
-        A sequence of {{unsigned long}} of length 2: [strideHeight, strideWidth].
+        A list of length 2: *[strideHeight, strideWidth]*.
         Specifies the stride of the sliding window for each spatial dimension of the convolution input.
         The default value is [1, 1].
 
     : <dfn>dilations</dfn>
     ::
-        A sequence of {{unsigned long}} of length 2: [dilationHeight, dilationWidth]. Specifies the dilation factor for each spatial dimension applied on the convolution filter (kernel).
+        A list of length 2: *[dilationHeight, dilationWidth]*. Specifies the dilation factor for each spatial dimension applied on the convolution filter (kernel).
         The default value is [1, 1].
 
     : <dfn>outputPadding</dfn>
     ::
-        A sequence of {{unsigned long}} of length 2.
+        A list of length 2.
         Specifies the padding values applied to each spatial dimension of the output tensor. The explicit padding values are needed to disambiguate the output tensor shape for transposed convolution when the value of the *options*.{{MLConvTranspose2dOptions/strides}} is greater than 1.
 
         Note that these values are only used to disambiguate output shape when needed; it does not necessarily cause any padding value to be written to the output tensor.
 
-        The default values is [0, 0].
+        The default value is [0, 0].
 
     : <dfn>outputSizes</dfn>
     ::
-        A sequence of {{unsigned long}} of length 2.
+        A list of length 2.
         Specifies the sizes of the last two dimensions of the output tensor. When the output sizes are explicitly specified, the output padding values in {{MLConvTranspose2dOptions/outputPadding}} are ignored.
 
         If not specified, the output sizes are automatically computed.
 
     : <dfn>autoPad</dfn>
     ::
-        An {{MLAutoPad}} [=string=].
-        Specifies the automatic input padding options.
-        The default value is {{MLAutoPad/"explicit"}}, which means that the values in the {{MLConvTranspose2dOptions/padding}} array should be used for input padding.
-
-        When the option is set other than {{MLAutoPad/"explicit"}}, the values in the {{MLConvTranspose2dOptions/padding}} array are ignored.
+        The automatic input padding options.
+        The default value is {{MLAutoPad/"explicit"}}, which means that the values in {{MLConvTranspose2dOptions/padding}} should be used for input padding.
+        When the option is set other than {{MLAutoPad/"explicit"}}, the values in {{MLConvTranspose2dOptions/padding}} are ignored.
 
         With the {{MLAutoPad/"same-upper"}} option, the padding values are automatically computed such that the additional ending padding of the spatial input dimensions would allow all of the input values in the corresponding dimension to be filtered.
 
@@ -2262,13 +2251,10 @@ partial interface MLGraphBuilder {
 
     : <dfn>groups</dfn>
     ::
-        An {{unsigned long}} scalar.
-        Specifies the number of groups that input channels and output channels are divided into.
-        The default value is 1.
+        The number of groups that input channels and output channels are divided into.
 
     : <dfn>inputLayout</dfn>
     ::
-        An {{MLInputOperandLayout}} [=string=].
         Specifies the layout format of the input and output tensor as follows:
             - {{MLInputOperandLayout/"nchw"}}
                 - input tensor: *[batches, inputChannels, height, width]*
@@ -2276,26 +2262,21 @@ partial interface MLGraphBuilder {
             - {{MLInputOperandLayout/"nhwc"}}:
                 - input tensor: *[batches, height, width, inputChannels]*
                 - output tensor: *[batches, height, width, outputChannels]*
-        The default value is {{MLInputOperandLayout/"nchw"}}.
 
     : <dfn>filterLayout</dfn>
     ::
-        An {{MLConvTranspose2dFilterOperandLayout}} [=string=].
         Specifies the layout format of the filter tensor as follow:
-            - {{MLConvTranspose2dFilterOperandLayout/"iohw"}}: [inputChannels, outputChannels/groups, height, width]
-            - {{MLConvTranspose2dFilterOperandLayout/"hwoi"}}: [height, width, outputChannels/groups, inputChannels]
-            - {{MLConvTranspose2dFilterOperandLayout/"ohwi"}}: [outputChannels/groups, height, width, inputChannels]
-        The default value is {{MLConvTranspose2dFilterOperandLayout/"iohw"}}.
+            - {{MLConvTranspose2dFilterOperandLayout/"iohw"}}: *[inputChannels, outputChannels/groups, height, width]*
+            - {{MLConvTranspose2dFilterOperandLayout/"hwoi"}}: *[height, width, outputChannels/groups, inputChannels]*
+            - {{MLConvTranspose2dFilterOperandLayout/"ohwi"}}: *[outputChannels/groups, height, width, inputChannels]*
 
     : <dfn>bias</dfn>
     ::
-        An {{MLOperand}} object.
-        Specifies the additional 1-D tensor with the shape of *[outputChannels]* whose values are to be added to the convolution result.
+        An additional 1-D tensor with the shape of *[outputChannels]* whose values are to be added to the convolution result.
 
     : <dfn>activation</dfn>
     ::
-        An {{MLActivation}} object.
-        Specifies the optional activation function that immediately follows the convolution operation.
+        An optional activation function that immediately follows the convolution operation.
 </dl>
 
 <div>
@@ -2913,7 +2894,7 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLGatherOptions>
     : <dfn>axis</dfn>
     ::
-        An {{unsigned long}} scalar specifying the axis along which the gathered values are obtained. Its value must be in the range [0, N-1] where N is the [=rank=] of the input tensor.
+        The axis along which the gathered values are obtained. Its value must be in the range [0, N-1] where N is the [=rank=] of the input tensor.
 </dl>
 
 <div>
@@ -3048,23 +3029,23 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLGemmOptions>
     : <dfn>c</dfn>
     ::
-        An {{MLOperand}}. Specifies the third input tensor. It is either a scalar, or of the shape that is unidirectionally broadcastable to the shape [M, N] according to [[!numpy-broadcasting-rule]]. When it is not specified, the computation is done as if *c* is a scalar 0.0.
+        The third input tensor. It is either a scalar, or of the shape that is unidirectionally broadcastable to the shape [M, N] according to [[!numpy-broadcasting-rule]]. When it is not specified, the computation is done as if *c* is a scalar 0.0.
 
     : <dfn>alpha</dfn>
     ::
-        A {{float}} scalar multiplier for the first input.
+        A multiplier for the first input.
 
     : <dfn>beta</dfn>
     ::
-        A {{float}} scalar multiplier for the third input {{MLGemmOptions/c}}.
+        A multiplier for the third input {{MLGemmOptions/c}}.
 
     : <dfn>aTranspose</dfn>
     ::
-        A {{boolean}} indicating if the first input should be transposed prior to calculating the output.
+        Indicates if the first input should be transposed prior to calculating the output.
 
     : <dfn>bTranspose</dfn>
     ::
-        A {{boolean}} indicating if the second input should be transposed prior to calculating the output.
+        Indicates if the second input should be transposed prior to calculating the output.
 </dl>
 
 <div>
@@ -3162,37 +3143,36 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLGruOptions>
     : <dfn>bias</dfn>
     ::
-        An {{MLOperand}}. Specifies the 2-D input bias tensor of shape [numDirections, 3 * hiddenSize]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to the {{MLGruOptions/layout}} argument.
+        The 2-D input bias tensor of shape *[numDirections, 3 * hiddenSize]*. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to the {{MLGruOptions/layout}} argument.
 
     : <dfn>recurrentBias</dfn>
     ::
-        An {{MLOperand}}. Specifies the 2-D recurrent bias tensor of shape [numDirections, 3 * hiddenSize]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to the {{MLGruOptions/layout}} argument.
+        The 2-D recurrent bias tensor of shape *[numDirections, 3 * hiddenSize]*. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to the {{MLGruOptions/layout}} argument.
 
     : <dfn>initialHiddenState</dfn>
     ::
-        An {{MLOperand}}. The 3-D initial hidden state tensor of shape [numDirections, batchSize, hiddenSize].
+        The 3-D initial hidden state tensor of shape *[numDirections, batchSize, hiddenSize]*.
         When not specified, implementations SHOULD use a tensor filled with zero.
 
     : <dfn>resetAfter</dfn>
     ::
-        A {{boolean}} indicating whether to apply the reset gate after or before matrix multiplication. The default value is true.
+        Indicates whether to apply the reset gate after or before matrix multiplication.
 
     : <dfn>returnSequence</dfn>
     ::
-        A {{boolean}} indicating whether to also return the entire sequence with every output from each time step in it in addition to the output of the last time step.
-        The default value is false.
+        Indicates whether to also return the entire sequence with every output from each time step in it in addition to the output of the last time step.
 
     : <dfn>direction</dfn>
     ::
-        An {{MLRecurrentNetworkDirection}}. Specifies the processing direction of the input sequence. When set to {{MLRecurrentNetworkDirection/"both"}}, the size of the first dimension of the weight and the bias tensor shapes must be 2, and the input is processed in both directions.
+        The processing direction of the input sequence. When set to {{MLRecurrentNetworkDirection/"both"}}, the size of the first dimension of the weight and the bias tensor shapes must be 2, and the input is processed in both directions.
 
     : <dfn>layout</dfn>
     ::
-        An {{MLGruWeightLayout}}. The ordering of the weight and bias vectors for the internal gates of GRU, specifically the `update (z)`, `reset (r)`, and `new (n)` gate, as indicated in the second dimension of the weight and bias tensor shape. When not specified, the default layout is {{MLGruWeightLayout/"zrn"}}.
+        The ordering of the weight and bias vectors for the internal gates of GRU, specifically the `update (z)`, `reset (r)`, and `new (n)` gate, as indicated in the second dimension of the weight and bias tensor shape.
 
     : <dfn>activations</dfn>
     ::
-        A sequence of {{MLActivation}}. Specifies a pair of activation functions with the first function used for the update and reset gate, and the second used for the new gate. When not specified, implementations SHOULD use the the pair of sigmoid ("sigmoid") and the hyperbolic tangent ("tanh") functions, respectively.
+        Specifies a pair of activation functions with the first function used for the update and reset gate, and the second used for the new gate. When not specified, implementations SHOULD use the the pair of sigmoid ("sigmoid") and the hyperbolic tangent ("tanh") functions, respectively.
 </dl>
 
 <div>
@@ -3324,23 +3304,23 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLGruCellOptions>
     : <dfn>bias</dfn>
     ::
-        An {{MLOperand}}. Specifies the 1-D input bias tensor of shape [3 * hiddenSize]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to the {{MLGruOptions/layout}} argument.
+        The 1-D input bias tensor of shape [3 * hiddenSize]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to the {{MLGruOptions/layout}} argument.
 
     : <dfn>recurrentBias</dfn>
     ::
-        An {{MLOperand}}. Specifies the 1-D recurrent bias tensor of shape [3 * hiddenSize]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to the {{MLGruOptions/layout}} argument.
+        The 1-D recurrent bias tensor of shape [3 * hiddenSize]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to the {{MLGruOptions/layout}} argument.
 
     : <dfn>resetAfter</dfn>
     ::
-        A {{boolean}} indicating whether to apply the reset gate after or before matrix multiplication. The default value is true.
+        Indicates whether to apply the reset gate after or before matrix multiplication.
 
     : <dfn>layout</dfn>
     ::
-        An {{MLGruWeightLayout}}. The ordering of the weight and bias vectors for the internal gates of GRU, specifically the `update (z)`, `reset (r)`, and `new (n)` gate, as indicated in the second dimension of the weight and bias tensor shape. When not specified, the default layout is {{MLGruWeightLayout/"zrn"}}.
+        The ordering of the weight and bias vectors for the internal gates of GRU, specifically the `update (z)`, `reset (r)`, and `new (n)` gate, as indicated in the second dimension of the weight and bias tensor shape.
 
     : <dfn>activations</dfn>
     ::
-        A sequence of {{MLActivation}}. Specifies a pair of activation functions with the first function used for the update and reset gate, and the second used for the new gate. When not specified, implementations SHOULD use the the pair of sigmoid ("sigmoid") and the hyperbolic tangent ("tanh") functions, respectively.
+        Specifies a pair of activation functions with the first function used for the update and reset gate, and the second used for the new gate. When not specified, implementations SHOULD use the the pair of sigmoid ("sigmoid") and the hyperbolic tangent ("tanh") functions, respectively.
 </dl>
 
 <div>
@@ -3524,12 +3504,10 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLHardSigmoidOptions>
     : <dfn>alpha</dfn>
     ::
-         A {{float}} scalar multiplier.
-         The default value is 0.2.
+         A scalar multiplier.
     : <dfn>beta</dfn>
     ::
-         A {{float}} scalar addition.
-         The default value is 0.5.
+         A scalar addition.
 </dl>
 
 #### {{MLGraphBuilder/hardSigmoid(input, options)}} #### {#api-mlgraphbuilder-hardsigmoid-input-options}
@@ -3712,23 +3690,23 @@ partial interface MLGraphBuilder {
 };
 </script>
 
-The {{MLInstanceNormalizationOptions}} members are:
+{{MLInstanceNormalizationOptions}} has the following members:
 <dl dfn-type=dict-member dfn-for=MLInstanceNormalizationOptions>
     : <dfn>scale</dfn>
     ::
-        An {{MLOperand}}. Specifies the 1-D tensor of the scaling values whose [=list/size=] is equal to the number of channels, i.e. the size of the feature dimension of the input. For example, for an |input| tensor with `nchw` layout, the [=list/size=] is equal to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1].
+        The 1-D tensor of the scaling values whose [=list/size=] is equal to the number of channels, i.e. the size of the feature dimension of the input. For example, for an |input| tensor with `nchw` layout, the [=list/size=] is equal to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1].
 
     : <dfn>bias</dfn>
     ::
-        An {{MLOperand}}. Specifies the 1-D tensor of the bias values whose [=list/size=] is equal to the size of the feature dimension of the input. For example, for an |input| tensor with `nchw` layout, the [=list/size=] is equal to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1].
+        The 1-D tensor of the bias values whose [=list/size=] is equal to the size of the feature dimension of the input. For example, for an |input| tensor with `nchw` layout, the [=list/size=] is equal to |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[1].
 
     : <dfn>epsilon</dfn>
     ::
-        A {{float}} scalar. Specifies a small value to prevent computational error due to divide-by-zero.
+        A small value to prevent computational error due to divide-by-zero.
 
     : <dfn>layout</dfn>
     ::
-        An {{MLInputOperandLayout}}. Specifies the layout format of the input.
+        The layout format of the input.
 
 </dl>
 
@@ -3813,23 +3791,23 @@ partial interface MLGraphBuilder {
 };
 </script>
 
-The {{MLLayerNormalizationOptions}} members are:
+{{MLLayerNormalizationOptions}} has the following members:
 <dl dfn-type=dict-member dfn-for=MLLayerNormalizationOptions>
     : <dfn>scale</dfn>
     ::
-        An {{MLOperand}}. Specifies the N-D tensor of the scaling values whose shape is determined by the |axes| member in that each value in |axes| indicates the dimension of the input tensor with scaling values. For example, for an |axes| values of [1,2,3], the shape of this tensor is the list of the corresponding sizes of the input dimension 1, 2 and 3. When this member is not present, the scaling value is assumed to be 1.
+        The N-D tensor of the scaling values whose shape is determined by the |axes| member in that each value in |axes| indicates the dimension of the input tensor with scaling values. For example, for an |axes| values of [1,2,3], the shape of this tensor is the list of the corresponding sizes of the input dimension 1, 2 and 3. When this member is not present, the scaling value is assumed to be 1.
 
     : <dfn>bias</dfn>
     ::
-        An {{MLOperand}}. Specifies the N-D tensor of the bias values whose shape is determined by the |axes| member in that each value in |axes| indicates the dimension of the input tensor with bias values. For example, for an |axes| values of [1,2,3], the shape of this tensor is the list of the corresponding sizes of the input dimension 1, 2 and 3. When this member is not present, the bias value is assumed to be 0.
+        The N-D tensor of the bias values whose shape is determined by the |axes| member in that each value in |axes| indicates the dimension of the input tensor with bias values. For example, for an |axes| values of [1,2,3], the shape of this tensor is the list of the corresponding sizes of the input dimension 1, 2 and 3. When this member is not present, the bias value is assumed to be 0.
 
     : <dfn>axes</dfn>
     ::  
-        A sequence of {{unsigned long}}. The indices to the input dimensions to reduce. When this member is not present, it is assumed to be [1,2,3] that is, the reduction for the mean and variance values are calculated across all the input features for each individual sample in the batch.
+        The indices to the input dimensions to reduce. When this member is not present, it is assumed to be [1,2,3] that is, the reduction for the mean and variance values are calculated across all the input features for each individual sample in the batch.
 
     : <dfn>epsilon</dfn>
     ::
-        A {{float}} scalar. Specifies a small value to prevent computational error due to divide-by-zero.
+        A small value to prevent computational error due to divide-by-zero.
 </dl>
 
 <div>
@@ -3934,8 +3912,7 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLLeakyReluOptions>
     : <dfn>alpha</dfn>
     ::
-         A {{float}} scalar multiplier.
-         The default value is 0.01.
+         A scalar multiplier.
 </dl>
 
 #### {{MLGraphBuilder/leakyRelu(input, options)}} #### {#api-mlgraphbuilder-leaky-relu-input-options}
@@ -4023,12 +4000,10 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLLinearOptions>
     : <dfn>alpha</dfn>
     ::
-         A {{float}} scalar multiplier.
-         The default value is 1.
+         A scalar multiplier.
     : <dfn>beta</dfn>
     ::
-         A {{float}} scalar addition.
-         The default value is 0.
+         A scalar addition.
 </dl>
 
 #### {{MLGraphBuilder/linear(input, options)}} #### {#api-mlgraphbuilder-linear-input-options}
@@ -4112,39 +4087,39 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLLstmOptions>
     : <dfn>bias</dfn>
     ::
-        An {{MLOperand}}. Specifies the 2-D input bias tensor of shape [numDirections, 4 * hiddenSize]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to {{MLLstmOptions/layout}}.
+        The 2-D input bias tensor of shape [numDirections, 4 * hiddenSize]. The ordering of the bias vectors in the second dimension of the tensor shape is specified according to {{MLLstmOptions/layout}}.
 
     : <dfn>recurrentBias</dfn>
     ::
-        An {{MLOperand}}. Specifies the 2-D recurrent bias tensor of shape [numDirections, 4 * hiddenSize]. The ordering of the bias vectors in the first dimension of the tensor shape is specified according to {{MLLstmOptions/layout}}.
+        The 2-D recurrent bias tensor of shape [numDirections, 4 * hiddenSize]. The ordering of the bias vectors in the first dimension of the tensor shape is specified according to {{MLLstmOptions/layout}}.
 
     : <dfn>peepholeWeight</dfn>
     ::
-        An {{MLOperand}}. Specifies the 2-D weight tensor for peepholes of shape [numDirections, 3 * hiddenSize]. The pack ordering of the weight vectors is for the `input (i)`, `output (o)`, and `forget (f)` gate, respectively.
+        The 2-D weight tensor for peepholes of shape [numDirections, 3 * hiddenSize]. The pack ordering of the weight vectors is for the `input (i)`, `output (o)`, and `forget (f)` gate, respectively.
 
     : <dfn>initialHiddenState</dfn>
     ::
-        An {{MLOperand}}. Specifies the 3-D initial hidden state tensor of shape [numDirections, batchSize, hiddenSize]. When not specified, implementations SHOULD use a tensor filled with zero.
+        The 3-D initial hidden state tensor of shape [numDirections, batchSize, hiddenSize]. When not specified, implementations SHOULD use a tensor filled with zero.
 
     : <dfn>initialCellState</dfn>
     ::
-        An {{MLOperand}}. Specifies the 3-D initial hidden state tensor of shape [numDirections, batchSize, hiddenSize]. When not specified, implementations SHOULD use a tensor filled with zero.
+        The 3-D initial hidden state tensor of shape [numDirections, batchSize, hiddenSize]. When not specified, implementations SHOULD use a tensor filled with zero.
 
     : <dfn>returnSequence</dfn>
     ::
-         A {{boolean}} indicating whether to also return the entire sequence with every output from each time step in it in addition to the output of the last time step.
+         Indicates whether to also return the entire sequence with every output from each time step in it in addition to the output of the last time step.
 
     : <dfn>direction</dfn>
     ::
-        An {{MLRecurrentNetworkDirection}}. Specifies the processing direction of the input sequence. When set to {{MLRecurrentNetworkDirection/"both"}}, the size of the first dimension of the weight and the bias tensor shapes must be 2, and the input is processed in both directions.
+        The processing direction of the input sequence. When set to {{MLRecurrentNetworkDirection/"both"}}, the size of the first dimension of the weight and the bias tensor shapes must be 2, and the input is processed in both directions.
 
     : <dfn>layout</dfn>
     ::
-        An {{MLLstmWeightLayout}}. The ordering of the weight and bias vectors for the internal gates of LSTM, specifically the `input (i)`, `output (o)`, `forget (f)`, and `cell (g)` gate, as indicated in the first dimension of the weight and bias tensor shapes. When not specified, the default layout is {{MLLstmWeightLayout/"iofg"}}.
+        The ordering of the weight and bias vectors for the internal gates of LSTM, specifically the `input (i)`, `output (o)`, `forget (f)`, and `cell (g)` gate, as indicated in the first dimension of the weight and bias tensor shapes.
 
     : <dfn>activations</dfn>
     ::
-        A sequence of {{MLActivation}}. A sequence of three activation functions, the first one is used for the `input (i)`, `forget (f)`, and `output (o)` gate, the second one is used for the `cell (g)` gate, and the last used for filtering the output cell state before combining it with the result of the output gate to form the output hidden state. When not specified, implementations SHOULD use the sequence of the sigmoid function ("sigmoid") followed by two hyperbolic tangent functions ("tanh") respectively.
+        A list of three activation functions, the first one is used for the `input (i)`, `forget (f)`, and `output (o)` gate, the second one is used for the `cell (g)` gate, and the last used for filtering the output cell state before combining it with the result of the output gate to form the output hidden state. When not specified, implementations SHOULD use the sequence of the sigmoid function ("sigmoid") followed by two hyperbolic tangent functions ("tanh") respectively.
 </dl>
 
 <div>
@@ -4325,23 +4300,23 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLLstmCellOptions>
     : <dfn>bias</dfn>
     ::
-        An {{MLOperand}}. The 1-D input bias tensor of shape [4 * hiddenSize]. The ordering of the bias vectors in the first dimension of the tensor shape is specified according to the {{MLLstmCellOptions/layout}} argument.
+        The 1-D input bias tensor of shape [4 * hiddenSize]. The ordering of the bias vectors in the first dimension of the tensor shape is specified according to the {{MLLstmCellOptions/layout}} argument.
 
     : <dfn>recurrentBias</dfn>
     ::
-        An {{MLOperand}}. The 1-D recurrent bias tensor of shape [4 * hiddenSize]. The ordering of the bias vectors in the first dimension of the tensor shape is specified according to the {{MLLstmCellOptions/layout}} argument.
+        The 1-D recurrent bias tensor of shape [4 * hiddenSize]. The ordering of the bias vectors in the first dimension of the tensor shape is specified according to the {{MLLstmCellOptions/layout}} argument.
 
     : <dfn>peepholeWeight</dfn>
     ::
-        An {{MLOperand}}. The 1-D weight tensor for peepholes of shape [3 * hiddenSize]. The pack ordering of the weight vectors is for the `input (i)`, `output (o)`, and `forget (f)` gate, respectively.
+        The 1-D weight tensor for peepholes of shape [3 * hiddenSize]. The pack ordering of the weight vectors is for the `input (i)`, `output (o)`, and `forget (f)` gate, respectively.
 
     : <dfn>layout</dfn>
     ::
-        An {{MLLstmWeightLayout}}. The ordering of the weight and bias vectors for the internal gates of LSTM, specifically the `input (i)`, `output (o)`, `forget (f)`, and `cell (g)` gate, as indicated in the first dimension of the weight and bias tensor shapes. When not specified, the default layout is {{MLLstmWeightLayout/"iofg"}}.
+        The ordering of the weight and bias vectors for the internal gates of LSTM, specifically the `input (i)`, `output (o)`, `forget (f)`, and `cell (g)` gate, as indicated in the first dimension of the weight and bias tensor shapes.
 
     : <dfn>activations</dfn>
     ::
-        A sequence of {{MLActivation}}. A sequence of three activation functions, the first one is used for the `input (i)`, `forget (f)`, and `output (o)` gate, the second one is used for the `cell (g)` gate, and the last used for filtering the output cell state before combining it with the result of the output gate to form the output hidden state. When not specified, they are assumed to be of the sigmoid function ("sigmoid") followed by two hyperbolic tangent functions ("tanh") respectively.
+        A list of three activation functions, the first one is used for the `input (i)`, `forget (f)`, and `output (o)` gate, the second one is used for the `cell (g)` gate, and the last used for filtering the output cell state before combining it with the result of the output gate to form the output hidden state. When not specified, they are assumed to be of the sigmoid function ("sigmoid") followed by two hyperbolic tangent functions ("tanh") respectively.
 </dl>
 
 <div>
@@ -4606,15 +4581,11 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLPadOptions>
     : <dfn>mode</dfn>
     ::
-        An {{MLPaddingMode}} [=string=].
-        Specifies the different ways to pad the tensor.
-        The default value is {{MLPaddingMode/"constant"}}.
+        The different ways to pad the tensor.
 
     : <dfn>value</dfn>
     ::
-        A {{float}}.
-        Specifies the padding value when {{MLPadOptions/mode}} is set to {{MLPaddingMode/"constant"}}.
-        The default value is 0.
+        The padding value when {{MLPadOptions/mode}} is set to {{MLPaddingMode/"constant"}}.
 </dl>
 
 <div>
@@ -4738,33 +4709,32 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLPool2dOptions>
     : <dfn>windowDimensions</dfn>
     ::
-         A sequence of {{unsigned long}} of length 2: [windowHeight, windowWidth].
+         A list of length 2: *[windowHeight, windowWidth]*.
          Specifies the dimensions of the sliding window.
          The default value for the window dimensions are the height and width dimensions of the input shape.
 
     : <dfn>padding</dfn>
     ::
-        A sequence of {{unsigned long}} of length 4: [beginningHeight, endingHeight, beginningWidth, endingWidth].
+        A list of length 4: *[beginningHeight, endingHeight, beginningWidth, endingWidth]*.
         Specifies the additional rows and columns added to the beginning and ending of each spatial dimension of the convolution input.
         The default value is [0,0,0,0].
 
     : <dfn>strides</dfn>
     ::
-        A sequence of {{unsigned long}} of length 2: [strideHeight, strideWidth].
+        A list of length 2: *[strideHeight, strideWidth]*.
         Specifies the stride of the sliding window for each spatial dimension of the convolution input.
         The default value is [1,1].
 
     : <dfn>dilations</dfn>
     ::
-        A sequence of {{unsigned long}} of length 2: [dilationHeight, dilationWidth]. Specifies the dilation factor for each spatial dimension applied on the convolution filter (kernel).
+        A list of length 2: *[dilationHeight, dilationWidth]*. Specifies the dilation factor for each spatial dimension applied on the convolution filter (kernel).
         The default value is [1,1].
 
     : <dfn>autoPad</dfn>
     ::
-        An {{MLAutoPad}} [=string=].
-        Specifies the automatic input padding options.
-        The default value is {{MLAutoPad/"explicit"}}, which means that the values in the {{MLPool2dOptions/padding}} array should be used for input padding.
-        When the option is set other than {{MLAutoPad/"explicit"}}, the values in the {{MLPool2dOptions/padding}} array are ignored.
+        The automatic input padding options.
+        The default value is {{MLAutoPad/"explicit"}}, which means that the values in {{MLPool2dOptions/padding}} should be used for input padding.
+        When the option is set other than {{MLAutoPad/"explicit"}}, the values in {{MLPool2dOptions/padding}} are ignored.
 
         With the {{MLAutoPad/"same-upper"}} option, the padding values are automatically computed such that the additional ending padding of the spatial input dimensions would allow all of the input values in the corresponding dimension to be filtered.
 
@@ -4772,7 +4742,6 @@ partial interface MLGraphBuilder {
 
     : <dfn>layout</dfn>
     ::
-        An {{MLInputOperandLayout}} [=string=].
         Specifies the layout format of the input and output tensor as follows:
             - {{MLInputOperandLayout/"nchw"}}
                 - input tensor: *[batches, inputChannels, height, width]*
@@ -4780,16 +4749,14 @@ partial interface MLGraphBuilder {
             - {{MLInputOperandLayout/"nhwc"}}:
                 - input tensor: *[batches, height, width, inputChannels]*
                 - output tensor: *[batches, height, width, outputChannels]*
-        The default value is {{MLInputOperandLayout/"nchw"}}.
 
     : <dfn>roundingType</dfn>
     ::
-        An {{MLRoundingType}} [=string=].
-        Specifies the rounding function used to compute the output shape.
+        The rounding function used to compute the output shape.
 
     : <dfn>outputSizes</dfn>
     ::
-        A sequence of {{unsigned long}} of length 2.
+        A list of length 2.
         Specifies the sizes of the two spacial dimensions of the output tensor. When the output sizes are explicitly specified, the {{MLPool2dOptions/roundingType}} is ignored.
 
         If not specified, the output sizes are automatically computed.
@@ -4972,11 +4939,11 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLReduceOptions>
     : <dfn>axes</dfn>
     ::
-        A sequence of {{unsigned long}}. The dimensions to reduce. The values in the sequence must be in the range [0, N-1] where N is the [=rank=] of the input tensor. If not present, all dimensions are reduced.
+        The dimensions to reduce. The values in the list must be in the range [0, N-1] where N is the [=rank=] of the input tensor. If not present, all dimensions are reduced.
 
     : <dfn>keepDimensions</dfn>
     ::
-        A {{boolean}}. If true, retains reduced dimensions with [=list/size=] 1. The default value is false.
+        If true, retains reduced dimensions with [=list/size=] 1.
 </dl>
 
 <div>
@@ -5203,24 +5170,22 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLResample2dOptions>
     : <dfn>mode</dfn>
     ::
-        An {{MLInterpolationMode}} [=string=].
-        Specifies the interpolation algorithm used to fill the output tensor values.
-        The default value is {{MLInterpolationMode/"nearest-neighbor"}}, standing for *Nearest Neighbor* interpolation.
+        The interpolation algorithm used to fill the output tensor values.
 
     : <dfn>scales</dfn>
     ::
-        A sequence of {{float}} of length 2.
-        Specifies the scaling factor in each spatial dimensions of the input: [scaleHeight, scaleWidth].
+        A list of length 2.
+        Specifies the scaling factor in each spatial dimensions of the input: *[scaleHeight, scaleWidth]*.
         The default value is [1.0, 1.0].
 
     : <dfn>sizes</dfn>
     ::
-        A sequence of {{unsigned long}} of length 2.
-        Specifies the target sizes for each spatial dimensions of the input: [sizeHeight, sizeWidth]. When the target sizes are specified, the {{MLResample2dOptions/scales}} argument is ignored, since the scaling factor values are derived from the target sizes of each spatial dimension of the input.
+        A list of length 2.
+        Specifies the target sizes for each spatial dimensions of the input: *[sizeHeight, sizeWidth]*. When the target sizes are specified, the {{MLResample2dOptions/scales}} argument is ignored, since the scaling factor values are derived from the target sizes of each spatial dimension of the input.
 
     : <dfn>axes</dfn>
     ::
-        A sequence of {{unsigned long}} of length 2.
+        A list of length 2.
         Specifies the two consecutive dimensions of the input tensor to which the interpolation algorithm applies. The valid values in the sequence are [0, 1], [1, 2] or [2, 3].
         The default value is [2, 3].
 </dl>
@@ -5586,8 +5551,7 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLSoftplusOptions>
     : <dfn>steepness</dfn>
     ::
-         A {{float}} scalar parameter.
-         The default value is 1.
+         A scalar parameter.
 </dl>
 
 #### {{MLGraphBuilder/softplus(input, options)}} #### {#api-mlgraphbuilder-softplus-input-options}
@@ -5738,8 +5702,7 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLSplitOptions>
     : <dfn>axis</dfn>
     ::
-        An {{unsigned long}} scalar. The dimension along which to split. Its value must be in the range [0, N-1] where N is the [=rank=] of the input tensor.
-        The default value is 0.
+        The dimension along which to split. Its value must be in the range [0, N-1] where N is the [=rank=] of the input tensor.
 </dl>
 
 <details open algorithm>
@@ -5876,8 +5839,7 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLTransposeOptions>
     : <dfn>permutation</dfn>
     ::
-        A sequence of {{unsigned long}} values.
-        Specifies the values used to permute the output shape.
+        The values used to permute the output shape.
         The default value is [N-1, ..., 0], where N is the [=rank=] of the input tensor, e.g. [2,1,0] for a 3-D tensor.
         These default values cause the output to become a transposed tensor of the input. When specified, the number of values in the sequence must be the same as the [=rank=] of the input tensor, and the values in the sequence must be within the range from 0 to N-1 with no two or more same values found in the sequence.
 </dl>
@@ -5931,10 +5893,10 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLTriangularOptions>
     : <dfn>upper</dfn>
     ::
-        A {{boolean}} value. Indicate whether the output the upper or the lower part of the input matrix is retained. If not set, it is assumed to be true, indicating that the upper part is retained.
+        Indicates whether the output the upper or the lower part of the input matrix is retained. True indicates that the upper part is retained.
     : <dfn>diagonal</dfn>
     ::
-        A {{long}} value. Specify how many diagonals above or below the main diagonals of the input matrix are retained or excluded. If not set, this value is assumed to be 0, which means no diagonals other than the main diagonals are affected. 
+        Specifies how many diagonals above or below the main diagonals of the input matrix are retained or excluded. A value of 0 means no diagonals other than the main diagonals are affected.
 </dl>
 
 <div>


### PR DESCRIPTION
Bikeshed automatically annotates dictionary members with types and defaults, so repeating that in the prose is extra work and extra noise. Remove both and reword as needed. For #483

Also:

- Simplify text by removing "Specifies" from most definition prose.
- Replace "sequence" with "list" in prose.
- Consistently give list member definitions using `*[ ... ]*` styling.
- Document the above in coding conventions.

This probably merits some discussion, so uploading early for comments.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/526.html" title="Last updated on Feb 4, 2024, 4:54 PM UTC (1a340fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/526/7ec2e18...inexorabletash:1a340fd.html" title="Last updated on Feb 4, 2024, 4:54 PM UTC (1a340fd)">Diff</a>