### PR TITLE
Bug fix: Make concat() validation and initialization more precise.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1554,22 +1554,24 @@ partial interface MLGraphBuilder {
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
-    1. [=Assert=]: the shape, i.e. {{MLOperandDescriptor/dimensions}} of each operand in |inputs| is the same, except on the dimension given by |axis| on which they are concatenated.
-    1. [=Assert=]: the {{MLOperandDescriptor/dataType}} of each operand in |inputs| is the same.
-    1. If any of the following steps fail, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. Let |desc| be |inputs|[0].{{MLOperand/[[descriptor]]}}.
-        1. If |axis| is greater than or equal to |desc|'s [=rank=], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-        1. Set |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] to 0.
-        1. [=list/For each=] |index| in [=the range=] 0 to |inputs|'s [=rank=], exclusive:
-            1. Let |input| be |inputs|[|index|].
-            1. If [=validating MLOperand=] given |input| and [=this=] returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-            1. If |input|'s [=MLOperand/dataType=] is not equal to |inputs|[0]'s [=MLOperand/dataType=], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-            1. [=list/For each=] |dim| in [=the range=] 0 to |input|'s [=rank=], exclusive:
-                <div class="note">
-                    If the shape of each corresponding dimension and type of the operands, except for those of the dimension given by |axis|, is not the same, fail.
-                </div>
-                1. If |dim| is not equal to |axis| and if |input|'s [=MLOperand/shape=][|dim|] is not equal to |inputs|[0]'s [=MLOperand/shape=][|dim|], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-                1. If |dim| is equal to |axis|, add to |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] the value of |input|'s [=MLOperand/shape=][|dim|].
+    1. If |inputs| [=list/is empty=], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Let |first| be |inputs|[0].
+    1. If |axis| is greater than or equal to |first|'s [=rank=], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+    1. Let |desc| be a new {{MLOperandDescriptor}}.
+    1. Set |desc|.{{MLOperandDescriptor/dataType}} to |first|'s [=MLOperand/dataType=].
+    1. Set |desc|.{{MLOperandDescriptor/dimensions}} to a [=list/clone=] of |first|'s [=MLOperand/shape=].
+    1. Set |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] to 0.
+    1. [=list/For each=] |index| in [=the range=] 0 to |inputs|'s [=list/size=], exclusive:
+        1. Let |input| be |inputs|[|index|].
+        1. If [=validating MLOperand=] given |input| and [=this=] returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |input|'s [=MLOperand/dataType=] is not equal to |first|'s [=MLOperand/dataType=], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. If |input|'s [=MLOperand/rank=] is not equal to |first|'s [=MLOperand/rank=], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+        1. [=list/For each=] |dim| in [=the range=] 0 to |input|'s [=rank=], exclusive:
+            <div class="note">
+                If the shape of each corresponding dimension and type of the operands, except for those of the dimension given by |axis|, is not the same, fail.
+            </div>
+            1. If |dim| is not equal to |axis| and if |input|'s [=MLOperand/shape=][|dim|] is not equal to |first|'s [=MLOperand/shape=][|dim|], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
+            1. If |dim| is equal to |axis|, add to |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] the value of |input|'s [=MLOperand/shape=][|dim|].
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
         1. Make a request to the underlying platform to:

--- a/index.bs
+++ b/index.bs
@@ -1560,8 +1560,8 @@ partial interface MLGraphBuilder {
     1. Let |desc| be a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dataType}} to |first|'s [=MLOperand/dataType=].
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to a [=list/clone=] of |first|'s [=MLOperand/shape=].
-    1. Set |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] to 0.
-    1. [=list/For each=] |index| in [=the range=] 0 to |inputs|'s [=list/size=], exclusive:
+    1. Set |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] to |first|'s [=MLOperand/shape=][|axis|].
+    1. [=list/For each=] |index| in [=the range=] 1 to |inputs|'s [=list/size=], exclusive:
         1. Let |input| be |inputs|[|index|].
         1. If [=validating MLOperand=] given |input| and [=this=] returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |input|'s [=MLOperand/dataType=] is not equal to |first|'s [=MLOperand/dataType=], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.


### PR DESCRIPTION
- Validate that inputs is non-empty, present in the Chromium prototype implementation.
- Add local "first" variable, to simplify steps.
- Drop assertion about dataTypes being the same, already covered by the algorithm.
- Add step validating that the ranks are the same, present in the Chromium prototype implementation, and drop the assertion.
- Make output descriptor creation more explicit.
- Drop "If any of the following steps fail" since the steps explicitly threw already.
- Init desc.dimensions[axis] from "first" and start loop at 1.

Fixes #503


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/577.html" title="Last updated on Feb 21, 2024, 6:15 PM UTC (4b3f05e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/577/4ad9a63...inexorabletash:4b3f05e.html" title="Last updated on Feb 21, 2024, 6:15 PM UTC (4b3f05e)">Diff</a>