### PR TITLE
Bug fix: Correct an unclosed autolink 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -787,7 +787,7 @@ Its [=policy-controlled feature/default allowlist=] is <code>'self'</code>.
 
 <details open algorithm>
 <summary>
-    To <dfn>create a context</dfn> given |options| (a {{GPUDevice}} or {{MLContextOptions), run these steps:
+    To <dfn>create a context</dfn> given |options| (a {{GPUDevice}} or {{MLContextOptions}}), run these steps:
 </summary>
 <div class=algorithm-steps>
     1. Let |context| be a new {{MLContext}} object.


### PR DESCRIPTION
Just a missing `}}`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/581.html" title="Last updated on Feb 22, 2024, 8:50 PM UTC (43d2e1e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/581/a6326c0...inexorabletash:43d2e1e.html" title="Last updated on Feb 22, 2024, 8:50 PM UTC (43d2e1e)">Diff</a>