### PR TITLE
Style: Prefer characters to entities

### DIFF
--- a/docs/SpecCodingConventions.md
+++ b/docs/SpecCodingConventions.md
@@ -73,6 +73,15 @@ Example:
 * When referencing an operator in text (e.g. sigmoid, tanh, etc), link the operator name to the `MLGraphBuilder` methods for creating the corresponding `MLOperand` or `MLActivation`, e.g. `{{MLGraphBuilder/sigmoid()}}`. This provides consistent styling, and provides a thorough overview of the operator, even if the method itself isn't being discussed.
 
 
+### Characters and Encoding
+
+* The spec is encoded with UTF-8.
+* For non-ASCII characters, prefer to use characters directly, rather than [character references](https://html.spec.whatwg.org/multipage/syntax.html#character-references) (a.k.a. entities), except when necessary for escaping e.g. `sequence&lt;DOMString&gt;`. These commonly occur in names in the Acknowledgements and References sections.
+* Commonly used punctuation and symbol characters include:
+    * « » (U+00AB / U+00BB Left/Right Pointing Double Angle Quotation Marks) used for [list literals](https://infra.spec.whatwg.org/#lists))
+    * → (U+2192 Rightwards Arrow) used for [map iteration](https://infra.spec.whatwg.org/#map-iterate)
+
+
 ### Formatting
 
 * Bikeshed will automatically style linked terms appropriately, for example Web IDL types show up as `code`. Try to avoid manual styling wherever possible; if you're not getting the style you expect, you may have incorrect definitions or links.

--- a/docs/SpecCodingConventions.md
+++ b/docs/SpecCodingConventions.md
@@ -78,7 +78,7 @@ Example:
 * The spec is encoded with UTF-8.
 * For non-ASCII characters, prefer to use characters directly, rather than [character references](https://html.spec.whatwg.org/multipage/syntax.html#character-references) (a.k.a. entities), except when necessary for escaping e.g. `sequence&lt;DOMString&gt;`. These commonly occur in names in the Acknowledgements and References sections.
 * Commonly used punctuation and symbol characters include:
-    * « » (U+00AB / U+00BB Left/Right Pointing Double Angle Quotation Marks) used for [list literals](https://infra.spec.whatwg.org/#lists))
+    * « » (U+00AB / U+00BB Left/Right Pointing Double Angle Quotation Marks) used for [list literals](https://infra.spec.whatwg.org/#lists)
     * → (U+2192 Rightwards Arrow) used for [map iteration](https://infra.spec.whatwg.org/#map-iterate)
 
 

--- a/index.bs
+++ b/index.bs
@@ -945,7 +945,7 @@ When the {{MLContext/[[contextType]]}} is set to [=context type/default=] with t
     To <dfn>validate graph resources</dfn>, given {{MLNamedArrayBufferViews}} |resources| and [=ordered map=] |descriptors|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. [=map/For each=] |name| &rarr; |resource| of |resources|:
+    1. [=map/For each=] |name| → |resource| of |resources|:
         1. If |descriptors|[|name|] does not [=map/exist=], return false.
         1. If [=validating buffer with descriptor=] given |resource| and |descriptors|[|name|] returns false, then return false.
     1. Return true.
@@ -968,14 +968,14 @@ When the {{MLContext/[[contextType]]}} is set to [=context type/default=] with t
   </summary>
   <div class=algorithm-steps>
     1. Let |inputResources| denote the input resources of |graph|.{{MLGraph/[[implementation]]}}.
-    1. [=map/For each=] |name| &rarr; |inputValue| of |inputs|:
+    1. [=map/For each=] |name| → |inputValue| of |inputs|:
         1. Let |inputDescriptor| be |graph|.{{MLGraph/[[inputDescriptors]]}}[|name|].
         1. Let |inputTensor| be a new tensor for |graph|.{{MLGraph/[[implementation]]}} as follows:
             1. Set the data type of |inputTensor| to the one that matches |inputValue|'s [=element type=].
             1. Set the dimensions of |inputTensor| to |inputDescriptor|.{{MLOperandDescriptor/dimensions}}.
             1. Set the values of elements in |inputTensor| to the values of elements in |inputValue|.
         1. Request the underlying implementation of |graph| to bind |inputResources|[|name|] to |inputTensor|.
-    1. [=map/For each=] |name| &rarr; |outputValue| of |outputs|:
+    1. [=map/For each=] |name| → |outputValue| of |outputs|:
         1. Issue a compute request to |graph|.{{MLGraph/[[implementation]]}} given |name| and |inputResources| and wait for completion.
             1. If that returns an error, then [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
             1. Otherwise, store the result in |outputTensor|.
@@ -995,7 +995,7 @@ When the {{MLContext/[[contextType]]}} is set to [=context type/default=] with t
   </summary>
   <div class=algorithm-steps>
     1. Let |transferredViews| be a new {{MLNamedArrayBufferViews}}.
-    1. [=map/For each=] |name| &rarr; |view| of |views|:
+    1. [=map/For each=] |name| → |view| of |views|:
         1. Let |transferredBuffer| be the result of [=ArrayBuffer/transfer|transferring=] |view|'s [=underlying buffer=].
         1. Let |constructor| be the appropriate [=view constructor=] for the type of {{ArrayBufferView}} |view|.
         1. Let |elementsNumber| be the result of |view|'s [=BufferSource/byte length=] ÷ |view|'s [=element size=].
@@ -1363,7 +1363,7 @@ Build a composed graph up to a given output operand into a computational graph a
     1. Let |promise| be [=a new promise=].
     1. Return |promise| and run the following steps [=in parallel=]:
         1. If |outputs| is empty, then [=reject=] |promise| with a {{TypeError}}, and abort these steps.
-        1. [=map/For each=] |name| &rarr; |operand| of |outputs|:
+        1. [=map/For each=] |name| → |operand| of |outputs|:
             1. If |name| is empty, then [=reject=] |promise| with a {{TypeError}}, and abort these steps.
         1. If any of the following sub-steps fail, then [=reject=] |promise| with an "{{OperationError}}" {{DOMException}}, and abort these steps.
             1. Let |graph| be a new {{MLGraph}}:
@@ -1372,7 +1372,7 @@ Build a composed graph up to a given output operand into a computational graph a
                 1. Connect |graph| to a new [=implementation-defined=] graph implementation |graphImpl| given |graph|.
                 1. Set |graph|.{{MLGraph/[[implementation]]}} to |graphImpl|.
             1. Make a request to the underlying platform to initialize the graph:
-                1. [=map/For each=] |name| &rarr; |operand| of |outputs|:
+                1. [=map/For each=] |name| → |operand| of |outputs|:
                     1. If [=validating MLOperand=] given |operand| and [=this=] returns false, then [=reject=] |promise| with a {{TypeError}}, and abort these steps.
                     1. If |operand| was created as an input by the underlying platform:
                         1. If |operand|.{{MLOperand/[[name]]}} is not unique for |graphImpl|, then [=reject=] |promise| with a {{TypeError}}, and abort these steps.
@@ -2575,23 +2575,23 @@ partial interface MLGraphBuilder {
     1. Let |axis| be |options|.{{MLGatherOptions/axis}}.
     1. Let |axisSize| be |input|'s [=MLOperand/shape=][|axis|]
     1. If |axis| is greater than or equal to |rankInput|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. [=map/For each=] |index| &rarr; |value| of |indices|:
+    1. [=map/For each=] |index| → |value| of |indices|:
         1. If |index| is greater than or equal to |axisSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |dimCount| be zero.
     1. Let |rankOutput| be zero.
     1. Let |shapeOutput| be an empty list.
-    1. [=map/For each=] |size| &rarr; |value| of |shapeInput|:
+    1. [=map/For each=] |size| → |value| of |shapeInput|:
         1. If |dimCount| is equal to |axis| then [=break=].
         1. Set |shapeOutput|[|dimCount|] to |size|.
         1. Increment |dimCount| by one.
     1. Set |rankOutput| to |dimCount|.
     1. Let |dimCount| be zero.
-    1. [=map/For each=] |size| &rarr; |value| of |shapeIndices|:
+    1. [=map/For each=] |size| → |value| of |shapeIndices|:
         1. Set |shapeOutput|[|rankOutput| + |dimCount|] to |size|.
         1. Increment |dimCount| by one.
     1. Set |rankOutput| to |rankOutput| + |dimCount|.
     1. Let |dimCount| be zero.
-    1. [=map/For each=] |size| &rarr; |value| of |shapeInput|:
+    1. [=map/For each=] |size| → |value| of |shapeInput|:
         1. If |dimCount| is less than or equal to |axis| then [=continue=].
         1. Set |shapeOutput|[|rankOutput| + |dimCount| - |axis| - 1] to |size|.
         1. Increment |dimCount| by one.


### PR DESCRIPTION
Replace `&rarr;` with → and document this preference.

Really, really minor editorial change. I think the use of `&rarr;` was my fault.

When #506 is resolved, we should document the outcome as well.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/570.html" title="Last updated on Feb 15, 2024, 7:14 PM UTC (ccce939)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/570/c4c369a...inexorabletash:ccce939.html" title="Last updated on Feb 15, 2024, 7:14 PM UTC (ccce939)">Diff</a>