### PR TITLE
Wording change: drop links to File API's "object", define platform operand/operator 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -709,14 +709,16 @@ A key part of the {{MLGraphBuilder}} interface are the operations (such as
 {{MLGraphBuilder}}.{{MLGraphBuilder/gemm()}} and {{MLGraphBuilder}}.{{MLGraphBuilder/softmax()}}). The operations have a functional
 semantics, with no side effects.
 Each operation invocation conceptually returns a distinct new value, without
-changing the value of any other {{MLOperand}}.
+changing the value of any other {{MLOperand}}. 
+
+Internally, the {{MLGraphBuilder}} methods such as {{MLGraphBuilder/gemm()}} create an [=implementation-defined=] <dfn>platform operator</dfn> which is held by the {{MLOperand}} or {{MLActivation}}, which performs the actual operation on the input data when the computation is run. An {{MLOperand}} also holds an [=implementation-defined=] <dfn>platform operand</dfn>, which references the operand in the underlying computational graph, and is connected to [=platform operators=] as input and/or output.
 
 The runtime values (of {{MLOperand}}s) are tensors, which are essentially multidimensional
 arrays. The representation of the tensors is implementation dependent, but it typically
 includes the array data stored in some buffer (memory) and some metadata describing the
 array data (such as its shape).
 
-As mentioned above, the operations have a functional semantics. This allows the implementation
+As mentioned above, the operations have functional semantics. This allows the implementation
 to potentially share the array data between multiple tensors. For example, the implementation
 of operations such as reshape, or slice may return a view of its input tensor
 that shares the same buffer as the input tensor. (In the case of reshape,
@@ -911,12 +913,12 @@ interface MLActivation {
     : <dfn>\[[builder]]</dfn> of type {{MLGraphBuilder}}
     ::
         The graph builder object this {{MLActivation}} belongs to.
-    : <dfn>\[[options]]</dfn> of type [=object=]
+    : <dfn>\[[options]]</dfn> of type [=ordered map=]
     ::
         A dictionary containing {{MLActivation}} options.
-    : <dfn>\[[operator]]</dfn> of type [=object=]
+    : <dfn>\[[operator]]</dfn> of type [=platform operator=]
     ::
-        Reference to {{MLActivation}}'s corresponding [=implementation-defined=] platform operator object.
+        Reference to {{MLActivation}}'s corresponding [=platform operator=].
   </dl>
 </div>
 
@@ -940,7 +942,7 @@ The {{MLActivation}} objects (including the ones passed as input to methods) are
     1. If |options| is given, set |activation|.{{MLActivation/[[options]]}} to |options|.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Make a request to the underlying platform to:
-            1. Create an [=implementation-defined=] platform operator |opImpl| for the given |name| operation.
+            1. Create [=platform operator=] |opImpl| for the given |name| operation.
             1. Set |activation|.{{MLActivation/[[operator]]}} to |opImpl|.
         1. If |init-steps| are given, run |init-steps| with |options|.
             1. Otherwise, initialize |activation|.{{MLActivation/[[operator]]}} given |options| in an [=implementation-defined=] way for the given |name| operation.
@@ -1526,9 +1528,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the |op| argMin or argMax operation, given |options|.
+            1. Let |opImpl| be [=platform operator=] for the |op| argMin or argMax operation, given |options|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -1625,7 +1627,7 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |input|.{{MLOperand/[[descriptor]]}}, that may use the same underlying data as |input|.
         1. Make a request to the underlying platform to initialize the batch normalization:
-            1. Create an [=implementation-defined=] platform operator |batchNormImpl| for this method, given |input|, |mean|, |variance| and |options|.
+            1. Create [=platform operator=] |batchNormImpl| for this method, given |input|, |mean|, |variance| and |options|.
             1. If |options|.activation [=map/exists=],register it as activation to |batchNormImpl|.
             1. Connect |output| as output to |batchNormImpl|.
     1. Return |output|.
@@ -1729,9 +1731,9 @@ partial interface MLGraphBuilder {
         1. Let |operand| be the result of [=creating an MLOperand=] given [=this=], |input| and |type|.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Create an [=implementation-defined=] platform operator |castImpl| for this method, given |type|.
+            1. Create [=platform operator=] |castImpl| for this method, given |type|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |castImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent an output, given |output| and |castImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent an output, given |output| and |castImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |operand|.{{MLOperand/[[operand]]}} as input to |castImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |castImpl|.
@@ -1811,9 +1813,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Create an [=implementation-defined=] platform operator |clampImpl| for this method, given |options|.{{MLClampOptions/minValue}} and |options|.{{MLClampOptions/maxValue}}.
+            1. Create [=platform operator=] |clampImpl| for this method, given |options|.{{MLClampOptions/minValue}} and |options|.{{MLClampOptions/maxValue}}.
             1. Set |output|.{{MLOperand/[[operator]]}} to |clampImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent clamp output, given |output| and |clampImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent clamp output, given |output| and |clampImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |clampImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |clampImpl|.
@@ -1891,9 +1893,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
-            1. Create an [=implementation-defined=] platform operator |concatImpl| for this method, given |inputs| and |axis|.
+            1. Create [=platform operator=] |concatImpl| for this method, given |inputs| and |axis|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |concatImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent output,given |output| and |concatImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent output,given |output| and |concatImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |inputs| as input to |concatImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |concatImpl|.
@@ -1929,7 +1931,7 @@ Create a constant {{MLOperand}} of the specified data type and shape that contai
         1. Let |operand| be the result of [=creating an MLOperand=] given [=this=] and |descriptor|.
         1. Let |bytes| be the result of [=getting a copy of the bytes held by the buffer source=] given |bufferView|.
         1. Make a request to the underlying platform to:
-            1. Create an [=implementation-defined=] platform operand |constantImpl| to represent a constant, given |descriptor|.
+            1. Create an [=platform operand=] |constantImpl| to represent a constant, given |descriptor|.
             1. Set |operand|.{{MLOperand/[[operand]]}} to |constantImpl|.
             1. Register |operand| as a tensor constant with |bytes| as value.
     1. Return |operand|.
@@ -1967,7 +1969,7 @@ Data truncation will occur when the specified value exceeds the range of the spe
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |operand| be the result of [=creating an MLOperand=] given [=this=] and |descriptor|.
         1. Make a request to the underlying platform to:
-            1. Create an [=implementation-defined=] platform operand |constantImpl| to represent a constant, given |descriptor|.
+            1. Create an [=platform operand=] |constantImpl| to represent a constant, given |descriptor|.
             1. Set |operand|.{{MLOperand/[[operand]]}} to |constantImpl|.
             1. Register |operand| as a scalar constant with |value| as value.
     1. Return |operand|.
@@ -2010,7 +2012,7 @@ Data truncation will occur when the values in the range exceed the range of the 
         1. [=list/For each=] |index| in [=the range=] 0 to |size|, exclusive:
             1. Set |buffer|[|index|] to |start| + (|index| * |step|).
         1. Make a request to the underlying platform to:
-            1. Create an [=implementation-defined=] platform operand |constantImpl| to represent a constant operand, given |descriptor|.
+            1. Create an [=platform operand=] |constantImpl| to represent a constant operand, given |descriptor|.
             1. Set |operand|.{{MLOperand/[[operand]]}} to |constantImpl|.
             1. Register |operand| as a constant with |buffer| as value.
     1. Return |operand|.
@@ -2170,10 +2172,10 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
-            1. Create an [=implementation-defined=] platform operator |conv2dImpl| for this method, given |options| and |filter|.
+            1. Create [=platform operator=] |conv2dImpl| for this method, given |options| and |filter|.
                 1. If |options|.{{MLConv2dOptions/activation}} [=map/exists=],register it as activation to |conv2dImpl|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |conv2dImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |conv2dImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |conv2dImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |conv2dImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |conv2dImpl|.
@@ -2345,10 +2347,10 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
-            1. Create an [=implementation-defined=] platform operator |convTranspose2dImpl| for this method, given |options| and |filter|.
+            1. Create [=platform operator=] |convTranspose2dImpl| for this method, given |options| and |filter|.
                 1. If |options|.{{MLConvTranspose2dOptions/activation}} [=map/exists=],register it as activation to |convTranspose2dImpl|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |convTranspose2dImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |convTranspose2dImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |convTranspose2dImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |convTranspose2dImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |convTranspose2dImpl|.
@@ -2409,9 +2411,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |descriptor|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the binary operation |op|, given |a| and |b|.
+            1. Let |opImpl| be [=platform operator=] for the binary operation |op|, given |a| and |b|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |a|.{{MLOperand/[[operand]]}} and |b|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -2545,9 +2547,9 @@ Although operations *greaterOrEqual* and *lesserOrEqual* can each be implemented
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |descriptor|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the binary operation |op|, given |a| and |b|.
+            1. Let |opImpl| be [=platform operator=] for the binary operation |op|, given |a| and |b|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |a|.{{MLOperand/[[operand]]}} and |b|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -2659,9 +2661,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the unary operation |op|.
+            1. Let |opImpl| be [=platform operator=] for the unary operation |op|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -2820,9 +2822,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the ELU operation, given |options|.
+            1. Let |opImpl| be [=platform operator=] for the ELU operation, given |options|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -2885,9 +2887,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |outputDesc|.
         1. Make a request to the underlying platform to:
-            1. Create an [=implementation-defined=] platform operator |expandImpl| for this method, given |input| and |newShape|.
+            1. Create [=platform operator=] |expandImpl| for this method, given |input| and |newShape|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |expandImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent output,given |output| and |expandImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent output,given |output| and |expandImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input| as input to |expandImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |expandImpl|.
@@ -2960,9 +2962,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given |desc|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the Gather operation, given |input|, |indices|, and |options|.
+            1. Let |opImpl| be [=platform operator=] for the Gather operation, given |input|, |indices|, and |options|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} and |indices|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -3096,9 +3098,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the GEMM operation, given |options|.
+            1. Let |opImpl| be [=platform operator=] for the GEMM operation, given |options|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |a|.{{MLOperand/[[operand]]}} and |b|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -3223,7 +3225,7 @@ partial interface MLGraphBuilder {
     1. Let |output| be an empty sequence of {{MLOperand}} objects.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for "gru", given |weight|, |recurrentWeight|, |steps|, |hiddenSize| and |options| as parameters.
+            1. Let |opImpl| be [=platform operator=] for "gru", given |weight|, |recurrentWeight|, |steps|, |hiddenSize| and |options| as parameters.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output| as output to |opImpl|.
     1. Return |output|.
@@ -3373,9 +3375,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for "gruCell", given |weight|, |recurrentWeight|, |hiddenState|, |hiddenSize| and |options| as parameters.
+            1. Let |opImpl| be [=platform operator=] for "gruCell", given |weight|, |recurrentWeight|, |hiddenState|, |hiddenSize| and |options| as parameters.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -3549,9 +3551,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the hard sigmoid operation, given |options|.
+            1. Let |opImpl| be [=platform operator=] for the hard sigmoid operation, given |options|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -3629,9 +3631,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the hard-swish operation.
+            1. Let |opImpl| be [=platform operator=] for the hard-swish operation.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -3749,9 +3751,9 @@ The {{MLInstanceNormalizationOptions}} members are:
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the instance normalization operation, given |options|.
+            1. Let |opImpl| be [=platform operator=] for the instance normalization operation, given |options|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -3854,9 +3856,9 @@ The {{MLLayerNormalizationOptions}} members are:
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the instance normalization operation, given |options|.
+            1. Let |opImpl| be [=platform operator=] for the instance normalization operation, given |options|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -3955,9 +3957,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the Leaky RELU operation, given |options|.
+            1. Let |opImpl| be [=platform operator=] for the Leaky RELU operation, given |options|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -4047,9 +4049,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the linear operation, given |options|.
+            1. Let |opImpl| be [=platform operator=] for the linear operation, given |options|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -4205,9 +4207,9 @@ partial interface MLGraphBuilder {
             1. Let |output| be the [=/list=] « |output0|, |output1|, |output2| ».
         1. Otherwise, let |output| be the [=/list=] « |output0|, |output1| ».
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the LSTM operation, given |weight|, |recurrentWeight|, |steps|, |hiddenSize| and |options|.
+            1. Let |opImpl| be [=platform operator=] for the LSTM operation, given |weight|, |recurrentWeight|, |steps|, |hiddenSize| and |options|.
             1. Set |output0|.{{MLOperand/[[operator]]}}, |output1|.{{MLOperand/[[operator]]}} and |output2|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output0|.{{MLOperand/[[operand]]}}, |output1|.{{MLOperand/[[operand]]}} and |output2|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output| as output to |opImpl|.
@@ -4382,9 +4384,9 @@ partial interface MLGraphBuilder {
         1. Let |output1| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
         1. Let |output| be the [=/list=] « |output0|, |output1| ».
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the LSTM cell operation, given |weight|, |recurrentWeight|, |hiddenState|, |cellState|, |hiddenSize| and |options|.
+            1. Let |opImpl| be [=platform operator=] for the LSTM cell operation, given |weight|, |recurrentWeight|, |hiddenState|, |cellState|, |hiddenSize| and |options|.
             1. Set |output0|.{{MLOperand/[[operator]]}} and |output1|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output0|.{{MLOperand/[[operand]]}} and |output1|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output| as output to |opImpl|.
@@ -4567,9 +4569,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the matrix multiplication operation.
+            1. Let |opImpl| be [=platform operator=] for the matrix multiplication operation.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |a|.{{MLOperand/[[operand]]}} and |b|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -4652,9 +4654,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the padding operation, given |beginningPadding|, |endingPadding| and |options|.
+            1. Let |opImpl| be [=platform operator=] for the padding operation, given |beginningPadding|, |endingPadding| and |options|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -4844,9 +4846,9 @@ partial interface MLGraphBuilder {
         1. Make a request to the underlying platform to:
             1. Calculate the output dimensions given |input| and |options|. Set |desc|.{{MLOperandDescriptor/dimensions}} to that.
             1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the |op| pooling operation, given |options|.
+            1. Let |opImpl| be [=platform operator=] for the |op| pooling operation, given |options|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -4919,9 +4921,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |descriptor|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the PreLU operation, given |slope|.
+            1. Let |opImpl| be [=platform operator=] for the PreLU operation, given |slope|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -5013,9 +5015,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the |op| reduce operation, given |options|.
+            1. Let |opImpl| be [=platform operator=] for the |op| reduce operation, given |options|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -5140,9 +5142,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the ReLU operation.
+            1. Let |opImpl| be [=platform operator=] for the ReLU operation.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -5264,9 +5266,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the resample 2D operation, given |options|.
+            1. Let |opImpl| be [=platform operator=] for the resample 2D operation, given |options|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -5310,9 +5312,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the reshape operation.
+            1. Let |opImpl| be [=platform operator=] for the reshape operation.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -5402,9 +5404,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the sigmoid operation.
+            1. Let |opImpl| be [=platform operator=] for the sigmoid operation.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -5459,9 +5461,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the slice operation, given |starts| and |sizes|.
+            1. Let |opImpl| be [=platform operator=] for the slice operation, given |starts| and |sizes|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -5518,9 +5520,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the softmax operation.
+            1. Let |opImpl| be [=platform operator=] for the softmax operation.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -5607,9 +5609,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the softplus operation, given |options|.
+            1. Let |opImpl| be [=platform operator=] for the softplus operation, given |options|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -5679,9 +5681,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the softsign operation.
+            1. Let |opImpl| be [=platform operator=] for the softsign operation.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -5750,9 +5752,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the split operation, given |splits| and |options|.
+            1. Let |opImpl| be [=platform operator=] for the split operation, given |splits| and |options|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -5828,9 +5830,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the hyperbolic tangent operation.
+            1. Let |opImpl| be [=platform operator=] for the hyperbolic tangent operation.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -5901,9 +5903,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the transpose operation, given |options|.
+            1. Let |opImpl| be [=platform operator=] for the transpose operation, given |options|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -5951,9 +5953,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the triangular operation, given |options|.
+            1. Let |opImpl| be [=platform operator=] for the triangular operation, given |options|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -6049,9 +6051,9 @@ partial interface MLGraphBuilder {
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |descriptor|.
         1. Make a request to the underlying platform to:
-            1. Let |opImpl| be an [=implementation-defined=] platform operator for the where operation, given |condition|, |input| and |other|.
+            1. Let |opImpl| be [=platform operator=] for the where operation, given |condition|, |input| and |other|.
             1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=implementation-defined=] platform operand |outputImpl| to represent the output, given |output| and |opImpl|.
+            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
             1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
         1. Connect |condition|.{{MLOperand/[[operand]]}}, |input| and |other|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
@@ -6103,13 +6105,13 @@ interface MLOperand {};
     ::
         The {{MLOperand}}'s name (only for input operands).
 
-    : <dfn>\[[operand]]</dfn> of type [=object=]
+    : <dfn>\[[operand]]</dfn> of type [=platform operand=]
     ::
-        Reference to {{MLOperand}}'s corresponding [=implementation-defined=] platform operand object.
+        Reference to {{MLOperand}}'s corresponding [=platform operand=].
 
-    : <dfn>\[[operator]]</dfn> of type [=object=]
+    : <dfn>\[[operator]]</dfn> of type [=platform operator=]
     ::
-        Reference to {{MLOperand}}'s corresponding [=implementation-defined=] platform operator object.
+        Reference to {{MLOperand}}'s corresponding [=platform operator=].
   </dl>
 </div>
 


### PR DESCRIPTION
The default linking for [=object=] is to FileAPI's blob URL entry object member[1], which is definitely wrong.
    
Replace such references with:
    
* Infra's ordered map[2], when a dictionary is intended, as that's what a JavaScript object is translated into via bindings.
    
* Links to new definitions for "platform operator" and "platform operand" which include the "implementation-defined" phrase so links to the terms can be greatly simplified. These definitions should be further expanded to include "connect", "input" and "output" but that can be tackled later.
    
This reduces the number of "implementation-defined" phrases to just a handful in the spec, which helps with #462.
    
[1] https://www.w3.org/TR/FileAPI/#blob-url-entry-object
    
[2] https://infra.spec.whatwg.org/#ordered-map


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 405 Method Not Allowed :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 2, 2024, 5:45 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Finexorabletash%2Fwebnn%2F6ab284b11a97f5e2b592bec1fda3f457052ce4f0%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN"><html lang='en'><head><meta content='text/html; charset=utf-8' http-equiv='Content-Type'><title>CSS Spec Preprocessor</title><link href='/bikeshed/img/favicon.png' rel='icon' type='image/png'><link href='/bikeshed/core/stylesheets/base.css' rel='stylesheet' type='text/css'><link href='/bikeshed/core/stylesheets/system.css' rel='stylesheet' type='text/css'><link href='/bikeshed/stylesheets/bikeshed.css' rel='stylesheet' type='text/css'><script nonce='EsVfxjbdUoqHS3iutlsxQh8ulCn5lqYTDgiZEz2yoGI=' type='text/javascript'><!--
var gCookieDomain=".api.csswg.org";var gCookiePath="\/bikeshed\/";var gCookiePrefix="bikeshed_";var gUserId=false;if(!Array.indexOf){Array.prototype.indexOf=function(obj){for(var index=0;index<this.length;index++){if(this[index]==obj){return index;}}return-1;}}try{if(1!=Node.ELEMENT_NODE){throw true;}}catch(exc){var Node={ELEMENT_NODE:1,ATTRIBUTE_NODE:2,TEXT_NODE:3};}var system={mAPIXHR:null,mAPITimer:null,mAPIQueue:[],commonPrefix:function(string1,string2){var prefix='';var length=((string1.length<string2.length)?string1.length:string2.length);var index=-1;while((++index<length)&(string1[index]==string2[index])){prefix+=string1[index];}return prefix;},getCookie:function(name){var cookies=document.cookie.split(';');name+='=';var prefixedName=gCookiePrefix+name;for(var index=0;index<cookies.length;index++){cookie=cookies[index].trim();if(prefixedName==cookie.substring(0,prefixedName.length)){return unescape(cookie.substring(prefixedName.length));}if(name==cookie.substring(0,name.length)){return unescape(cookie.substring(name.length));}}return null;},setCookie:function(name,value){if(null==value){var expDate=new Date();expDate.setDate(expDate.getDate()-1);document.cookie=gCookiePrefix+name+'=; expires='+expDate.toGMTString()+'; '+'domain='+gCookieDomain+'; path='+gCookiePath;}else{document.cookie=gCookiePrefix+name+'='+escape(value)+'; expires=0; '+'domain='+gCookieDomain+'; path='+gCookiePath;}},hasClass:function(element,className){if(element&&('className'in element)){var classes=element.className.split(' ');if(-1<classes.indexOf(className)){return true;}}return false;},addClass:function(element,className){if(element){var classes=(('className'in element)?element.className.split(' '):new Array());if(-1==classes.indexOf(className)){classes.push(className);element.className=classes.join(' ');}}},removeClass:function(element,className){if(element){var classes=(('className'in element)?element.className.split(' '):new Array());var index;while(-1<(index=classes.indexOf(className))){classes.splice(index,1);}element.className=classes.join(' ');}},findChildWithClass:function(element,className){if(element){var children=element.children;if(children){for(var index=0;index<children.length;index++){var child=children[index];if((child.nodeType==Node.ELEMENT_NODE)&&this.hasClass(child,className)){return child;}}}}return null;},getFirstElementChild:function(element){if(element){var children=element.children;for(var index=0;index<children.length;index++){var child=children[index];if(child.nodeType==Node.ELEMENT_NODE){return child;}}}return null;},iterateElementChildren:function(element,callback){if(element){var children=Array();for(var index=0;index<element.children.length;index++){var child=element.children[index];if(child.nodeType==Node.ELEMENT_NODE){children.push(child);}}for(var index=0;index<children.length;index++){var child=children[index];var result=callback(child,index);if(result){return result;}}}return false;},isLoggedIn:function(){var login=document.getElementById('login');return(login&&this.hasClass(login,'loggedin'));},toggleLoginMenu:function(){var login=document.getElementById('login');if(login){if(this.hasClass(login,'open')){this.removeClass(login,'open');}else{this.addClass(login,'open');}}},updatePageURI:function(uri){var login=document.getElementById('login');if(login){var a=system.createElement('a',{'href':uri});uri=a.pathname;system.iterateElementChildren(login,function(div,index){system.iterateElementChildren(div,function(item,index){if(item.hasAttribute('href')){var href=item.getAttribute('href');var index=href.indexOf('/return/');if(0<=index){var prefix=system.commonPrefix(uri,item.pathname);item.setAttribute('href',href.substring(0,index)+'/return/'+uri.substring(prefix.length));}}});});}},createProgressIcon:function(){var progress=this.createElement('span',{'class':'progress p1'});progress.setAttribute('data-timer',setInterval(function(){var state=progress.className.slice(-1);state=(state-0+1)%8;progress.className='progress p'+state;},125));return progress;},removeProgressIcon:function(progress){if(progress){clearInterval(progress.getAttribute('data-timer')-0);if(progress.parentNode){progress.parentNode.removeChild(progress);}}},addLoadEvent:function(onLoad){try{var oldOnLoad=window.onload;if('function'!=typeof(window.onload)){window.onload=onLoad;}else{window.onload=function(){if(oldOnLoad){oldOnLoad();}onLoad();}}}catch(err){}},createElement:function(tagName,attrs,textContent){var element=document.createElement(tagName);if(attrs){for(attr in attrs){if(attrs.hasOwnProperty(attr)){if('id'==attr){element.id=attrs.id;}else if('className'==attr){element.className=attrs.className;}else if(attrs[attr]){element.setAttribute(attr,attrs[attr]);}}}}if(textContent){element.textContent=textContent;}return element;},emptyElement:function(element){if(element){while(element.lastChild){element.removeChild(element.lastChild);}}},addFormData:function(form,name,value){if(form){var hidden=this.createElement('input',{'type':'hidden','name':name,'value':value});form.appendChild(hidden);}},addUserHyperLink:function(parent,user){var userName=(user&&user.name ?((user.name.toLowerCase()==user.full_name.toLowerCase())?user.full_name:user.name):'Anonymous User');var title=(user&&user.full_name&&user.name&&(user.full_name.toLowerCase()!=user.name.toLowerCase())?user.full_name:'');var email=(user&&user.email&&user.display_email ?user.email:'');var uri=(user&&user.uri ?user.uri:'');if(email){parent.appendChild(this.createElement('a',{'href':'mailto:'+email,'title':title},userName));}else if(uri){parent.appendChild(this.createElement('a',{'href':uri,'title':title},userName));}else{parent.appendChild(this.createElement('span',{'title':title},userName));}},_processAPIQueue:function(){var call=this.mAPIQueue.shift();if(call){if(!this.mAPIXHR){this.mAPIXHR=new XMLHttpRequest();}this.mAPIXHR.onreadystatechange=function(){if(4==system.mAPIXHR.readyState){if(call.callback){var response=false;try{if('json'==call.type){response=JSON.parse(system.mAPIXHR.responseText);}else if('xml'==call.type){response=system.mAPIXHR.responseXML.documentElement}}catch(err){}try{call.callback(system.mAPIXHR.status,response);}catch(err){if(call.progress){system.removeProgressIcon(call.progress);}throw err;}}if(call.progress){system.removeProgressIcon(call.progress);}this.mAPITimer=setTimeout(function(){system._processAPIQueue()},10);}};try{this.mAPIXHR.open(call.method,call.uri,true);if(call.callback){this.mAPIXHR.setRequestHeader('Accept','application/json');}if('POST'==call.method){this.mAPIXHR.setRequestHeader('Content-type','application/x-www-form-urlencoded');this.mAPIXHR.setRequestHeader('Content-length',call.data.length);}if('xml'==call.type){this.mAPIXHR.responseType='document';}else{this.mAPIXHR.responseType='';}this.mAPIXHR.send(call.data);}catch(err){if(call.progress){system.removeProgressIcon(call.progress);}this.mAPITimer=setTimeout(function(){system._processAPIQueue()},10);throw err;}}else{this.mAPITimer=null;}},callAPI:function(method,uri,data,type,callback,progressTarget,priority){var progress=null;if(progressTarget){progress=this.createProgressIcon();progressTarget.parentNode.insertBefore(progress,progressTarget.nextSibling);}var call={method:method,uri:uri,type:type,data:data,callback:callback,progress:progress};if(priority){this.mAPIQueue.unshift(call);}else{this.mAPIQueue.push(call);}if(null===this.mAPITimer){this.mAPITimer=setTimeout(function(){system._processAPIQueue()},10);}},encodeParams:function(params,arrayName){var paramString='';for(param in params){if(params.hasOwnProperty(param)){if(paramString){paramString+='&';}var name=param;if(arrayName){name=arrayName+'['+param+']';}if(Array.isArray(params[param])){for(var index=0;index<params[param].length;index++){paramString+=name+'[]='+params[param][index];}}else if('object'==typeof(params[param])){paramString+=this.encodeParams(params[param],param);}else if('boolean'==typeof(params[param])){paramString+=name+'='+(params[param]+0);}else{paramString+=name+'='+encodeURIComponent(params[param]);}}}return paramString;},getXML:function(uri,params,callback,progressTarget,priority){if(null==params){params={};}var paramString=this.encodeParams(params);this.callAPI('GET',uri+'?'+paramString,null,'xml',callback,progressTarget,priority);},callAPIGet:function(uri,params,callback,progressTarget,priority){if(null==params){params={};}var loginKey=this.getCookie('loginkey');if(loginKey){params.loginkey=loginKey;}var paramString=this.encodeParams(params);this.callAPI('GET',uri+'?'+paramString,null,'json',callback,progressTarget,priority);},callAPIPost:function(uri,params,callback,progressTarget,priority){if(null==params){params={};}var loginKey=this.getCookie('loginkey');if(loginKey){params.loginkey=loginKey;}var data=this.encodeParams(params);this.callAPI('POST',uri,data,'json',callback,progressTarget,priority);},abortAPICall:function(){if(this.mAPIXHR){if((4!=this.mAPIXHR.readyState)&&(0!=this.mAPIXHR.readyState)){this.mAPIXHR.abort();}}},setMenuAlert:function(menuId,state){var menuLink=document.getElementById(menuId);if(menuLink){if(state){if(!this.hasClass(menuLink,'alert')){var icon=this.createElement('span',{'class':'icon alert','style':'top: -14px ! important'});menuLink.appendChild(icon);this.addClass(menuLink,'alert');setTimeout(function(){icon.setAttribute('style','top: '+(menuLink.offsetTop+3)+'px');},100);}}else{if(this.hasClass(menuLink,'alert')){var icon=menuLink.lastChild;icon.setAttribute('style','top: -14px ! important');this.removeClass(menuLink,'alert');setTimeout(function(){menuLink.removeChild(icon);},500);}}}}};
// --></script><script nonce='EsVfxjbdUoqHS3iutlsxQh8ulCn5lqYTDgiZEz2yoGI=' type='text/javascript'><!--
function updateForceControl(){var outputHTMLControl=document.getElementById('output-error');var forceControl=document.getElementById('force');var dieOnControl=document.getElementById('die-on');forceControl.disabled=outputHTMLControl.checked;dieOnControl.disabled=(outputHTMLControl.checked||forceControl.checked);}system.addLoadEvent(updateForceControl)
// --></script></head><body><div class='header'><div class='logo'><a href='http://www.w3.org/' rel='home'><img alt='W3C' src='/bikeshed/core/img/logo-w3c-screen-sm.png'></a></div><div class='login' id='login'><div><a href='/bikeshed/login/return/'>Login</a></div></div><p class='nav'><a>Home</a></p><h1 id='title'>CSS Spec Preprocessor</h1></div><div class='body'><p class='error'>Must use POST to process URL</p><form accept-charset='utf-8' action='' enctype='multipart/form-data' method='post'><fieldset><legend>Specification Source</legend><table class='labels'><tr><th><label for='file'>Upload File:</label></th><td><input name='file' type='file' value=''></td></tr><tr><th><label for='url'>Load from URL:</label></th><td><input id='url' name='url' size='60' type='text' value='https://raw.githubusercontent.com/inexorabletash/webnn/6ab284b11a97f5e2b592bec1fda3f457052ce4f0/index.bs'></td></tr><tr><th><label for='text'>Enter Text:</label></th><td><textarea cols='80' id='text' name='text' rows='10'></textarea></td></tr></table></fieldset><fieldset><legend>Options</legend><table class='labels'><tr><th><label for='input'>Input Type:</label></th><td><select id='input' name='input'><option selected value='spec'>Specification</option><option value='issues'>Issues List</option></select></td></tr><tr><th>Output:</th><td><input id='output-error' name='output' type='radio' value='err'><label for='output-error'>Errors &amp; Warnings</label><br><input id='output-html' name='output' type='radio' value='html'><label for='output-html'>Generated HTML</label><br><input checked id='output-frame' name='output' type='radio' value='frame'><label for='output-frame'>Both (in Frames)</label></td></tr><tr><th style='vertical-align: baseline'>Error Handling:</th><td><input checked id='force' name='force' type='checkbox' value='1'><label for='force'>Force HTML Output (ignore fatal errors)</label></td></tr><tr><th>Die On:</th><td><select id='die-on' name='die-on'><option selected value='nothing'>Nothing</option><option value='fatal'>Fatal</option><option value='link-error'>Link Error</option><option value='warning'>Warning</option><option value='everything'>Everything</option></select></td></tr><tr><th><label for='time'>Default Time:</label></th><td><input id='time' name='time' size='40' type='text'> (yyyy-mm-dd hh:mm:ss +0000)</td></tr></table></fieldset><input name='action' type='submit' value='Process'></form><div class='instructions'>This tool may also be used from the command line, e.g.:<code><span>curl http://api.csswg.org/bikeshed/ -F file=@Overview.bs -F force=1 &gt; Overview.html</span><span>curl http://api.csswg.org/bikeshed/ -F url=https://drafts.csswg.org/css-align-3/Overview.bs &gt; Overview.html</span><span>curl http://api.csswg.org/bikeshed/ -F file=@Overview.bs -F output=err</span><span>curl http://api.csswg.org/bikeshed/ -F file=@Issues.txt -F input=issues &gt; Issues.html</span></code><p>Valid paramaters are:</p><dl><dt>file</dt><dd>file contents to process</dd><dt>url</dt><dd>url contents to process</dd><dt>input</dt><dd>input type: &#039;spec&#039; or &#039;issues&#039; (default = &#039;spec&#039;)</dd><dt>output</dt><dd>desired output: &#039;html&#039;, &#039;err&#039; (default to Accept: header value)</dd><dt>force</dt><dd>send HTML output even if fatal errors encountered, otherwise output determined by Accept: header</dd><dt>die-on</dt><dd>select category of error to stop on, options are: nothing, fatal, link-error, warning, everything (default = &#039;fatal&#039;)</dd><dt>time</dt><dd>default specification time (yyyy-mm-dd hh:mm:ss +0000)</dd><dt>md-&lt;key&gt;</dt><dd>override metadata (e.g.: md-status=CR)</dd></dl><p>Parameters may be submitted as query arguments or form fields. HTTP POST must be used.</p><p>Further information can be found in the <a href='https://speced.github.io/bikeshed/#curl'>Bikeshed documentation</a>.</p></div></div><div class='footer'><address>Please send comments, questions, and error reports to <a href='&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#98;&#105;&#107;&#101;&#115;&#104;&#101;&#100;&#64;&#99;&#115;&#115;&#119;&#103;&#46;&#111;&#114;&#103;?subject=CSS Spec Preprocessor'>the server administrator &#60;&#98;&#105;&#107;&#101;&#115;&#104;&#101;&#100;&#64;&#99;&#115;&#115;&#119;&#103;&#46;&#111;&#114;&#103;&#62;</a></address></div><script nonce='EsVfxjbdUoqHS3iutlsxQh8ulCn5lqYTDgiZEz2yoGI=' type='text/javascript'><!--
document.getElementById('output-error').onchange=function(event){updateForceControl()};document.getElementById('output-html').onchange=function(event){updateForceControl()};document.getElementById('output-frame').onchange=function(event){updateForceControl()};document.getElementById('force').onchange=function(event){updateForceControl()};
// --></script></body></html>
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20webmachinelearning/webnn%23540.)._
</details>
