### PR TITLE
Remove hard-coded colors which break dark mode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -116,7 +116,6 @@ summary {
 
 div.algorithm-steps {
     padding: .5em;
-    background-color: ghostwhite;
 }
 
 .algorithm-steps {
@@ -142,7 +141,6 @@ div.informalsteps {
     padding: .5em;
     border: thin solid #88e !important;
     border-radius: .5em;
-    background-color: ghostwhite;
 }
 
 .informalsteps {
@@ -167,7 +165,6 @@ div.internal-slots {
     padding: .5em;
     border: thin solid #88e !important;
     border-radius: .5em;
-    background-color: aliceblue;
 }
 
 .internal-slots {


### PR DESCRIPTION
The algorithm and internal slot boxes had hard-coded CSS background colors set which didn't adjust when the page was viewed in dark mode.

They are simply removed as they don't seem necessary.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/reillyeon/webnn/pull/557.html" title="Last updated on Feb 6, 2024, 6:38 PM UTC (ee958c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/557/c9d2dd7...reillyeon:ee958c0.html" title="Last updated on Feb 6, 2024, 6:38 PM UTC (ee958c0)">Diff</a>