### PR TITLE
Style: Make grouped algorithm steps consistent

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1238,6 +1238,7 @@ partial interface MLGraphBuilder {
   <summary>
     The following argMin/argMax algorithms are supported.
   </summary>
+  <div class=algorithm-steps>
     <div algorithm>
     The <dfn method for=MLGraphBuilder>argMin(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/argminmax-op | create argMin/argMax operation=] given "argMin", |input| and |options|.
@@ -1251,6 +1252,7 @@ partial interface MLGraphBuilder {
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
     </div>
+  </div>
 </details>
 
 ### batchNormalization ### {#api-mlgraphbuilder-batchnorm}

--- a/index.bs
+++ b/index.bs
@@ -4487,25 +4487,27 @@ partial interface MLGraphBuilder {
   <summary>
     The following pooling algorithms are supported.
   </summary>
-  <div algorithm class=algorithm-steps>
+  <div class=algorithm-steps>
+    <div algorithm>
     The <dfn method for=MLGraphBuilder>averagePool2d(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/pooling-op | create pooling operation=] given "averagePool2d", |input| and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
-  </div>
+    </div>
 
-  <div algorithm class=algorithm-steps>
+    <div algorithm>
     The <dfn method for=MLGraphBuilder>l2Pool2d(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/pooling-op | create pooling operation=] given "l2Pool2d", |input| and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
-  </div>
+    </div>
 
-  <div algorithm class=algorithm-steps>
+    <div algorithm>
     The <dfn method for=MLGraphBuilder>maxPool2d(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/pooling-op | create pooling operation=] given "maxPool2d", |input| and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
+    </div>
   </div>
 </details>
 
@@ -4656,6 +4658,7 @@ partial interface MLGraphBuilder {
   <summary>
     The following reduce algorithms are supported.
   </summary>
+  <div class=algorithm-steps>
     <div algorithm>
     The <dfn method for=MLGraphBuilder>reduceL1(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceL1", |input| and |options|.
@@ -4725,6 +4728,7 @@ partial interface MLGraphBuilder {
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
     </div>
+  </div>
 </details>
 
 ### relu ### {#api-mlgraphbuilder-relu-method}


### PR DESCRIPTION
For operations defined in bulk - argMin/argMax, element-wise binary, unary, and logical ops, plus pooling and reduction ops - make the styling consistent:

- A single `<div class=algorithm-steps>` around all definitions
- A separate `<div algorithm>` around each op's steps.

This was already done for the element-wise ops so already the majority style. Pooling ops now have just a single "Algorithm" watermark (instead of 3), and argMin/argMax and reduction ops now have a watermark instead of none.

For #450


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/576.html" title="Last updated on Feb 21, 2024, 5:27 PM UTC (b57760b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/576/4ad9a63...inexorabletash:b57760b.html" title="Last updated on Feb 21, 2024, 5:27 PM UTC (b57760b)">Diff</a>