### PR TITLE
Meta: Add a gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/index.html


### PR DESCRIPTION
`make` generates an `index.html` file which should not be uploaded to the repo

In another spec I worked on, this [resulted in the `index.html` file accidentally being uploaded](https://github.com/WICG/file-system-access/pull/398) (and no one noticed for a while, whoops). It would be nice to avoid that outcome here :)