### PR TITLE
Wording change: Add types to all internal algorithm members

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -825,7 +825,7 @@ Its <a>default allowlist</a> is <code>'self'</code>.
 
 <details open algorithm>
 <summary>
-    To <dfn>create a context</dfn> given |options|, run these steps:
+    To <dfn>create a context</dfn> given |options| (a {{GPUDevice}} or {{MLContextOptions), run these steps:
 </summary>
 <div class=algorithm-steps>
     1. Let |context| be a new {{MLContext}} object.
@@ -931,7 +931,7 @@ The {{MLActivation}} objects (including the ones passed as input to methods) are
 
 <details open algorithm>
   <summary>
-    To <dfn>create an MLActivation</dfn> given |builder|, |name|, optional |options| and optional |init-steps|, run the following steps:
+    To <dfn>create an MLActivation</dfn> given {{MLGraphBuilder}} |builder|, [=string=] |name|, optional [=ordered map=] |options| and optional algorithm |init-steps|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. Let |activation| be a new {{MLActivation}}.
@@ -1168,7 +1168,7 @@ partial interface MLContext {
 
 <details open algorithm>
   <summary>
-    To <dfn>validate graph resources</dfn>, given |resources| and |descriptors|, run the following steps:
+    To <dfn>validate graph resources</dfn>, given {{MLNamedArrayBufferViews}} |resources| and [=ordered map=] |descriptors|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. [=map/For each=] |name| &rarr; |resource| of |resources|:
@@ -1180,7 +1180,7 @@ partial interface MLContext {
 
 <details open algorithm>
   <summary>
-    To <dfn>validate buffer with descriptor</dfn> given |bufferView| and |descriptor|, run the following steps:
+    To <dfn>validate buffer with descriptor</dfn> given {{MLBufferView}} |bufferView| and {{MLOperandDescriptor}} |descriptor|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. If |bufferView|'s [=element type=] does not match to |descriptor|.{{MLOperandDescriptor/dataType}}  according to [this table](#appendices-mloperanddatatype-arraybufferview-compatibility), return false.
@@ -1190,7 +1190,7 @@ partial interface MLContext {
 
 <details open algorithm>
   <summary>
-    To <dfn>execute graph</dfn>, given |graph|, |inputs| and |outputs|, run the following steps:
+    To <dfn>execute graph</dfn>, given {{MLGraph}} |graph|, {{MLNamedArrayBufferViews}} |inputs| and {{MLNamedArrayBufferViews}} |outputs|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. Let |inputResources| denote the input resources of |graph|.{{MLGraph/[[implementation]]}}.
@@ -1514,7 +1514,7 @@ partial interface MLGraphBuilder {
 
 <details open algorithm>
   <summary>
-    To <dfn for="MLGraphBuilder" data-lt="argminmax-op">create argMin/argMax operation</dfn> given |op|, {{MLOperand}} |input| and {{MLArgMinMaxOptions}} |options|, run the following steps:
+    To <dfn for="MLGraphBuilder" data-lt="argminmax-op">create argMin/argMax operation</dfn> given [=string=] |op|, {{MLOperand}} |input| and {{MLArgMinMaxOptions}} |options|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "argMin", "argMax".
@@ -1783,7 +1783,7 @@ partial interface MLGraphBuilder {
 
 <details open algorithm>
   <summary>
-    To <dfn>check clamp options</dfn> given |options|, run the following steps:
+    To <dfn>check clamp options</dfn> given {{MLClampOptions}} |options|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. If |options|.{{MLClampOptions/minValue}} is greater than |options|.{{MLClampOptions/maxValue}}, then return false.
@@ -2397,7 +2397,7 @@ partial interface MLGraphBuilder {
 
 <details open algorithm>
   <summary>
-    To <dfn for="MLGraphBuilder" data-lt="element-wise-binary-op">create element-wise binary operation</dfn> given |op|, {{MLOperand}} |a| and {{MLOperand}} |b|, run the following steps:
+    To <dfn for="MLGraphBuilder" data-lt="element-wise-binary-op">create element-wise binary operation</dfn> given [=string=] |op|, {{MLOperand}} |a| and {{MLOperand}} |b|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "add", "sub", "mul", "div", "max", "min", "pow".
@@ -2421,7 +2421,7 @@ partial interface MLGraphBuilder {
 
 <details open algorithm>
   <summary>
-    To <dfn for="MLGraphBuilder">broadcast-shapes</dfn> given |shape1| and |shape2|, run the following steps:
+    To <dfn for="MLGraphBuilder">broadcast-shapes</dfn> given [=/list=] |shape1| and [=/list=] |shape2|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: The type of |shape1| and |shape2| is `sequence of unsigned long`.
@@ -2530,7 +2530,7 @@ Although operations *greaterOrEqual* and *lesserOrEqual* can each be implemented
 
 <details open algorithm>
   <summary>
-    To <dfn for="MLGraphBuilder" data-lt="element-wise-logical-op">create element-wise logical operation</dfn> given |op|, {{MLOperand}} |a| and an optional {{MLOperand}} |b|, run the following steps:
+    To <dfn for="MLGraphBuilder" data-lt="element-wise-logical-op">create element-wise logical operation</dfn> given [=string=] |op|, {{MLOperand}} |a| and an optional {{MLOperand}} |b|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "equal", "greater", "greaterOrEqual", "lesser", "lesserOrEqual", "not".
@@ -2652,7 +2652,7 @@ partial interface MLGraphBuilder {
 
 <details open algorithm>
   <summary>
-    To <dfn for="MLGraphBuilder" data-lt="element-wise-unary-op">create element-wise unary operation</dfn> given |op| and {{MLOperand}} |input|, run the following steps:
+    To <dfn for="MLGraphBuilder" data-lt="element-wise-unary-op">create element-wise unary operation</dfn> given [=string=] |op| and {{MLOperand}} |input|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "abs", "ceil", "cos", "erf", "exp", "floor", "identity", "log", "neg", "reciprocal", "sin", "sqrt", "tan".
@@ -4820,7 +4820,7 @@ partial interface MLGraphBuilder {
 
 <details open algorithm>
   <summary>
-    To <dfn for="MLGraphBuilder" data-lt="pooling-op">create pooling operation</dfn> given |op|, {{MLOperand}} |input| and {{MLPool2dOptions}} |options|, run the following steps:
+    To <dfn for="MLGraphBuilder" data-lt="pooling-op">create pooling operation</dfn> given [=string=] |op|, {{MLOperand}} |input| and {{MLPool2dOptions}} |options|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "averagePool2d", "l2Pool2d", "maxPool2d".
@@ -5001,7 +5001,7 @@ partial interface MLGraphBuilder {
 
 <details open algorithm>
   <summary>
-    To <dfn for="MLGraphBuilder" data-lt="reduce-op">create reduce operation</dfn> given |op|, {{MLOperand}} |input| and {{MLReduceOptions}} |options|, run the following steps:
+    To <dfn for="MLGraphBuilder" data-lt="reduce-op">create reduce operation</dfn> given [=string=] |op|, {{MLOperand}} |input| and {{MLReduceOptions}} |options|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "reduceL1", "reduceL2", "reduceLogSum", "reduceLogSumExp", "reduceMax", "reduceMean", "reduceMin", "reduceProduct", "reduceSum", "reduceSumSquare".
@@ -6152,7 +6152,7 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
 
 <details open algorithm>
   <summary>
-    To <dfn>check dimensions</dfn> given |dimensions| and |type|, run the following steps:
+    To <dfn>check dimensions</dfn> given [=/list=] |dimensions| and {{MLOperandDataType}} |type|, run the following steps:
   </summary>
   <div class=algorithm-steps>
     1. If the [=list/size=] of |dimensions| is 0, return false.


### PR DESCRIPTION
Note that this isn't TypeScript or C++ - we are free to make the type annotations more specific, easier to read, etc. So there may be cases where we don't simply give an Infra or Web IDL type or rigorously follow the Infra style. Comments and suggestions welcome!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/536.html" title="Last updated on Jan 27, 2024, 6:57 PM UTC (7cc1a6e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/536/479ce17...inexorabletash:7cc1a6e.html" title="Last updated on Jan 27, 2024, 6:57 PM UTC (7cc1a6e)">Diff</a>