### PR TITLE
Content: Define operand concept, simplify graph connection steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -694,21 +694,11 @@ graphs of neural networks.
 
 The {{MLGraph}} interface represents a compiled computational graph that is immutable (that is, a model).
 
-The {{MLGraphBuilder}} interface serves as a builder (factory) to create an {{MLGraph}}.
-An {{MLOperand}} is a representation of data that flows within the computational graph,
-which include input-values for inference, constants (including trained weights)
-used for inference, intermediate values (often referred to as activations) computed
-during inference, as well as the output values of inference.
-At inference time, every {{MLOperand}} will be bound to a tensor (the actual data).
+The {{MLGraphBuilder}} interface serves as a builder (factory) to construct the computation graph that is then compiled to create an MLGraph.
 
-The {{MLGraphBuilder}} interface enables the creation of {{MLOperand}}s.
-A key part of the {{MLGraphBuilder}} interface are the operations (such as
-{{MLGraphBuilder}}.{{MLGraphBuilder/gemm()}} and {{MLGraphBuilder}}.{{MLGraphBuilder/softmax()}}). The operations have a functional
-semantics, with no side effects.
-Each operation invocation conceptually returns a distinct new value, without
-changing the value of any other {{MLOperand}}. 
+In WebNN, the computational graph is composed of <dfn>operators</dfn> which act on data, and are the nodes of the graph. An [=operator=]'s <dfn for=operator>input</dfn> is one or more {{MLOperand}}s representing the data flow for the computation, and are the edges of the graph. Operands include input values, constants (including trained weights), and intermediate values (often referred to as activations). An [=operator=]'s <dfn for=operator>output</dfn> is one or more {{MLOperand}}s, representing the output values of the computation. [=Operators=] have operator-specific parameters that control their behavior, which can include zero or more <dfn for=operator lt="activation|activation function">activation functions</dfn>, which are {{MLActivation}}s. The operations have functional semantics, with no side effects. Each operation invocation conceptually returns a distinct new value, without changing the value of any other {{MLOperand}}.
 
-Internally, the {{MLGraphBuilder}} methods such as {{MLGraphBuilder/gemm()}} create an [=implementation-defined=] <dfn>platform operator</dfn> which is held by the {{MLOperand}} or {{MLActivation}}, which performs the actual operation on the input data when the computation is run. An {{MLOperand}} also holds an [=implementation-defined=] <dfn>platform operand</dfn>, which references the operand in the underlying computational graph, and is connected to [=platform operators=] as input and/or output.
+A key part of the {{MLGraphBuilder}} interface are methods such as {{MLGraphBuilder/gemm()}} and {{MLGraphBuilder/softmax()}} which create an operator which represents actual operation to perform on the input data when the computation is run, and return a new {{MLOperand}} or {{MLActivation}} holding the operator. Methods that create an {{MLOperand}} connect any [=operator/inputs=] and [=operator/activations=] to the operator.
 
 The runtime values (of {{MLOperand}}s) are tensors, which are essentially multidimensional
 arrays. The representation of the tensors is implementation dependent, but it typically
@@ -725,6 +715,8 @@ The implementation may use views, as above, for intermediate values.
 Before the execution, the computation graph that is used to compute one or more specified outputs needs to be compiled and optimized. The key purpose of the compilation step is to enable optimizations that span two or more operations, such as operation or loop fusion.
 
 The {{MLGraphBuilder}}.{{MLGraphBuilder/build()}} method compiles the graph in the background without blocking the calling thread, and returns a {{Promise}} that resolves to an {{MLGraph}}. The compilation step produces an {{MLGraph}} that represents a compiled graph for optimal execution.
+
+The {{MLGraph}} is composed of <dfn>platform operators</dfn> and <dfn>platform operands</dfn> which correspond to the [=operators=] and {{MLOperand}}s, but are not script-visible and may be compositions or decompositions of the graph as constructed by script.
 
 Once the {{MLGraph}} is constructed, the {{MLContext}}.{{MLContext/compute()}} method performs the execution of the graph asynchronously either on a parallel timeline in a separate worker thread for the CPU execution or on a GPU timeline in a GPU command queue. This method returns immediately without blocking the calling thread while the actual execution is offloaded to a different timeline. The caller supplies the input values using {{MLNamedArrayBufferViews}}, binding the input {{MLOperand}}s to their values. The caller then supplies pre-allocated buffers for output {{MLOperand}}s using {{MLNamedArrayBufferViews}}. The execution produces the results of the computation from all the inputs bound to the graph. The computation results will be placed at the bound outputs at the time the operation is successfully completed on the offloaded timeline at which time the calling thread is signaled. This type of execution supports both the CPU and GPU device.
 
@@ -1148,13 +1140,9 @@ interface MLOperand {
     ::
         The {{MLOperand}}'s name (only for input operands).
 
-    : <dfn>\[[operand]]</dfn> of type [=platform operand=]
+    : <dfn>\[[operator]]</dfn> of type [=operator=]
     ::
-        Reference to {{MLOperand}}'s corresponding [=platform operand=].
-
-    : <dfn>\[[operator]]</dfn> of type [=platform operator=]
-    ::
-        Reference to {{MLOperand}}'s corresponding [=platform operator=].
+        Reference to {{MLOperand}}'s corresponding [=operator=].
   </dl>
 </div>
 
@@ -1259,9 +1247,9 @@ interface MLActivation {};
     : <dfn>\[[options]]</dfn> of type [=ordered map=]
     ::
         A dictionary containing {{MLActivation}} options.
-    : <dfn>\[[operator]]</dfn> of type [=platform operator=]
+    : <dfn>\[[operator]]</dfn> of type [=operator=]
     ::
-        Reference to {{MLActivation}}'s corresponding [=platform operator=].
+        Reference to {{MLActivation}}'s corresponding [=operator=].
   </dl>
 </div>
 
@@ -1283,12 +1271,10 @@ The {{MLActivation}} objects (including the ones passed as input to methods) are
     1. Set |activation|.{{MLActivation/[[builder]]}} to |builder|.
     1. Set |activation|.{{MLActivation/[[name]]}} to |name|.
     1. If |options| is given, set |activation|.{{MLActivation/[[options]]}} to |options|.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-        1. Make a request to the underlying platform to:
-            1. Create [=platform operator=] |opImpl| for the given |name| operation.
-            1. Set |activation|.{{MLActivation/[[operator]]}} to |opImpl|.
-        1. If |init-steps| are given, run |init-steps| with |options|.
-            1. Otherwise, initialize |activation|.{{MLActivation/[[operator]]}} given |options| in an [=implementation-defined=] way for the given |name| operation.
+    1. Let |operator| be an [=operator=] for the |name| operation.
+    1. Set |activation|.{{MLActivation/[[operator]]}} to |operator|.
+    1. If |init-steps| are given, run |init-steps| with |options|.
+    1. Otherwise, initialize |activation|.{{MLActivation/[[operator]]}} given |options| in an [=implementation-defined=] way for the given |name| operation.
     1. Return |activation|.
   </div>
 </details>
@@ -1367,13 +1353,10 @@ Create a named {{MLOperand}} based on a descriptor, that can be used as an input
     </div>
     1. If |name| is empty, then [=exception/throw=] a {{TypeError}}.
     1. If [=MLOperandDescriptor/checking dimensions=] given |descriptor| returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |operand| be the result of [=creating an MLOperand=] given [=this=] and |descriptor|.
         1. Set |operand|.{{MLOperand/[[name]]}} to |name|.
-        1. Make a request to the underlying platform to:
-            1. Create an [=implementation-defined=] platform input operand |operandImpl| given |descriptor|.
-            1. Set |operand|.{{MLOperand/[[operand]]}} to |operandImpl|.
-            1. Register |operand| as an input.
+        1. Register |operand| as an input.
     1. Return |operand|.
   </div>
 </details>
@@ -1401,13 +1384,10 @@ Create a constant {{MLOperand}} of the specified data type and shape that contai
     </div>
     1. If [=MLOperandDescriptor/checking dimensions=] given |descriptor| returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If [=validating buffer with descriptor=] given |bufferView| and |descriptor| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |operand| be the result of [=creating an MLOperand=] given [=this=] and |descriptor|.
         1. Let |bytes| be the result of [=getting a copy of the bytes held by the buffer source=] given |bufferView|.
-        1. Make a request to the underlying platform to:
-            1. Create an [=platform operand=] |constantImpl| to represent a constant, given |descriptor|.
-            1. Set |operand|.{{MLOperand/[[operand]]}} to |constantImpl|.
-            1. Register |operand| as a tensor constant with |bytes| as value.
+        1. Register |operand| as a tensor constant with |bytes| as value.
     1. Return |operand|.
   </div>
 </details>
@@ -1437,12 +1417,9 @@ Data truncation will occur when the specified value exceeds the range of the spe
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
         1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |type|.
         1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to an empty [=/list=].
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |operand| be the result of [=creating an MLOperand=] given [=this=] and |descriptor|.
-        1. Make a request to the underlying platform to:
-            1. Create an [=platform operand=] |constantImpl| to represent a constant, given |descriptor|.
-            1. Set |operand|.{{MLOperand/[[operand]]}} to |constantImpl|.
-            1. Register |operand| as a scalar constant with |value| as value.
+        1. Register |operand| as a scalar constant with |value| as value.
     1. Return |operand|.
   </div>
 </details>
@@ -1473,19 +1450,14 @@ Data truncation will occur when the values in the range exceed the range of the 
     </div>
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
         1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |type|.
-        1. Let |size| be *max(0, ceil((end - start)/step))*.
+        1. Let |size| be max(0, ceil((|end| - |start|)/|step|)).
         1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to the [=/list=] « |size| ».
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-        1. Let |operand| be the result of [=creating an MLOperand=] given [=this=], |start|, |end|, |step|, and |type|.
-        1. Make a request to the underlying platform to:
-            1. Create an [=implementation-defined=] platform memory buffer the size of |size| multiplied by sizeof(|descriptor|.{{MLOperandDescriptor/dataType}}).
-            2. Store the beginning address to that memory buffer as a pointer |buffer| of the corresponding data type.
+    1. *Make graph connections:*
+        1. Let |operand| be the result of [=creating an MLOperand=] given [=this=] and |descriptor|.
+        1. Let |buffer| be an [=implementation-defined=] platform memory buffer the size of |size| multiplied by sizeof(|descriptor|.{{MLOperandDescriptor/dataType}}).
         1. [=list/For each=] |index| in [=the range=] 0 to |size|, exclusive:
             1. Set |buffer|[|index|] to |start| + (|index| * |step|).
-        1. Make a request to the underlying platform to:
-            1. Create an [=platform operand=] |constantImpl| to represent a constant operand, given |descriptor|.
-            1. Set |operand|.{{MLOperand/[[operand]]}} to |constantImpl|.
-            1. Register |operand| as a constant with |buffer| as value.
+        1. Register |operand| as a constant with |buffer| as value.
     1. Return |operand|.
   </div>
 </details>
@@ -1517,13 +1489,15 @@ Build a composed graph up to a given output operand into a computational graph a
                         1. Add |operand|.{{MLOperand/[[descriptor]]}} to |graph|.{{MLGraph/[[inputDescriptors]]}}[|operand|.{{MLOperand/[[name]]}}].
                     1. If |operand| was created as a constant by the underlying platform:
                         1. Implementations MAY preprocess and optimize the tensor data of |operand| for the underlying platform.
-                    1. Register |operand|.{{MLOperand/[[operand]]}} in |graphImpl| as graph output.
-                    1. Register |operand|.{{MLOperand/[[operator]]}} to |graphImpl|.
-                
+                    1. Register a [=platform operand=] representing |operand| in |graphImpl| as graph output.
+                    1. Register a [=platform operator=] representing |operand|.{{MLOperand/[[operator]]}} to |graphImpl|.
+
                 Issue(552): Decide how to specify graph initialization.
         1. [=Resolve=] |promise| with |graph|.
   </div>
 </details>
+
+Issue(448): More fully specify the behavior of {{MLGraphBuilder/build()}} in terms of traversing the graph of [=operators=] and {{MLOperand}}s, creating the corresponding [=platform operators=] and [=platform operands=], and connecting [=operator/inputs=], [=operator/outputs=], and [=operator/activations=].
 
 
 ### argMin/argMax operations ### {#api-mlgraphbuilder-argminmax}
@@ -1576,15 +1550,12 @@ partial interface MLGraphBuilder {
     1. Let |desc| be a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dataType}} to {{MLOperandDataType/"int64"}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |outputShape|.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
+        1. Let |operator| be an [=operator=] for the operation |op|, given |options|.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the |op| argMin or argMax operation, given |options|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -1677,12 +1648,13 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLBatchNormalizationOptions/bias}} [=map/exists=]:
         1. If its [=list/size=] is not 1, then [=exception/throw=] a {{TypeError}}.
         1. If |options|.{{MLBatchNormalizationOptions/bias}}'s [=MLOperand/shape=][0] is not equal to |input|'s [=MLOperand/shape=][|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
+        1. Let |operator| be an [=operator=] for the batchNormalization operation, given |input|, |mean|, |variance| and |options|.
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |input|.{{MLOperand/[[descriptor]]}}, that may use the same underlying data as |input|.
-        1. Make a request to the underlying platform to initialize the batch normalization:
-            1. Create [=platform operator=] |batchNormImpl| for this method, given |input|, |mean|, |variance| and |options|.
-            1. If |options|.{{MLBatchNormalizationOptions/activation}} [=map/exists=],register it as activation to |batchNormImpl|.
-            1. Connect |output| as output to |batchNormImpl|.
+        1. If |options|.{{MLBatchNormalizationOptions/activation}} [=map/exists=], then add it to |operator|'s [=operator/activation functions=].
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -1728,16 +1700,12 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>cast(|input|, |type|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-        1. Let |operand| be the result of [=creating an MLOperand=] given [=this=], |input| and |type|.
+    1. *Make graph connections:*
+        1. Let |operator| be an [=operator=] for the cast operation, given |type|.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Create [=platform operator=] |castImpl| for this method, given |type|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |castImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent an output, given |output| and |castImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |operand|.{{MLOperand/[[operand]]}} as input to |castImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |castImpl|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -1811,15 +1779,12 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. If [=checking clamp options=] given |options| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Create [=platform operator=] |clampImpl| for this method, given |options|.{{MLClampOptions/minValue}} and |options|.{{MLClampOptions/maxValue}}.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |clampImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent clamp output, given |output| and |clampImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |clampImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |clampImpl|.
+        1. Let |operator| be an [=operator=] for the clamp operation, given |options|.{{MLClampOptions/minValue}} and |options|.{{MLClampOptions/maxValue}}.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -1893,15 +1858,12 @@ partial interface MLGraphBuilder {
             </div>
             1. If |dim| is not equal to |axis| and if |input|'s [=MLOperand/shape=][|dim|] is not equal to |first|'s [=MLOperand/shape=][|dim|], then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
             1. If |dim| is equal to |axis|, add to |desc|.{{MLOperandDescriptor/dimensions}}[|axis|] the value of |input|'s [=MLOperand/shape=][|dim|].
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
-        1. Make a request to the underlying platform to:
-            1. Create [=platform operator=] |concatImpl| for this method, given |inputs| and |axis|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |concatImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent output,given |output| and |concatImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |inputs| as input to |concatImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |concatImpl|.
+        1. Let |operator| be an [=operator=] for the concat operation, given |inputs| and |axis|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -2090,16 +2052,13 @@ partial interface MLGraphBuilder {
     1. Let |desc| be a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |outputShape|.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
-        1. Make a request to the underlying platform to:
-            1. Create [=platform operator=] |conv2dImpl| for this method, given |options| and |filter|.
-                1. If |options|.{{MLConv2dOptions/activation}} [=map/exists=],register it as activation to |conv2dImpl|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |conv2dImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |conv2dImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |conv2dImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |conv2dImpl|.
+        1. Let |operator| be an [=operator=] for the conv2d operation, given |options| and |filter|.
+        1. If |options|.{{MLConv2dOptions/activation}} [=map/exists=], then add it to |operator|'s [=operator/activations=].
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -2305,16 +2264,13 @@ partial interface MLGraphBuilder {
     1. Let |desc| be a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |outputShape|.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
-        1. Make a request to the underlying platform to:
-            1. Create [=platform operator=] |convTranspose2dImpl| for this method, given |options| and |filter|.
-                1. If |options|.{{MLConvTranspose2dOptions/activation}} [=map/exists=],register it as activation to |convTranspose2dImpl|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |convTranspose2dImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |convTranspose2dImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |convTranspose2dImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |convTranspose2dImpl|.
+        1. Let |operator| be an [=operator=] for the convTranspose2d operation, given |options| and |filter|.
+        1. If |options|.{{MLConvTranspose2dOptions/activation}} [=map/exists=], add it to |operator|'s [=operator/activations=].
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -2369,15 +2325,12 @@ partial interface MLGraphBuilder {
     1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |a|'s [=MLOperand/dataType=].
     1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to the result of [=bidirectionally broadcasting the shapes=] |a|'s [=MLOperand/shape=] and |b|'s [=MLOperand/shape=].
         1. If that returns failure, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |descriptor|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the binary operation |op|, given |a| and |b|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |a|.{{MLOperand/[[operand]]}} and |b|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the binary operation |op|, given |a| and |b|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/inputs=] to |a| and |b|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -2490,15 +2443,12 @@ Although operations {{MLGraphBuilder/greaterOrEqual()}} and {{MLGraphBuilder/les
     1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to {{MLOperandDataType/"uint8"}}.
     1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to the result of [=bidirectionally broadcasting the shapes=] |a|'s [=MLOperand/shape=] and |b|'s [=MLOperand/shape=].
         1. If that returns failure, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |descriptor|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the binary operation |op|, given |a| and |b|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |a|.{{MLOperand/[[operand]]}} and |b|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the binary operation |op|, given |a| and |b|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/inputs=] to |a| and |b|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -2604,15 +2554,12 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "abs", "ceil", "cos", "erf", "exp", "floor", "identity", "log", "neg", "reciprocal", "sin", "sqrt", "tan".
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the unary operation |op|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the unary operation |op|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -2765,15 +2712,12 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>elu(|input|, |options|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the ELU operation, given |options|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the ELU operation, given |options|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -2826,15 +2770,12 @@ partial interface MLGraphBuilder {
     1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].
     1. Set |outputDescriptor|.{{MLOperandDescriptor/dimensions}} to the result of [=unidirectionally broadcasting the shapes=] |input|'s [=MLOperand/shape=] and |newShape|.
         1. If that returns failure, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |outputDescriptor|.
-        1. Make a request to the underlying platform to:
-            1. Create [=platform operator=] |expandImpl| for this method, given |input| and |newShape|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |expandImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent output,given |output| and |expandImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input| as input to |expandImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |expandImpl|.
+        1. Let |operator| be an [=operator=] for the expand operation, given |input| and |newShape|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -2901,15 +2842,12 @@ partial interface MLGraphBuilder {
     1. Let |desc| be a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |shapeOutput|.
     1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given |desc|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the Gather operation, given |input|, |indices|, and |options|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} and |indices|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the Gather operation, given |input|, |indices|, and |options|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/inputs=] to |input| and |indices|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -3039,15 +2977,12 @@ partial interface MLGraphBuilder {
     1. Let |desc| be a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the [=/list=] « |shapeA|[0], |shapeB|[1] ».
     1. Set |desc|.{{MLOperandDescriptor/dataType}} to |a|'s [=MLOperand/dataType=].
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the GEMM operation, given |options|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |a|.{{MLOperand/[[operand]]}} and |b|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the GEMM operation, given |options|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/inputs=] to |a| and |b|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -3165,12 +3100,14 @@ partial interface MLGraphBuilder {
         1. If its [=MLOperand/rank=] is not 3, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and its [=list/size=] is not 2, then [=exception/throw=] a {{TypeError}}.
     1. If |steps| is not equal to |input|'s [=MLOperand/shape=][0], then [=exception/throw=] a {{TypeError}}.
-    1. Let |output| be an empty sequence of {{MLOperand}} objects.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for "gru", given |weight|, |recurrentWeight|, |steps|, |hiddenSize| and |options| as parameters.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output| as output to |opImpl|.
+    1. *Make graph connections:*
+        1. Let |operator| be an [=operator=] for "gru", given |weight|, |recurrentWeight|, |steps|, |hiddenSize| and |options| as parameters.
+        1. Let |output| be an empty sequence of {{MLOperand}} objects.
+
+            Issue: Populate |output|
+
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -3315,15 +3252,12 @@ partial interface MLGraphBuilder {
     1. Let |desc| be a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the [=/list=] « |input|'s [=MLOperand/shape=][0], |hiddenSize| ».
     1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for "gruCell", given |weight|, |recurrentWeight|, |hiddenState|, |hiddenSize| and |options| as parameters.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for "gruCell", given |weight|, |recurrentWeight|, |hiddenState|, |hiddenSize| and |options| as parameters.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -3489,15 +3423,12 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>hardSigmoid(|input|, |options|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the hard sigmoid operation, given |options|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the hard sigmoid operation, given |options|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -3569,15 +3500,12 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>hardSwish(|input|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the hard-swish operation.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the hard-swish operation.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -3656,15 +3584,12 @@ partial interface MLGraphBuilder {
     1. If |input|'s [=MLOperand/rank=] is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLInstanceNormalizationOptions/scale}}'s [=MLOperand/rank=] is not equal to 1, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLInstanceNormalizationOptions/bias}}'s [=MLOperand/rank=] is not equal to 1, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the instance normalization operation, given |options|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the instance normalization operation, given |options|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -3762,15 +3687,12 @@ partial interface MLGraphBuilder {
         1. Let |size| be |input|'s [=MLOperand/shape=][|axis|].
         1. If |options|.{{MLLayerNormalizationOptions/scale}}'s [=MLOperand/shape=][|index|] is not equal to |size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
         1. If |options|.{{MLLayerNormalizationOptions/bias}}'s [=MLOperand/shape=][|index|] is not equal to |size|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the instance normalization operation, given |options|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the instance normalization operation, given |options|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -3862,15 +3784,12 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>leakyRelu(|input|, |options|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the Leaky RELU operation, given |options|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the Leaky RELU operation, given |options|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -3952,15 +3871,12 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>linear(|input|, |options|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the linear operation, given |options|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the linear operation, given |options|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -4099,24 +4015,23 @@ partial interface MLGraphBuilder {
         1. If |options|.{{MLLstmOptions/initialCellState}}'s [=MLOperand/shape=][2] is not |hiddenSize|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |options|.{{MLLstmOptions/activations}} [=map/exists=]:
         1. If its [=list/size=] is not 3, then [=exception/throw=] a {{TypeError}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Calculate the output shape:*
         1. Let |desc| be a new {{MLOperandDescriptor}}.
         1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the [=/list=] « |numDirections|, |batchSize|, |hiddenSize| ».
         1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].
+        1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the [=/list=] « |steps|, |numDirections|, |batchSize|, |hiddenSize| ».
+    1. *Make graph connections:*
+        1. Let |operator| be an [=operator=] for the LSTM operation, given |weight|, |recurrentWeight|, |steps|, |hiddenSize| and |options|.
         1. Let |output0| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
         1. Let |output1| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
-        1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the [=/list=] « |steps|, |numDirections|, |batchSize|, |hiddenSize| ».
         1. If |options|.{{MLLstmOptions/returnSequence}} is set to true:
             1. Let |output2| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
             1. Let |output| be the [=/list=] « |output0|, |output1|, |output2| ».
-        1. Otherwise, let |output| be the [=/list=] « |output0|, |output1| ».
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the LSTM operation, given |weight|, |recurrentWeight|, |steps|, |hiddenSize| and |options|.
-            1. Set |output0|.{{MLOperand/[[operator]]}}, |output1|.{{MLOperand/[[operator]]}} and |output2|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output0|.{{MLOperand/[[operand]]}}, |output1|.{{MLOperand/[[operand]]}} and |output2|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output| as output to |opImpl|.
+        1. Otherwise:
+            1. Let |output| be the [=/list=] « |output0|, |output1| ».
+        1. Set |output0|.{{MLOperand/[[operator]]}}, |output1|.{{MLOperand/[[operator]]}} and |output2|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -4283,17 +4198,14 @@ partial interface MLGraphBuilder {
     1. Let |desc| be a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the [=/list=] « |batchSize|, |hiddenSize| ».
     1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output0| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
         1. Let |output1| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
         1. Let |output| be the [=/list=] « |output0|, |output1| ».
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the LSTM cell operation, given |weight|, |recurrentWeight|, |hiddenState|, |cellState|, |hiddenSize| and |options|.
-            1. Set |output0|.{{MLOperand/[[operator]]}} and |output1|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output0|.{{MLOperand/[[operand]]}} and |output1|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output| as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the LSTM cell operation, given |weight|, |recurrentWeight|, |hiddenState|, |cellState|, |hiddenSize| and |options|.
+        1. Set |output0|.{{MLOperand/[[operator]]}} and |output1|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -4471,15 +4383,12 @@ partial interface MLGraphBuilder {
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of [=MLGraphBuilder/calculating matmul output sizes=] given |a| and |b|.
     1. If that throws an error, re-[=exception/throw=] the error.
     1. Set |desc|.{{MLOperandDescriptor/dataType}} to |a|'s [=MLOperand/dataType=].
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the matrix multiplication operation.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |a|.{{MLOperand/[[operand]]}} and |b|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the matrix multiplication operation.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/inputs=] to |a| and |b|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -4552,15 +4461,12 @@ partial interface MLGraphBuilder {
     1. If |beginningPadding|'s [=list/size=] and |endingPadding|'s [=list/size=] are not both equal to |input|'s [=MLOperand/rank=], then [=exception/throw=] a "{{TypeError}}".
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of [=MLGraphBuilder/calculating padding output sizes=] given |input|, |beginningPadding| and |endingPadding|.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the padding operation, given |beginningPadding|, |endingPadding| and |options|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the padding operation, given |beginningPadding|, |endingPadding| and |options|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -4775,16 +4681,13 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLPool2dOptions/dilations}}'s [=list/size=] is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If any value in |options|.{{MLPool2dOptions/dilations}} is not greater than 0, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
-        1. Make a request to the underlying platform to:
-            1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of [=MLGraphBuilder/calculating pool2d output sizes=] given |options|.{{MLPool2dOptions/layout}}, |input|'s [=MLOperand/shape=], |options|.{{MLPool2dOptions/roundingType}}, |options|.{{MLPool2dOptions/windowDimensions}}, |options|.{{MLPool2dOptions/padding}}, |options|.{{MLPool2dOptions/strides}}, |options|.{{MLPool2dOptions/dilations}}, and |options|.{{MLPool2dOptions/outputSizes}} (if it [=map/exists=]).
-            1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
-            1. Let |opImpl| be [=platform operator=] for the |op| pooling operation, given |options|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+    1. *Make graph connections:*
+        1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of [=MLGraphBuilder/calculating pool2d output sizes=] given |options|.{{MLPool2dOptions/layout}}, |input|'s [=MLOperand/shape=], |options|.{{MLPool2dOptions/roundingType}}, |options|.{{MLPool2dOptions/windowDimensions}}, |options|.{{MLPool2dOptions/padding}}, |options|.{{MLPool2dOptions/strides}}, |options|.{{MLPool2dOptions/dilations}}, and |options|.{{MLPool2dOptions/outputSizes}} (if it [=map/exists=]).
+        1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
+        1. Let |operator| be an [=operator=] for the|op| pooling operation, given |options|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -4853,15 +4756,12 @@ partial interface MLGraphBuilder {
     1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].
     1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to the result of [=unidirectionally broadcasting the shapes=] |slope|'s [=MLOperand/shape=] and |input|'s [=MLOperand/shape=].
         1. If that returns failure, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |descriptor|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the PreLU operation, given |slope|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the PreLU operation, given |slope|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -4966,15 +4866,12 @@ partial interface MLGraphBuilder {
     1. Let |desc| be a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |outputShape|.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the |op| reduce operation, given |options|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the|op| reduce operation, given |options|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -5095,15 +4992,12 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>relu(|input|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the ReLU operation.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the ReLU operation.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -5217,15 +5111,12 @@ partial interface MLGraphBuilder {
     1. If |input|'s [=MLOperand/rank=] is not 4, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/checking resample options=] given |options| returns false, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| be the result of [=MLGraphBuilder/calculating resample output sizes=] given |input| and |options|.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the resample 2D operation, given |options|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the resample 2D operation, given |options|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -5261,15 +5152,12 @@ partial interface MLGraphBuilder {
     1. If product of all values in |newShape| is not equal to |inputElementCount|, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |newShape|.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the reshape operation.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the reshape operation.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -5353,15 +5241,12 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>sigmoid(|input|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the sigmoid operation.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the sigmoid operation.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -5410,15 +5295,12 @@ partial interface MLGraphBuilder {
   <div class=algorithm-steps>
     1. If |sizes|'s [=list/size=] is 0, then [=exception/throw=] a {{TypeError}}.
     1. If |starts|'s [=list/size=] and |sizes|'s [=list/size=] are not both equal to |input|'s [=MLOperand/rank=], then [=exception/throw=] a {{TypeError}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the slice operation, given |starts| and |sizes|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the slice operation, given |starts| and |sizes|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -5469,15 +5351,12 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. If |input|'s [=MLOperand/rank=] is not 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the softmax operation.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the softmax operation.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -5557,15 +5436,12 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>softplus(|input|, |options|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the softplus operation, given |options|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the softplus operation, given |options|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -5629,15 +5505,12 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>softsign(|input|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the softsign operation.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the softsign operation.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -5699,15 +5572,12 @@ partial interface MLGraphBuilder {
   <div class=algorithm-steps>
     1. If |splits| is an {{unsigned long}}, and |input|'s [=MLOperand/shape=][|options|.{{MLSplitOptions/axis}}] % |splits| is not 0, then [=exception/throw=] a {{TypeError}}.
     1. If |splits| is a sequence of {{unsigned long}}, and the sum of its elements is not equal to |input|'s [=MLOperand/shape=][|options|.{{MLSplitOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the split operation, given |splits| and |options|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the split operation, given |splits| and |options|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -5777,15 +5647,12 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>tanh(|input|)</dfn> method steps are:
   </summary>
   <div class=algorithm-steps>
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the hyperbolic tangent operation.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the hyperbolic tangent operation.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -5849,15 +5716,12 @@ partial interface MLGraphBuilder {
         1. If |options|.{{MLTransposeOptions/permutation}}'s [=MLOperand/rank=] is not the same as |input|'s [=MLOperand/rank=], then [=exception/throw=] a {{TypeError}}.
         1. If the values in |options|.{{MLTransposeOptions/permutation}} are not in [=the range=] 0 and |input|'s [=MLOperand/rank=] exclusive, then [=exception/throw=] a {{TypeError}}.
         1. If the values in |options|.{{MLTransposeOptions/permutation}} contain duplicate value, then [=exception/throw=] a {{TypeError}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the transpose operation, given |options|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the transpose operation, given |options|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -5900,15 +5764,12 @@ partial interface MLGraphBuilder {
   </summary>
   <div class=algorithm-steps>
     1. If |input|'s [=MLOperand/rank=] is less than 2, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the triangular operation, given |options|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the triangular operation, given |options|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>
@@ -6007,15 +5868,12 @@ partial interface MLGraphBuilder {
     1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to the result of [=bidirectionally broadcasting the shapes=] |input|'s [=MLOperand/shape=] and |other|'s [=MLOperand/shape=].
         1. If that returns failure, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
     1. If |condition| is not [=bidirectionally broadcastable=] to |descriptor|.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a "{{DataError}}" {{DOMException}}.
-    1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
+    1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |descriptor|.
-        1. Make a request to the underlying platform to:
-            1. Let |opImpl| be [=platform operator=] for the where operation, given |condition|, |input| and |other|.
-            1. Set |output|.{{MLOperand/[[operator]]}} to |opImpl|.
-            1. Create an [=platform operand=] |outputImpl| to represent the output, given |output| and |opImpl|.
-            1. Set |output|.{{MLOperand/[[operand]]}} to |outputImpl|.
-        1. Connect |condition|.{{MLOperand/[[operand]]}}, |input| and |other|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
-        1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
+        1. Let |operator| be an [=operator=] for the where operation, given |condition|, |input| and |other|.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/inputs=] to |condition|, |input| and |other|.
+        1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
   </div>
 </details>


### PR DESCRIPTION
As discussed in #572:

- Define an "operator" concept, with inputs, outputs, activations.
- Defer "platform operator" and "platform operand" to build.
- Standardize the graph connection steps across builder methods.
- Simplify activation, input and constant steps.

Not covered in this change:

- Erroring if input's [[builder]] doesn't match `this`
- Build algorithm - covered by #448 and #457
- gru() is missing steps to populate output. Added "Issue" note.
- Introducing "Validate arguments" section for each method.
- Introducing "Calculate output shape" section for each method.

For #549 and #572.