### PR TITLE
Bug fix: Fix MLGraphBuilder.input()'s handling of scalars. Fixes #502

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3318,8 +3318,7 @@ Create a named {{MLOperand}} based on a descriptor, that can be used as an input
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
     1. If |name| is empty, then [=exception/throw=] a {{TypeError}}.
-    1. [=Assert=]: If |descriptor|.{{MLOperandDescriptor/dimensions}} does not [=map/exist=], then |descriptor| defines a scalar input.
-    1. If |descriptor|.{{MLOperandDescriptor/dimensions}} [=map/exists=]:
+    1. If |descriptor|.{{MLOperandDescriptor/dimensions}}'s [=list/size=] is not 0:
         1. If [=checking dimensions=] given |descriptor|.{{MLOperandDescriptor/dataType}} and |descriptor|.{{MLOperandDescriptor/dimensions}} returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |descriptor|'s [=byte length=] is not supported by the underlying platform, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.


### PR DESCRIPTION
MLOperandDescriptor was updated in c320472d to always have dimensions, defaulted to an empty list for scalars. That makes the current prose for input() incorrect. Issue #502 already tracked correcting it, so let's simplify - just change the logic for "is a scalar?" and drop the bogus assert.

Note that I didn't leave a note about empty dimensions being a scalar, but can add that if desired.