### PR TITLE
Bug fix: Provide default for MLLayerNormalizationOptions axes in steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3820,6 +3820,7 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>layerNormalization(|input|, |options|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
+    1. If |options|.{{MLLayerNormalizationOptions/axes}} does not [=map/exist=], set |options|.{{MLLayerNormalizationOptions/axes}} to the [=/list=] « 1, 2, 3 ».
     1. If the [=rank=] of |options|.{{MLLayerNormalizationOptions/scale}} is not equal to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If the [=rank=] of |options|.{{MLLayerNormalizationOptions/bias}} is not equal to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=list/For each=] |index| in [=the range=] 0 to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, exclusive:

--- a/index.bs
+++ b/index.bs
@@ -3800,7 +3800,7 @@ partial interface MLGraphBuilder {
 
     : <dfn>axes</dfn>
     ::  
-        The indices to the input dimensions to reduce. When this member is not present, it is assumed to be [1,2,3] that is, the reduction for the mean and variance values are calculated across all the input features for each individual sample in the batch.
+        The indices to the input dimensions to reduce. When this member is not present, it is treated as if all dimensions except the first were given (e.g. for a 4-D input tensor, axes = [1,2,3]). That is, the reduction for the mean and variance values are calculated across all the input features for each independent batch.
 
     : <dfn>epsilon</dfn>
     ::

--- a/index.bs
+++ b/index.bs
@@ -3820,7 +3820,7 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>layerNormalization(|input|, |options|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. If |options|.{{MLLayerNormalizationOptions/axes}} does not [=map/exist=], set |options|.{{MLLayerNormalizationOptions/axes}} to the [=/list=] « 1, 2, 3 ».
+    1. If |options|.{{MLLayerNormalizationOptions/axes}} does not [=map/exist=], then set |options|.{{MLLayerNormalizationOptions/axes}} to a new [=/list=], either equal to [=the range=] from 1 to |input|'s [=rank-=], exclusive, if |input|'s [=rank=] is greater than 1, or an empty [=/list=] otherwise.
     1. If the [=rank=] of |options|.{{MLLayerNormalizationOptions/scale}} is not equal to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If the [=rank=] of |options|.{{MLLayerNormalizationOptions/bias}} is not equal to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. [=list/For each=] |index| in [=the range=] 0 to the [=list/size=] of |options|.{{MLLayerNormalizationOptions/axes}}, exclusive:


### PR DESCRIPTION
This adds an explicit algorithm step in layerNormalization() to provide a default described only in prose for the axes option.

For #211


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/538.html" title="Last updated on Feb 10, 2024, 2:11 AM UTC (b6c8489)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/538/d1a02f2...inexorabletash:b6c8489.html" title="Last updated on Feb 10, 2024, 2:11 AM UTC (b6c8489)">Diff</a>