### PR TITLE
Content: The input of triangular should be at least 2D tensor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5873,7 +5873,7 @@ partial interface MLGraphBuilder {
 </details>
 
 ### triangular ### {#api-mlgraphbuilder-triangular}
-Given a 2-D tensor (matrix), return a 2-D tensor containing either the upper or lower triangular part of the input tensor.
+Given a 2-D tensor (matrix), return a 2-D tensor containing either the upper or lower triangular part of the input tensor. If the input tensor has greater than 2 dimensions it is treated as a batch of matrices and the result has the same shape.
 
 <script type=idl>
 dictionary MLTriangularOptions {
@@ -5898,10 +5898,10 @@ partial interface MLGraphBuilder {
 
 <div>
     **Arguments:**
-        - *input*: an {{MLOperand}}. The input 2-D tensor.
+        - *input*: an {{MLOperand}}. The input tensor which is at least 2-D.
         - *options*: an optional {{MLTriangularOptions}}. The optional parameters of the operation.
 
-    **Returns:** an {{MLOperand}}. The output 2-D tensor representing a triangular matrix.
+    **Returns:** an {{MLOperand}}. The output tensor representing a triangular matrix, or batch of matrices which is the same shape as the input.
 </div>
 
 <details open algorithm>
@@ -5909,6 +5909,7 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>triangular(|input|, |options|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
+    1. If the [=list/size=] of |input|.{{MLOperand/[[descriptor]]}}.{{MLOperandDescriptor/dimensions}} is less than 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
@@ -5969,7 +5970,16 @@ partial interface MLGraphBuilder {
     //   [[0, 0, 0],
     //    [9, 0, 0],
     //    [2, 6, 0]]
-    const lowerNegative = builder.triangular(input, { upper: false, diagonal: -1 });
+    const lowerNegative = builder.triangular(input, { upper: false, diagonal: -1 })
+
+    // lower triangular matrix with two batches:
+    //   [[[7, 0, 0],
+    //     [9, 4, 0],
+    //     [2, 6, 3]],
+    //    [[1, 0, 0],
+    //     [4, 5, 0],
+    //     [7, 8, 9]]]
+    const lowerWithBatches = builder.triangular(input, { upper: false });
   </pre>
 </details>
 </div>


### PR DESCRIPTION
Fixes #494 which has the text and example. I added the validation step which matches the webnn-baseline impl referenced therein.

* "2-D" seems to be used more commonly than "2D" in the spec
* "batches" doesn't seem to be rigorously defined - room for future improvement here and in matmul?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/550.html" title="Last updated on Feb 7, 2024, 5:43 PM UTC (3cef040)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/550/d1a02f2...inexorabletash:3cef040.html" title="Last updated on Feb 7, 2024, 5:43 PM UTC (3cef040)">Diff</a>