### PR TITLE
Bug fix: Optional sequences shouldn't be defaulted to null

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1477,7 +1477,7 @@ Return the index location of the minimum or maxmium values of all the input valu
 
 <script type=idl>
 dictionary MLArgMinMaxOptions {
-  sequence<unsigned long> axes = null;
+  sequence<unsigned long> axes;
   boolean keepDimensions = false;
   boolean selectLastIndex = false;
 };
@@ -4914,7 +4914,7 @@ partial interface MLGraphBuilder {
 Reduce the input tensor along all dimensions, or along the axes specified in the {{MLReduceOptions/axes}}  array parameter. For each specified axis, the dimension with that index is reduced, i.e. the resulting tensor will not contain it, unless the {{MLReduceOptions/keepDimensions}} option is specified. The values of the resulting tensor are calculated using the specified reduction function that takes as parameters all the values across the reduced dimension.
 <script type=idl>
 dictionary MLReduceOptions {
-  sequence<unsigned long> axes = null;
+  sequence<unsigned long> axes;
   boolean keepDimensions = false;
 };
 


### PR DESCRIPTION
MLArgMinMaxOptions and MLReduceOptions have an 'axes' member that the IDL declares as defaulting to null. They have type sequence<unsigned long> which is not nullable. The intent is that these are optional members with default behavior if not present, which is handled in the algorithm already.

If the desire is to be able to explicitly pass null, the IDL fix would be to make the type nullable: `sequence<unsigned long>? axes = null;` but that's inconsistent with the rest of the spec and not the convention for optional dictionary members.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/539.html" title="Last updated on Feb 7, 2024, 5:43 PM UTC (44d5e0b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/539/d1a02f2...inexorabletash:44d5e0b.html" title="Last updated on Feb 7, 2024, 5:43 PM UTC (44d5e0b)">Diff</a>