### PR TITLE
Wording change: Define power prefs & device type using WebIDL enums

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -831,12 +831,12 @@ Its <a>default allowlist</a> is <code>'self'</code>.
     1. Let |context| be a new {{MLContext}} object.
     1. If |options| is a {{GPUDevice}} object,
         1. Set |context|.{{[[contextType]]}} to "[=context type/webgpu=]".
-        1. Set |context|.{{[[deviceType]]}} to "[=device type/gpu=]".
-        1. Set |context|.{{[[powerPreference]]}} to "[=power preference/default=]".
+        1. Set |context|.{{[[deviceType]]}} to {{MLDeviceType/"gpu"}}.
+        1. Set |context|.{{[[powerPreference]]}} to {{MLPowerPreference/"default"}}.
     1. Otherwise,
         1. Set |context|.{{[[contextType]]}} to "[=context type/default=]".
-        1. If |options|["{{deviceType}}"] [=map/exists=], then set |context|.{{[[deviceType]]}} to |options|["{{deviceType}}"]. Otherwise, set |context|.{{[[deviceType]]}} to "[=device type/cpu=]".
-        1. If |options|["{{powerPreference}}"] [=map/exists=], then set |context|.{{[[powerPreference]]}} to |options|["{{powerPreference}}"]. Otherwise, set |context|.{{[[powerPreference]]}} to "[=power preference/default=]".
+        1. If |options|["{{deviceType}}"] [=map/exists=], then set |context|.{{[[deviceType]]}} to |options|["{{deviceType}}"]. Otherwise, set |context|.{{[[deviceType]]}} to {{MLDeviceType/"cpu"}}.
+        1. If |options|["{{powerPreference}}"] [=map/exists=], then set |context|.{{[[powerPreference]]}} to |options|["{{powerPreference}}"]. Otherwise, set |context|.{{[[powerPreference]]}} to {{MLPowerPreference/"default"}}.
     1. If the user agent cannot support |context|.{{[[contextType]]}}, |context|.{{[[deviceType]]}} and |context|.{{[[powerPreference]]}}, return failure.
     1. Return |context|.
 </div>
@@ -1089,20 +1089,20 @@ The <dfn>context type</dfn> is the type of the execution context that manages th
 </dl>
 
 The <dfn>device type</dfn> indicates the kind of device used for the context. It is one of the following:
-<dl dfn-for="device type">
-<dt>"<dfn>cpu</dfn>"</dt>
+<dl dfn-for="MLDeviceType">
+<dt>"<dfn enum-value>cpu</dfn>"</dt>
 <dd>Provides the broadest compatibility and usability across all client devices with varying degrees of performance.</dd>
-<dt>"<dfn>gpu</dfn>"</dt>
+<dt>"<dfn enum-value>gpu</dfn>"</dt>
 <dd>Provides the broadest range of achievable performance across graphics hardware platforms from consumer devices to professional workstations.</dd>
 </dl>
 
 The <dfn>power preference</dfn> indicates preference as related to power consumption. It is one of the following:
-<dl dfn-for="power preference">
-<dt>"<dfn>default</dfn>"</dt>
+<dl dfn-for="MLPowerPreference">
+<dt>"<dfn enum-value>default</dfn>"</dt>
 <dd>Let the user agent select the most suitable behavior.</dd>
-<dt>"<dfn ignore>high-performance</dfn>"</dt>
+<dt>"<dfn enum-value>high-performance</dfn>"</dt>
 <dd>Prioritizes execution speed over power consumption.</dd>
-<dt>"<dfn ignore>low-power</dfn>"</dt>
+<dt>"<dfn enum-value>low-power</dfn>"</dt>
 <dd>Prioritizes power consumption over other considerations such as execution speed.</dd>
 </dl>
 
@@ -1129,7 +1129,7 @@ interface MLContext {};
 </div>
 
 <div class="note">
-When the {{[[contextType]]}} is set to [=context type/default=] with the {{MLContextOptions}}.{{deviceType}} set to [=device type/gpu=], the user agent is responsible for creating an internal GPU device that operates within the context and is capable of ML workload submission on behalf of the calling application. In this setting however, only {{ArrayBufferView}} inputs and outputs are allowed in and out of the graph execution since the application has no way to know what type of internal GPU device is being created on their behalf. In this case, the user agent is responsible for automatic uploads and downloads of the inputs and outputs to and from the GPU memory using this said internal device.
+When the {{[[contextType]]}} is set to [=context type/default=] with the {{MLContextOptions}}.{{deviceType}} set to {{MLDeviceType/"gpu"}}, the user agent is responsible for creating an internal GPU device that operates within the context and is capable of ML workload submission on behalf of the calling application. In this setting however, only {{ArrayBufferView}} inputs and outputs are allowed in and out of the graph execution since the application has no way to know what type of internal GPU device is being created on their behalf. In this case, the user agent is responsible for automatic uploads and downloads of the inputs and outputs to and from the GPU memory using this said internal device.
 </div>
 
 ### Synchronous Execution ### {#api-mlcontext-sync-execution}


### PR DESCRIPTION
Replace definitions for MLContext's device type and power preference which are used internally only, with the identical WebIDL-defined MLDeviceType and MLPowerPreference enums.

Fixes #497


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/535.html" title="Last updated on Jan 27, 2024, 6:53 PM UTC (8353c46)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/535/479ce17...inexorabletash:8353c46.html" title="Last updated on Jan 27, 2024, 6:53 PM UTC (8353c46)">Diff</a>