### PR TITLE
Bug fix: Correct linking for list/range iterations

### DIFF
--- a/SpecCodingConventions.md
+++ b/SpecCodingConventions.md
@@ -89,6 +89,8 @@ Example:
 * Use the most specific types possible (e.g. MLOperand, not generic object).
 * Use `[=this=]` to refer to the current object.
 * Use `[=map/For each=] |key| → |value| of |map|` when iterating over a map, but use more specific terms for the key and value (e.g. _For each name → input of inputs:_)
+* Use `[=list/For each=] |item| of |list|` when iterating over a list, but use more specific terms for the item (e.g. _For each dimension of dimensions:_)
+* Use `[=list/For each=] |index| in [=the range=] X to Y, inclusive` when iterating over a numeric range; a range is implicitly an ordered set which is a type of list. Specify _inclusive_ or _exclusive_ regarding the upper bound, for clarity.
 * Use "let" to introduce a variable and "set" to update a variable or assign to a property.
 * Use « » notation for literal lists, which helps make it clear that they are not JavaScript arrays.
 

--- a/index.bs
+++ b/index.bs
@@ -1866,11 +1866,11 @@ partial interface MLGraphBuilder {
         1. Let |desc| be |inputs|[0].{{MLOperand/[[descriptor]]}}.
         1. If |axis| is greater than or equal to the [=rank=] of |desc|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Set |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] to 0.
-        1. [=map/For each=] |index| in [=the range=] 0 to the [=rank=] of |inputs|, exclusive:
+        1. [=list/For each=] |index| in [=the range=] 0 to the [=rank=] of |inputs|, exclusive:
             1. Let |input| be |inputs|[|index|].
             1. If [=validating MLOperand=] given |input| and [=this=] returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
             1. If |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}} is not equal to |inputs|[0].{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dataType}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-            1. [=map/For each=] |dim| in [=the range=] 0 to the [=rank=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, exclusive:
+            1. [=list/For each=] |dim| in [=the range=] 0 to the [=rank=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, exclusive:
                 <div class="note">
                     If the shape of each corresponding dimension and type of the operands, except for those of the dimension given by |axis|, is not the same, fail.
                 </div>
@@ -1996,7 +1996,7 @@ Data truncation will occur when the values in the range exceed the range of the 
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform memory buffer the size of |size| multiplied by sizeof(|descriptor|.{{MLOperandDescriptor/dataType}}).
             2. Store the beginning address to that memory buffer as a pointer |buffer| of the corresponding data type.
-        1. [=map/For each=] |index| in [=the range=] 0 to |size|, exclusive:
+        1. [=list/For each=] |index| in [=the range=] 0 to |size|, exclusive:
             1. Set |buffer|[|index|] to |start| + (|index| * |step|).
         1. Make a request to the underlying platform to:
             1. Create an [=implementation-defined=] platform operand |constantImpl| to represent a constant operand, given |descriptor|.
@@ -2880,7 +2880,7 @@ partial interface MLGraphBuilder {
         1. Let |inputDesc| be |input|.{{MLOperand/[[descriptor]]}}.
         1. If the sequence length of |newShape| is not equal to the [=rank=] of |inputDesc|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Let |outputDesc| be a copy of |inputDesc|.
-        1. [=map/For each=] |index| in [=the range=] 0 to the [=rank=] of |input|, exclusive:
+        1. [=list/For each=] |index| in [=the range=] 0 to the [=rank=] of |input|, exclusive:
             1. Let |size| be the |input|.{{MLOperand/shape()}}[|index|].
             1. If |size| is not equal to 1 and not equal to |newShape|[index], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
             1. If |size| is equal to 1, then let |outputDesc|.{{MLOperandDescriptor/dimensions}}[|index|] be |newShape|[|index|].
@@ -3864,7 +3864,7 @@ The {{MLLayerNormalizationOptions}} members are:
     1. If the [=rank=] of |options|.{{MLLayerNormalizationOptions/scale}} is not equal to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=Assert=]: the type of |options|.{{MLLayerNormalizationOptions/bias}} is  {{MLOperand}}.
     1. If the [=rank=] of |options|.{{MLLayerNormalizationOptions/bias}} is not equal to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. [=map/For each=] |index| in [=the range=] 0 to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, exclusive:
+    1. [=list/For each=] |index| in [=the range=] 0 to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, exclusive:
         1. Let |axis| be |options|.{{MLLayerNormalizationOptions/axes}}[|index|].
         1. If |axis| is greater or equal to the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. Let |size| be |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}}[|axis|].
@@ -4579,7 +4579,7 @@ partial interface MLGraphBuilder {
     1. If |sizeB| is 1 and |sizeA| is not, then append 1 to |shapeB| to become [ |shapeB| | 1 ] and let |sizeB| be 2.
     1. If |shapeA|[|sizeA| - 1] is not equal to |shapeB|[0], then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
     1. Let |shape| be an array whose size |size| is the maximum of |sizeA| and |sizeB|.
-    1. [=map/For each=] |index| in [=the range=] 0 to |size|, exclusive:
+    1. [=list/For each=] |index| in [=the range=] 0 to |size|, exclusive:
         1. Set |shape|[|index|] to the maximum of |shapeA|[|index|] and |shapeB|[|index|].
     1. Return |shape|.
   </div>
@@ -6302,7 +6302,7 @@ dictionary MLOperandDescriptor {
   </summary>
   <div class=algorithm-steps>
     1. Let |elementLength| be 1.
-    1. [=map/For each=] |dimension| of |desc|.{{MLOperandDescriptor/dimensions}}:
+    1. [=list/For each=] |dimension| of |desc|.{{MLOperandDescriptor/dimensions}}:
         1. Set |elementLength| to |elementLength| × |dimension|.
     1. Let |elementSize| be the [=element size=] of one of the {{ArrayBufferView}} types that matches |desc|.{{MLOperandDescriptor/dataType}} according to [this table](#appendices-mloperanddatatype-arraybufferview-compatibility).
     1. Return |elementLength| × |elementSize|.


### PR DESCRIPTION
Some uses of "for each" in algorithms were linking to the map iteration definition in Infra. Fix this to point at the list iteration definition. Today I learned: this applies to iteration over ranges too!

Also updated coding conventions to cover these cases.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/527.html" title="Last updated on Jan 24, 2024, 8:07 PM UTC (dd5f9a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/527/fa91851...inexorabletash:dd5f9a0.html" title="Last updated on Jan 24, 2024, 8:07 PM UTC (dd5f9a0)">Diff</a>