### PR TITLE
Styles: simplify algorithm markup, improve step & dfn visibility

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -72,36 +72,7 @@ p, ul, ol, dl {
     margin: 1em 0;
 }
 
-/*
- * Stylistic labels, for clarity of presentation of these blocks.
- *
- * NOTE: This text is non-accessible and non-selectable; surrounding
- * text must also explain the context.
- */
-
-/* Box for Valid Usage requirements. */
-div.validusage {
-    padding: .5em;
-    border: thin solid #88e !important;
-    border-radius: .5em;
-}
-.validusage {
-    position: relative;
-}
-.validusage::before {
-    font-weight: bold;
-    font-style: italic;
-    font-size: 130%;
-    color: rgba(0, 0, 0, 0.15);
-    color: var(--watermark-text);
-    position: absolute;
-    right: .3em;
-    top: -.1em;
-}
-.validusage::before {
-    content: "Valid Usage";
-}
-
+/* Style <details>, for clarity of presentation of these blocks. */
 details {
     padding: .5em;
     border: thin solid #88e !important;
@@ -114,41 +85,16 @@ summary {
     padding: 0.5em;
 }
 
-/* Box for algorithm steps. */
-
-div.algorithm-steps {
-    padding: .5em;
+/* Algorithm declaration and steps. */
+.algorithm > summary {
+    font-weight: normal;
 }
 
-.algorithm-steps {
+.algorithm > ol {
     position: relative;
-    overflow: hidden;
 }
-.algorithm-steps::after {
-    font-weight: bold;
-    font-style: italic;
-    font-size: 130%;
-    color: rgba(0, 0, 0, 0.15);
-    color: var(--watermark-text);
-    position: absolute;
-    right: .3em;
-    bottom: .1em;
-}
-.algorithm-steps::after {
+.algorithm > ol::after {
     content: "Algorithm";
-}
-
-/* Informal steps */
-div.informalsteps {
-    padding: .5em;
-    border: thin solid #88e !important;
-    border-radius: .5em;
-}
-
-.informalsteps {
-    position: relative;
-}
-.informalsteps::after {
     font-weight: bold;
     font-style: italic;
     font-size: 130%;
@@ -156,10 +102,7 @@ div.informalsteps {
     color: var(--watermark-text);
     position: absolute;
     right: .3em;
-    bottom: .1em;
-}
-.informalsteps::after {
-    content: "Non-normative";
+    bottom: -1em;
 }
 
 /* Internal slots */
@@ -826,7 +769,6 @@ The <dfn>power preference</dfn> indicates preference as related to power consump
 <summary>
     To <dfn>create a context</dfn> given [=realm=] |realm| and |options| (a {{GPUDevice}} or {{MLContextOptions}}), run these steps:
 </summary>
-<div class=algorithm-steps>
     1. Let |context| be a new {{MLContext}} object with |realm|.
     1. If |options| is a {{GPUDevice}} object,
         1. Set |context|.{{MLContext/[[contextType]]}} to "[=context type/webgpu=]".
@@ -838,14 +780,12 @@ The <dfn>power preference</dfn> indicates preference as related to power consump
         1. If |options|["{{MLContextOptions/powerPreference}}"] [=map/exists=], then set |context|.{{MLContext/[[powerPreference]]}} to |options|["{{MLContextOptions/powerPreference}}"]. Otherwise, set |context|.{{MLContext/[[powerPreference]]}} to {{MLPowerPreference/"default"}}.
     1. If the user agent cannot support |context|.{{MLContext/[[contextType]]}}, |context|.{{MLContext/[[deviceType]]}} and |context|.{{MLContext/[[powerPreference]]}}, return failure.
     1. Return |context|.
-</div>
 </details>
 
 <details open algorithm>
 <summary>
     The <dfn method for=ML>createContext(|options|)</dfn> steps are:
 </summary>
-<div class=algorithm-steps>
     1. Let |global| be [=this=]'s [=relevant global object=].
     1. If |global|'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, return [=a new promise=] [=rejected=] with a "{{SecurityError}}" {{DOMException}}.
     1. Let |realm| be [=this=]'s [=relevant realm=].
@@ -854,14 +794,12 @@ The <dfn>power preference</dfn> indicates preference as related to power consump
         1. Let |context| be the result of [=creating a context=] given |realm| and |options|. If that returns failure, then [=queue an ML task=] with |global| to [=reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}} and abort these steps.
         1. [=Queue an ML task=] with |global| to [=resolve=] |promise| with |context|.
     1. Return |promise|.
-</div>
 </details>
 
 <details open algorithm>
 <summary>
     The <dfn method for=ML>createContext(|gpuDevice|)</dfn> method steps are:
 </summary>
-<div class=algorithm-steps>
     1. Let |global| be [=this=]'s [=relevant global object=].
     1. If |global|'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, return [=a new promise=] [=rejected=] with a "{{SecurityError}}" {{DOMException}}.
     1. Let |realm| be [=this=]'s [=relevant realm=].
@@ -870,7 +808,6 @@ The <dfn>power preference</dfn> indicates preference as related to power consump
         1. Let |context| be the result of [=creating a context=] given |realm| and |gpuDevice|. If that returns failure, then [=queue an ML task=] with |global| to [=reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}} and abort these steps.
         1. [=Queue an ML task=] with |global| to [=resolve=] |promise| with |context|.
     1. Return |promise|.
-</div>
 </details>
 
 ## {{MLContext}} interface ## {#api-mlcontext}
@@ -914,29 +851,24 @@ When the {{MLContext/[[contextType]]}} is set to [=context type/default=] with t
   <summary>
     To <dfn>validate graph resources</dfn>, given {{MLNamedArrayBufferViews}} |resources| and [=ordered map=] |descriptors|, run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. [=map/For each=] |name| → |resource| of |resources|:
         1. If |descriptors|[|name|] does not [=map/exist=], return false.
         1. If [=validating buffer with descriptor=] given |resource| and |descriptors|[|name|] returns false, then return false.
     1. Return true.
-  </div>
 </details>
 
 <details open algorithm>
   <summary>
     To <dfn>validate buffer with descriptor</dfn> given {{ArrayBufferView}} |bufferView| and {{MLOperandDescriptor}} |descriptor|, run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. If |bufferView|'s [=element type=] does not match to |descriptor|.{{MLOperandDescriptor/dataType}}  according to [this table](#appendices-mloperanddatatype-arraybufferview-compatibility), return false.
     1. If |bufferView|.\[[ByteLength]] is not equal to |descriptor|'s [=MLOperandDescriptor/byte length=], return false.
-  </div>
 </details>
 
 <details open algorithm>
   <summary>
     To <dfn>execute graph</dfn>, given {{MLGraph}} |graph|, {{MLNamedArrayBufferViews}} |inputs| and {{MLNamedArrayBufferViews}} |outputs|, run the following steps. They return {{undefined}}, or an error.
   </summary>
-  <div class=algorithm-steps>
     1. Let |inputResources| denote the input resources of |graph|.{{MLGraph/[[implementation]]}}.
     1. [=map/For each=] |name| → |inputValue| of |inputs|:
         1. Let |inputDescriptor| be |graph|.{{MLGraph/[[inputDescriptors]]}}[|name|].
@@ -954,7 +886,6 @@ When the {{MLContext/[[contextType]]}} is set to [=context type/default=] with t
         1. If |outputTensor|'s [=element type=] doesn't match |outputValue|'s [=element type=], then return a {{TypeError}}.
         1. Request the underlying implementation of |graph| to set the values of elements in |outputValue| to the values of elements in |outputTensor|.
     1. Return {{undefined}}.
-  </div>
 </details>
 
 ### {{MLNamedArrayBufferViews}} transfer algorithm ### {#mlnamedarraybufferviews-transfer-alg}
@@ -963,7 +894,6 @@ When the {{MLContext/[[contextType]]}} is set to [=context type/default=] with t
   <summary>
     To <dfn for="MLNamedArrayBufferViews">transfer</dfn> an {{MLNamedArrayBufferViews}} |views| with [=realm=] |realm|:
   </summary>
-  <div class=algorithm-steps>
     1. Let |transferredViews| be a new {{MLNamedArrayBufferViews}}.
     1. [=map/For each=] |name| → |view| of |views|:
         1. Let |transferredBuffer| be the result of [=ArrayBuffer/transfer|transferring=] |view|'s [=BufferSource/underlying buffer=].
@@ -972,7 +902,6 @@ When the {{MLContext/[[contextType]]}} is set to [=context type/default=] with t
         1. Let |transferredView| be [$Construct$](|constructor|, |transferredBuffer|, |view|.\[[ByteOffset]], |elementsNumber|).
         1. Set |transferredViews|[|name|] to |transferredView|.
     1. Return |transferredViews|.
-  </div>
 </details>
 
 ### {{MLContext/compute()}}  ### {#api-mlcontext-async-execution}
@@ -995,7 +924,6 @@ In accordance with the [=ArrayBufferView/write|Web IDL warning=], to prevent the
   <summary>
     The <dfn method for=MLContext>compute(|graph|, |inputs|, |outputs|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |global| be [=this=]'s [=relevant global object=].
     1. Let |realm| be [=this=]'s [=relevant realm=].
     1. If |graph|.{{MLGraph/[[context]]}} is not [=this=], then return [=a new promise=] [=rejected=] with a {{TypeError}}.
@@ -1012,7 +940,6 @@ In accordance with the [=ArrayBufferView/write|Web IDL warning=], to prevent the
         1. Set |result|.{{MLComputeResult/outputs}} to |transferredOutputs|.
         1. [=Queue an ML task=] with |global| to [=resolve=] |promise| with |result|.
     1. Return |promise|.
-  </div>
 </details>
 
 #### Examples #### {#api-mlcontext-async-execution-examples}
@@ -1112,20 +1039,17 @@ dictionary MLOperandDescriptor {
   <summary>
     The <dfn for="MLOperandDescriptor">byte length</dfn> of an {{MLOperandDescriptor}} |desc| is the value returned by the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. Let |elementLength| be 1.
     1. [=list/For each=] |dimension| of |desc|.{{MLOperandDescriptor/dimensions}}:
         1. Set |elementLength| to |elementLength| × |dimension|.
     1. Let |elementSize| be the [=element size=] of one of the {{ArrayBufferView}} types that matches |desc|.{{MLOperandDescriptor/dataType}} according to [this table](#appendices-mloperanddatatype-arraybufferview-compatibility).
     1. Return |elementLength| × |elementSize|.
-  </div>
 </details>
 
 <details open algorithm>
   <summary>
     To <dfn for="MLOperandDescriptor">check dimensions</dfn> given {{MLOperandDescriptor}} |descriptor|, run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. If any element of |descriptor|.{{MLOperandDescriptor/dimensions}} is too large to be supported by the implementation, return false.
     1. If |descriptor|.{{MLOperandDescriptor/dimensions}}'s [=list/size=] is too large to be supported by the implementation, return false.
 
@@ -1133,7 +1057,6 @@ dictionary MLOperandDescriptor {
 
     1. If |descriptor|'s [=MLOperandDescriptor/byte length=] is not supported by the implementation, then return false.
     1. Return true.
-  </div>
 </details>
 
 
@@ -1191,37 +1114,31 @@ The {{MLOperand}} objects are created by the methods of {{MLGraphBuilder}}, inte
   <summary>
     To <dfn>create an MLOperand</dfn> given {{MLGraphBuilder}} |builder| and {{MLOperandDescriptor}} |desc|, run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. Let |operand| be a new {{MLOperand}}.
     1. Set |operand|.{{MLOperand/[[builder]]}} to |builder|.
     1. Set |operand|.{{MLOperand/[[descriptor]]}} to |desc|.
     1. Return |operand|.
-  </div>
 </details>
 
 <details open algorithm>
   <summary>
     To <dfn>copy an MLOperand</dfn> given {{MLOperand}} |operand|, run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. Let |result| be a new {{MLOperand}}.
     1. Set |result|.{{MLOperand/[[builder]]}} to |operand|.{{MLOperand/[[builder]]}}.
     1. Set |result|.{{MLOperand/[[descriptor]]}} to |operand|.{{MLOperand/[[descriptor]]}}.
     1. If |operand|.{{MLOperand/[[name]]}} [=map/exists=], then set |result|.{{MLOperand/[[name]]}} to |operand|.{{MLOperand/[[name]]}}.
     1. Return |result|.
-  </div>
 </details>
 
 <details open algorithm>
   <summary>
     To <dfn for="MLOperand">validate MLOperand</dfn> given {{MLOperand}} |operand| and {{MLGraphBuilder}} |builder|, run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. If |builder| is not equal to |operand|.{{MLOperand/[[builder]]}}, return false.
     1. Let |desc| be |operand|.{{MLOperand/[[descriptor]]}}.
     1. If [=MLOperandDescriptor/checking dimensions=] given |desc| returns false, then return false.
     1. Return true.
-  </div>
 </details>
 
 ### {{MLOperand/dataType()}} ### {#api-mloperand-datatype}
@@ -1235,9 +1152,7 @@ Return a data type of the {{MLOperand}}.
   <summary>
     The <dfn method for=MLOperand>dataType()</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Return [=this=]'s [=MLOperand/dataType=].
-  </div>
 </details>
 
 ### {{MLOperand/shape()}} ### {#api-mloperand-shape}
@@ -1251,9 +1166,7 @@ Return a shape of the {{MLOperand}}.
   <summary>
     The <dfn method for=MLOperand>shape()</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Return [=this=]'s [=MLOperand/shape=].
-  </div>
 </details>
 
 ## {{MLActivation}} interface ## {#api-mlactivation}
@@ -1296,7 +1209,6 @@ The {{MLActivation}} objects (including the ones passed as input to methods) are
   <summary>
     To <dfn>create an MLActivation</dfn> given {{MLGraphBuilder}} |builder|, [=string=] |name|, optional [=ordered map=] |options| and optional algorithm |init-steps|, run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. Let |activation| be a new {{MLActivation}}.
     1. Set |activation|.{{MLActivation/[[builder]]}} to |builder|.
     1. Set |activation|.{{MLActivation/[[name]]}} to |name|.
@@ -1308,7 +1220,6 @@ The {{MLActivation}} objects (including the ones passed as input to methods) are
         1. If |init-steps| are given, run |init-steps| with |options|.
             1. Otherwise, initialize |activation|.{{MLActivation/[[operator]]}} given |options| in an [=implementation-defined=] way for the given |name| operation.
     1. Return |activation|.
-  </div>
 </details>
 
 ## {{MLGraphBuilder}} interface ## {#api-mlgraphbuilder}
@@ -1358,10 +1269,8 @@ Issue(552): Decide how to specify graph initialization.
   <summary>
     The [=new=] <dfn constructor for=MLGraphBuilder lt="MLGraphBuilder(context)">MLGraphBuilder(|context|)</dfn> constructor steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the [=webnn-feature|webnn=] feature, then [=exception/throw=] a "{{SecurityError}}" {{DOMException}}.
     1. Set [=this=].{{MLGraphBuilder/[[context]]}} to |context|.
-  </div>
 </details>
 
 ### input operands ### {#api-mlgraphbuilder-input}
@@ -1379,7 +1288,6 @@ Create a named {{MLOperand}} based on a descriptor, that can be used as an input
   <summary>
     The <dfn method for=MLGraphBuilder>input(|name|, |descriptor|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
@@ -1393,7 +1301,6 @@ Create a named {{MLOperand}} based on a descriptor, that can be used as an input
             1. Set |operand|.{{MLOperand/[[operand]]}} to |operandImpl|.
             1. Register |operand| as an input.
     1. Return |operand|.
-  </div>
 </details>
 
 ### constant operands ### {#api-mlgraphbuilder-constant}
@@ -1413,7 +1320,6 @@ Create a constant {{MLOperand}} of the specified data type and shape that contai
   <summary>
     The <dfn method for=MLGraphBuilder>constant(|descriptor|, |bufferView|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
@@ -1427,7 +1333,6 @@ Create a constant {{MLOperand}} of the specified data type and shape that contai
             1. Set |operand|.{{MLOperand/[[operand]]}} to |constantImpl|.
             1. Register |operand| as a tensor constant with |bytes| as value.
     1. Return |operand|.
-  </div>
 </details>
 
 #### {{MLGraphBuilder/constant(value, type)}} #### {#api-mlgraphbuilder-constant-value-type}
@@ -1448,7 +1353,6 @@ Data truncation will occur when the specified value exceeds the range of the spe
   <summary>
     The <dfn method for=MLGraphBuilder>constant(|value|, |type|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
@@ -1462,7 +1366,6 @@ Data truncation will occur when the specified value exceeds the range of the spe
             1. Set |operand|.{{MLOperand/[[operand]]}} to |constantImpl|.
             1. Register |operand| as a scalar constant with |value| as value.
     1. Return |operand|.
-  </div>
 </details>
 
 #### {{MLGraphBuilder/constant(start, end, step, type)}} #### {#api-mlgraphbuilder-constant-range}
@@ -1485,7 +1388,6 @@ Data truncation will occur when the values in the range exceed the range of the 
   <summary>
     The <dfn method for=MLGraphBuilder>constant(|start|, |end|, |step|, |type|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
@@ -1505,7 +1407,6 @@ Data truncation will occur when the values in the range exceed the range of the 
             1. Set |operand|.{{MLOperand/[[operand]]}} to |constantImpl|.
             1. Register |operand| as a constant with |buffer| as value.
     1. Return |operand|.
-  </div>
 </details>
 
 ### build method ### {#api-mlgraphbuilder-build}
@@ -1515,7 +1416,6 @@ Build a composed graph up to a given output operand into a computational graph a
   <summary>
     The <dfn method for=MLGraphBuilder>build(|outputs|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |promise| be [=a new promise=].
     1. Let |global| be [=this=]'s [=relevant global object=].
     1. Let |realm| be [=this=]'s [=relevant realm=].
@@ -1543,7 +1443,6 @@ Build a composed graph up to a given output operand into a computational graph a
                 Issue(552): Decide how to specify graph initialization.
         1. [=Queue an ML task=] with |global| to [=resolve=] |promise| with |graph|.
     1. Return |promise|.
-  </div>
 </details>
 
 
@@ -1590,7 +1489,6 @@ partial interface MLGraphBuilder {
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="argminmax-op">create argMin/argMax operation</dfn> given [=string=] |op|, {{MLOperand}} |input| and {{MLArgMinMaxOptions}} |options|, run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "argMin", "argMax".
     1. If |options|.{{MLArgMinMaxOptions/axes}} [=map/exists=], if any of its elements is not in [=the range=] 0 to |input|'s [=MLOperand/rank=], exclusive, then [=exception/throw=] a {{TypeError}}.
     1. Let |outputShape| be the result of [=MLGraphBuilder/calculating reduction output sizes=] given |input|'s [=MLOperand/shape=], |options|.{{MLArgMinMaxOptions/axes}} (if it [=map/exists=]), and |options|.{{MLArgMinMaxOptions/keepDimensions}}.
@@ -1607,14 +1505,12 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <details open>
   <summary>
     The following argMin/argMax algorithms are supported.
   </summary>
-  <div class=algorithm-steps>
     <div algorithm>
     The <dfn method for=MLGraphBuilder>argMin(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/argminmax-op | create argMin/argMax operation=] given "argMin", |input| and |options|.
@@ -1628,7 +1524,6 @@ partial interface MLGraphBuilder {
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
     </div>
-  </div>
 </details>
 
 ### batchNormalization ### {#api-mlgraphbuilder-batchnorm}
@@ -1686,7 +1581,6 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder>batchNormalization(|input|, |mean|, |variance|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If |options|.{{MLBatchNormalizationOptions/axis}} is not in [=the range=] 0 to |input|'s [=MLOperand/rank=], exclusive, then [=exception/throw=] a {{TypeError}}.
     1. If |mean|'s [=MLOperand/rank=] is not 1, then [=exception/throw=] a {{TypeError}}.
     1. If |mean|'s [=MLOperand/shape=][0] is not equal to |input|'s [=MLOperand/shape=][|options|.{{MLBatchNormalizationOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
@@ -1705,7 +1599,6 @@ partial interface MLGraphBuilder {
             1. If |options|.{{MLBatchNormalizationOptions/activation}} [=map/exists=],register it as activation to |batchNormImpl|.
             1. Connect |output| as output to |batchNormImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <div class="note">
@@ -1748,7 +1641,6 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder>cast(|input|, |type|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |operand| be the result of [=creating an MLOperand=] given [=this=], |input| and |type|.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
@@ -1760,7 +1652,6 @@ partial interface MLGraphBuilder {
         1. Connect |operand|.{{MLOperand/[[operand]]}} as input to |castImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |castImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 ### clamp ### {#api-mlgraphbuilder-clamp}
@@ -1809,10 +1700,8 @@ partial interface MLGraphBuilder {
   <summary>
     To <dfn>check clamp options</dfn> given {{MLClampOptions}} |options|, run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. If |options|.{{MLClampOptions/minValue}} is greater than |options|.{{MLClampOptions/maxValue}}, then return false.
     1. Return true.
-  </div>
 </details>
 
 #### {{MLGraphBuilder/clamp(input, options)}} #### {#api-mlgraphbuilder-clamp-operand-options}
@@ -1830,7 +1719,6 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder>clamp(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If [=checking clamp options=] given |options| returns false, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
@@ -1842,7 +1730,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |clampImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |clampImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 #### {{MLGraphBuilder/clamp(options)}} #### {#api-mlgraphbuilder-clamp-options}
@@ -1856,16 +1743,13 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>clamp(|options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If [=checking clamp options=] given |options| returns false, then [=exception/throw=] a {{TypeError}}.
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=], "clamp" and |options|.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
-  </div>
 </details>
 
 ### concat ### {#api-mlgraphbuilder-concat}
@@ -1888,11 +1772,9 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>concat(|inputs|, |axis|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
@@ -1924,7 +1806,6 @@ partial interface MLGraphBuilder {
         1. Connect |inputs| as input to |concatImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |concatImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 ### conv2d ### {#api-mlgraphbuilder-conv2d}
@@ -2025,29 +1906,24 @@ partial interface MLGraphBuilder {
   <summary>
     To <dfn for=MLGraphBuilder>calculate conv output size</dfn> given unsigned integers |inputSize|, |filterSize|, |beginningPadding|, |endingPadding|, |stride| and |dilation|, perform these steps. They return a number.
   </summary>
-  <div class=algorithm-steps>
     1. Let |effectiveFilterSize| be ( |filterSize| - 1 ) * |dilation| + 1.
     1. Let |outputSize| be ( |inputSize| - |effectiveFilterSize| + |beginningPadding| + |endingPadding| ) / |stride| + 1.
     1. Return |outputSize|.
-  </div>
 </details>
 
 <details open algorithm>
   <summary>
     To <dfn for=MLGraphBuilder>calculate conv2d output sizes</dfn> given unsigned integers |inputHeight|, |inputWidth|, |filterHeight| and |filterWidth|, [=/list=] of 4 unsigned integers |padding|, [=/list=] of 2 unsigned integers |strides|, and [=/list=] of 2 unsigned integers |dilations|, perform these steps. They return a [=/list=] of 2 numbers.
   </summary>
-  <div class=algorithm-steps>
     1. Let |outputHeight| be the result of [=MLGraphBuilder/calculating conv output size=] given |inputHeight|, |filterHeight|, |padding|[0], |padding|[1], |strides|[0] and |dilations|[0].
     1. Let |outputWidth| be the result of [=MLGraphBuilder/calculating conv output size=] given |inputWidth|, |filterWidth|, |padding|[2], |padding|[3], |strides|[1] and |dilations|[1].
     1. Return « |outputHeight|, |outputWidth| ».
-  </div>
 </details>
 
 <details open algorithm>
   <summary>
     The <dfn method for=MLGraphBuilder>conv2d(|input|, |filter|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |inputSize| be |input|'s [=MLOperand/rank=].
     1. Let |filterSize| be |filter|'s [=MLOperand/rank=].
     1. If |inputSize| is not 4, then [=exception/throw=] a {{TypeError}}.
@@ -2122,7 +1998,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |conv2dImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |conv2dImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 ### convTranspose2d ### {#api-mlgraphbuilder-convtranspose2d}
@@ -2236,30 +2111,24 @@ partial interface MLGraphBuilder {
   <summary>
     To <dfn for=MLGraphBuilder>calculate convtranspose output size</dfn> given unsigned integers |inputSize|, |filterSize|, |beginningPadding|, |endingPadding|, |stride|, |dilation|, and |outputPadding|, perform these steps. They return a number.
   </summary>
-  <div class=algorithm-steps>
     1. Let |effectiveFilterSize| be ( |filterSize| - 1 ) * |dilation| + 1.
     1. Let |outputSize| be ( |inputSize| - 1 ) * |stride| + |effectiveFilterSize| - |beginningPadding| - |endingPadding| + |outputPadding|.
     1. Return |outputSize|.
-  </div>
 </details>
 
 <details open algorithm>
   <summary>
     To <dfn for=MLGraphBuilder>calculate convtranspose2d output sizes</dfn> given unsigned integers |inputHeight|, |inputWidth|, |filterHeight| and |filterWidth|, [=/list=] of 4 unsigned integers |padding|, [=/list=] of 2 unsigned integers |strides|, [=/list=] of 2 unsigned integers |dilations|, and [=/list=] of 2 unsigned integers |outputPadding|, perform these steps. They return a [=/list=] of 2 numbers.
   </summary>
-  <div class=algorithm-steps>
     1. Let |outputHeight| be the result of [=MLGraphBuilder/calculating convtranspose output size=] given |inputHeight|, |filterHeight|, |padding|[0], |padding|[1], |strides|[0], |dilations|[0], and |outputPadding|[0].
     1. Let |outputWidth| be the result of [=MLGraphBuilder/calculating convtranspose output size=] given |inputWidth|, |filterWidth|, |padding|[2], |padding|[3], |strides|[1], |dilations|[1] and |outputPadding|[1].
     1. Return « |outputHeight|, |outputWidth| ».
-  </div>
 </details>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>convTranspose2d(|input|, |filter|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |inputSize| be |input|'s [=MLOperand/rank=].
     1. Let |filterSize| be |filter|'s [=MLOperand/rank=].
     1. If |inputSize| is not 4, then [=exception/throw=] a {{TypeError}}.
@@ -2337,7 +2206,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |convTranspose2dImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |convTranspose2dImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 ### Element-wise binary operations ### {#api-mlgraphbuilder-binary}
@@ -2383,7 +2251,6 @@ partial interface MLGraphBuilder {
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="element-wise-binary-op">create element-wise binary operation</dfn> given [=string=] |op|, {{MLOperand}} |a| and {{MLOperand}} |b|, run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "add", "sub", "mul", "div", "max", "min", "pow".
     1. If |a|'s [=MLOperand/dataType=] is not equal to |b|'s [=MLOperand/dataType=], then [=exception/throw=] a {{TypeError}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
@@ -2400,14 +2267,12 @@ partial interface MLGraphBuilder {
         1. Connect |a|.{{MLOperand/[[operand]]}} and |b|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <details open>
   <summary>
     The element-wise binary operation algorithms invoke the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] steps as follows.
   </summary>
-  <div class=algorithm-steps>
     <div algorithm>
     The <dfn method for=MLGraphBuilder>add(|a|, |b|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-binary-op | create element-wise binary operation=] given "add", |a| and |b|.
@@ -2456,7 +2321,6 @@ partial interface MLGraphBuilder {
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
     </div>
-</div>
 </details>
 
 ### Element-wise logical operations ### {#api-mlgraphbuilder-logical}
@@ -2501,7 +2365,6 @@ Although operations {{MLGraphBuilder/greaterOrEqual()}} and {{MLGraphBuilder/les
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="element-wise-logical-op">create element-wise logical operation</dfn> given [=string=] |op|, {{MLOperand}} |a| and an optional {{MLOperand}} |b|, run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "equal", "greater", "greaterOrEqual", "lesser", "lesserOrEqual", "not".
     1. If |op| is "not".
         1. If |a|'s [=MLOperand/dataType=] isn't {{MLOperandDataType/"uint8"}}, then [=exception/throw=] a {{TypeError}}.
@@ -2521,14 +2384,12 @@ Although operations {{MLGraphBuilder/greaterOrEqual()}} and {{MLGraphBuilder/les
         1. Connect |a|.{{MLOperand/[[operand]]}} and |b|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <details open>
   <summary>
     The element-wise logical operation algorithms invoke the [=MLGraphBuilder/element-wise-logical-op | create element-wise logical operation=] steps as follows.
   </summary>
-  <div class=algorithm-steps>
     <div algorithm>
     The <dfn method for=MLGraphBuilder>equal(|a|, |b|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-logical-op | create element-wise logical operation=] given "equal", |a| and |b|.
@@ -2570,7 +2431,6 @@ Although operations {{MLGraphBuilder/greaterOrEqual()}} and {{MLGraphBuilder/les
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
     </div>
-</div>
 </details>
 
 ### Element-wise unary operations ### {#api-mlgraphbuilder-unary}
@@ -2623,7 +2483,6 @@ partial interface MLGraphBuilder {
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="element-wise-unary-op">create element-wise unary operation</dfn> given [=string=] |op| and {{MLOperand}} |input|, run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "abs", "ceil", "cos", "erf", "exp", "floor", "identity", "log", "neg", "reciprocal", "sin", "sqrt", "tan".
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
@@ -2635,13 +2494,12 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
+
 <details open>
   <summary>
     The element-wise unary operation algorithms invoke the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] steps as follows.
   </summary>
-  <div class=algorithm-steps>
     <div algorithm>
     The <dfn method for=MLGraphBuilder>abs(|input|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/element-wise-unary-op | create element-wise unary operation=] given "abs" and |input|.
@@ -2732,7 +2590,6 @@ partial interface MLGraphBuilder {
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
     </div>
-  </div>
 </details>
 
 ### elu ### {#api-mlgraphbuilder-elu}
@@ -2781,11 +2638,9 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>elu(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
@@ -2796,7 +2651,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 #### {{MLGraphBuilder/elu(options)}} #### {#api-mlgraphbuilder-elu-options}
@@ -2810,14 +2664,11 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>elu(|options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=], "elu" and |options|.
     1. Return |op|.
-  </div>
 </details>
 
 ### expand ### {#api-mlgraphbuilder-expand}
@@ -2839,7 +2690,6 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder>expand(|input|, |newShape|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
@@ -2857,7 +2707,6 @@ partial interface MLGraphBuilder {
         1. Connect |input| as input to |expandImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |expandImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 ### gather ### {#api-mlgraphbuilder-gather}
@@ -2892,7 +2741,6 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder>gather(|input|, |indices|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If |indices|'s [=MLOperand/dataType=] is neither {{MLOperandDataType/"uint32"}} nor {{MLOperandDataType/"int64"}}, then [=exception/throw=] a {{TypeError}}.
     1. Let |shapeInput| be |input|'s [=MLOperand/shape=] and |rankInput| be |shapeInput|'s [=MLOperand/rank=].
     1. Let |shapeIndices| be |indices|'s [=MLOperand/shape=].
@@ -2932,7 +2780,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} and |indices|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <div class="example">
@@ -3040,11 +2887,9 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>gemm(|a|, |b|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |shapeA| be a [=list/clone=] of |a|'s [=MLOperand/shape=].
     1. Let |sizeA| be the [=list/size=] of |shapeA|.
     1. Let |shapeB| be a [=list/clone=] of |b|'s [=MLOperand/shape=].
@@ -3070,7 +2915,6 @@ partial interface MLGraphBuilder {
         1. Connect |a|.{{MLOperand/[[operand]]}} and |b|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <div class="note">
@@ -3175,11 +3019,9 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>gru(|input|, |weight|, |recurrentWeight|, |steps|, |hiddenSize|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If |input|'s [=MLOperand/rank=] or |weight| or |recurrentWeight| is not 3, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLGruOptions/bias}} [=map/exists=].
         1. If |options|.{{MLGruOptions/bias}}'s [=MLOperand/shape=][1] is not equal to 3 * |hiddenSize|, then [=exception/throw=] a {{TypeError}}.
@@ -3196,7 +3038,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output| as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <div class="note">
@@ -3326,11 +3167,9 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
      The <dfn method for=MLGraphBuilder>gruCell(|input|, |weight|, |recurrentWeight|, |hiddenState|, |hiddenSize|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If |input|'s [=MLOperand/rank=] or |weight| or |recurrentWeight| or |hiddenState| is not 2, then [=exception/throw=] a {{TypeError}}.
     1. If |weight|'s [=MLOperand/shape=][0] is not equal to 3 * |hiddenSize|, then [=exception/throw=] a {{TypeError}}.
     1. If |recurrentWeight|'s [=MLOperand/shape=][0] is not equal to 3 * |hiddenSize|, then [=exception/throw=] a {{TypeError}}.
@@ -3352,7 +3191,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <div class="note">
@@ -3511,11 +3349,9 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>hardSigmoid(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
@@ -3526,7 +3362,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 #### {{MLGraphBuilder/hardSigmoid(options)}} #### {#api-mlgraphbuilder-hardsigmoid-options}
@@ -3539,15 +3374,12 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>hardSigmoid(|options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=], "hardSigmoid" and |options|.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
-  </div>
 </details>
 
 ### hardSwish ### {#api-mlgraphbuilder-hard-swish}
@@ -3591,11 +3423,9 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>hardSwish(|input|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
@@ -3606,7 +3436,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 #### {{MLGraphBuilder/hardSwish()}} #### {#api-mlgraphbuilder-hardswish}
@@ -3622,11 +3451,9 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder id=hardswish-noargs>hardSwish()</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=] and "hardSwish".
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
- </div>
 </details>
 
 
@@ -3679,7 +3506,6 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder>instanceNormalization(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If |input|'s [=MLOperand/rank=] is not 4, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLInstanceNormalizationOptions/scale}}'s [=MLOperand/rank=] is not equal to 1, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLInstanceNormalizationOptions/bias}}'s [=MLOperand/rank=] is not equal to 1, then [=exception/throw=] a {{TypeError}}.
@@ -3693,7 +3519,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <div class="note">
@@ -3779,7 +3604,6 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder>layerNormalization(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If |options|.{{MLLayerNormalizationOptions/axes}} does not [=map/exist=], then set |options|.{{MLLayerNormalizationOptions/axes}} to a new [=/list=], either equal to [=the range=] from 1 to |input|'s [=MLOperand/rank=], exclusive, if |input|'s [=MLOperand/rank=] is greater than 1, or an empty [=/list=] otherwise.
     1. If |options|.{{MLLayerNormalizationOptions/scale}}'s [=MLOperand/rank=] is not equal to |options|.{{MLLayerNormalizationOptions/axes}}'s [=list/size=], then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLLayerNormalizationOptions/bias}}'s [=MLOperand/rank=] is not equal to |options|.{{MLLayerNormalizationOptions/axes}}'s [=list/size=], then [=exception/throw=] a {{TypeError}}.
@@ -3799,7 +3623,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <div class="note">
@@ -3884,11 +3707,9 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>leakyRelu(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
@@ -3899,7 +3720,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 #### {{MLGraphBuilder/leakyRelu(options)}} #### {#api-mlgraphbuilder-leaky-relu-options}
@@ -3912,15 +3732,12 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>leakyRelu(|options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=], "leakyRelu" and |options|.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
-  </div>
 </details>
 
 ### linear ### {#api-mlgraphbuilder-linear}
@@ -3978,7 +3795,6 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder>linear(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
@@ -3989,7 +3805,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 #### {{MLGraphBuilder/linear(options)}} #### {#api-mlgraphbuilder-linear-options}
@@ -4002,15 +3817,12 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>linear(|options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=],  "linear" and |options|.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
-  </div>
 </details>
 
 ### lstm ### {#api-mlgraphbuilder-lstm}
@@ -4096,11 +3908,9 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>lstm(|input|, |weight|, |recurrentWeight|, |steps|, |hiddenSize|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |numDirections| be 1 if |options|.{{MLLstmOptions/direction}} is {{MLRecurrentNetworkDirection/"forward"}}, or otherwise let it be 2.
     1. If |input|'s [=MLOperand/rank=] or |weight| or |recurrentWeight| is not 3, then [=exception/throw=] a {{TypeError}}.
     1. If |input|'s [=MLOperand/shape=][0] is not equal to |steps|, then [=exception/throw=] a {{TypeError}}.
@@ -4148,7 +3958,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output| as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <div class="note">
@@ -4296,11 +4105,9 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>lstmCell(|input|, |weight|, |recurrentWeight|, |hiddenState|, |cellState|, |hiddenSize|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If |input|'s [=MLOperand/rank=], |weight|, |recurrentWeight|, |hiddenState| or |cellState| is not 2, then [=exception/throw=] a {{TypeError}}.
     1. Let |batchSize| be |input|'s [=MLOperand/shape=][0].
     1. If |options|.{{MLLstmCellOptions/bias}} [=map/exists=]:
@@ -4329,7 +4136,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output| as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <div class="note">
@@ -4476,7 +4282,6 @@ partial interface MLGraphBuilder {
   <summary>
     To <dfn dfn-for=MLGraphBuilder>calculate matmul output sizes</dfn>, given |a| and |b| run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. Let |shapeA| be a [=list/clone=] of |a|'s [=MLOperand/shape=]
     1. Let |sizeA| be the [=list/size=] of |shapeA|.
     1. Let |shapeB| be a [=list/clone=] of |b|'s [=MLOperand/shape=]
@@ -4492,15 +4297,12 @@ partial interface MLGraphBuilder {
     1. Let |outputShape| be the result of [=bidirectionally broadcasting the shapes=] |batchShapeA| and |batchShapeB|. If that returns failure, then [=exception/throw=] a {{TypeError}}.
     1. [=list/Append=] « |rowsA|, |colsB| » to |outputShape|.
     1. Return |outputShape|.
-  </div>
 </details>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>matmul(|a|, |b|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |desc| be a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of [=MLGraphBuilder/calculating matmul output sizes=] given |a| and |b|.
     1. If that throws an error, re-[=exception/throw=] the error.
@@ -4515,7 +4317,6 @@ partial interface MLGraphBuilder {
         1. Connect |a|.{{MLOperand/[[operand]]}} and |b|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 ### pad ### {#api-mlgraphbuilder-pad}
@@ -4568,21 +4369,17 @@ partial interface MLGraphBuilder {
   <summary>
     To <dfn dfn-for=MLGraphBuilder>calculate padding output sizes</dfn>, given |input|, |beginningPadding| and |endingPadding|, run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. Let |shape| be a copy of |input|'s [=MLOperand/shape=].
     1. For |index| in [=the range=] 0 to |shape|'s [=MLOperand/rank=], exclusive:
         1. Add to |shape|[|index|] the value of |beginningPadding|[|index|].
         1. Add to |shape|[|index|] the value of |endingPadding|[|index|].
     1. Return |shape|.
-  </div>
 </details>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>pad(|input|, |beginningPadding|, |endingPadding|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If |beginningPadding|'s [=list/size=] and |endingPadding|'s [=list/size=] are not both equal to |input|'s [=MLOperand/rank=], then [=exception/throw=] a "{{TypeError}}".
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to the result of [=MLGraphBuilder/calculating padding output sizes=] given |input|, |beginningPadding| and |endingPadding|.
@@ -4596,7 +4393,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <div class="example">
@@ -4744,7 +4540,6 @@ partial interface MLGraphBuilder {
   <summary>
     To <dfn for=MLGraphBuilder>calculate pool2d output sizes</dfn> given {{MLInputOperandLayout}} |layout|, [=/list=] of 4 unsigned integers |inputShape|, {{MLRoundingType}} |roundingType|, [=/list=] of 2 unsigned integers |windowDimensions|, [=/list=] of 4 unsigned integers |padding|, [=/list=] of 2 unsigned integers |strides|, [=/list=] of 2 unsigned integers |dilations|, and optional [=/list=] of 2 unsigned integers |outputSizes|, perform these steps. They return a [=/list=] of 4 unsigned integers.
   </summary>
-  <div class=algorithm-steps>
     1. Switch on |layout|:
         <dl class=switch>
             : {{MLInputOperandLayout/"nchw"}}
@@ -4785,14 +4580,12 @@ partial interface MLGraphBuilder {
             : {{MLInputOperandLayout/"nhwc"}}
             :: Return « |batches|, |outputHeight|, |outputWidth|, |channels| ».
         </dl>
-  </div>
 </details>
 
 <details open algorithm>
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="pooling-op">create pooling operation</dfn> given [=string=] |op|, {{MLOperand}} |input| and {{MLPool2dOptions}} |options|, run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "averagePool2d", "l2Pool2d", "maxPool2d".
     1. If |input|'s [=MLOperand/rank=] is not 4, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLPool2dOptions/windowDimensions}} [=map/exists=] and its [=list/size=] is not 2, then [=exception/throw=] a {{TypeError}}.
@@ -4820,14 +4613,12 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <details open>
   <summary>
     The following pooling algorithms are supported.
   </summary>
-  <div class=algorithm-steps>
     <div algorithm>
     The <dfn method for=MLGraphBuilder>averagePool2d(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/pooling-op | create pooling operation=] given "averagePool2d", |input| and |options|.
@@ -4848,7 +4639,6 @@ partial interface MLGraphBuilder {
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
     </div>
-  </div>
 </details>
 
 #### averagePool2d #### {#api-mlgraphbuilder-pool2d-average}
@@ -4878,11 +4668,9 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>prelu(|input|, |slope|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
     1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].
     1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to the result of [=unidirectionally broadcasting the shapes=] |slope|'s [=MLOperand/shape=] and |input|'s [=MLOperand/shape=].
@@ -4897,7 +4685,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <div class="note">
@@ -4974,7 +4761,6 @@ partial interface MLGraphBuilder {
   <summary>
     To <dfn for="MLGraphBuilder">calculate reduction output sizes</dfn>, given a [=/list=] of unsigned integers |inputShape|, a optional [=/list=] of unsigned integers |axes|, and [=/boolean=] |keepDimensions|, perform the following steps. They return a new [=/list=] of unsigned integers.
   </summary>
-  <div class=algorithm-steps>
     1. Let |inputSize| be |inputShape|'s [=list/size=].
     1. If |axes| is not given, let |axes| be [=the range=] 0 to |inputSize|, exclusive.
     1. If |keepDimensions| is true, then:
@@ -4986,14 +4772,12 @@ partial interface MLGraphBuilder {
         1. [=list/For each=] |index| in [=the range=] 0 to |inputSize|, exclusive:
             1. If |axes| does not [=list/contain=] |index|, then [=list/append=] |inputShape|[|index|].
     1. Return |outputShape|.
-  </div>
 </details>
 
 <details open algorithm>
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="reduce-op">create reduce operation</dfn> given [=string=] |op|, {{MLOperand}} |input| and {{MLReduceOptions}} |options|, run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. [=Assert=]: |op| is one of "reduceL1", "reduceL2", "reduceLogSum", "reduceLogSumExp", "reduceMax", "reduceMean", "reduceMin", "reduceProduct", "reduceSum", "reduceSumSquare".
     1. If |options|.{{MLReduceOptions/axes}} [=map/exists=], if any of its elements is not in [=the range=] 0 to |input|'s [=MLOperand/rank=], exclusive, then [=exception/throw=] a {{TypeError}}.
     1. Let |outputShape| be the result of [=MLGraphBuilder/calculating reduction output sizes=] given |input|'s [=MLOperand/shape=], |options|.{{MLReduceOptions/axes}} (if it [=map/exists=]), and |options|.{{MLReduceOptions/keepDimensions}}.
@@ -5010,14 +4794,12 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <details open>
   <summary>
     The following reduce algorithms are supported.
   </summary>
-  <div class=algorithm-steps>
     <div algorithm>
     The <dfn method for=MLGraphBuilder>reduceL1(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of running the [=MLGraphBuilder/reduce-op | create reduce operation=] given "reduceL1", |input| and |options|.
@@ -5087,7 +4869,6 @@ partial interface MLGraphBuilder {
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
     </div>
-  </div>
 </details>
 
 ### relu ### {#api-mlgraphbuilder-relu-method}
@@ -5124,11 +4905,9 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>relu(|input|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
@@ -5139,7 +4918,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 #### {{MLGraphBuilder/relu()}} #### {#api-mlgraphbuilder-relu}
@@ -5155,11 +4933,9 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder id=relu-noargs>relu()</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=] and "relu".
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
-  </div>
 </details>
 
 ### resample2d ### {#api-mlgraphbuilder-resample2d-method}
@@ -5214,40 +4990,32 @@ partial interface MLGraphBuilder {
 </dl>
 
 <details open algorithm>
-
   <summary>
     To <dfn for="MLGraphBuilder">check resample options</dfn> given |options|, run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. If |options|.{{MLResample2dOptions/scales}} does not [=map/exist=], set it to to the [=/list=] « 1.0, 1.0 ».
     1. Otherwise, if any of its values is not greater than 0, or if its [=list/size=] is not 2, return false.
     1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], and if its size is not 2, or if any of its values is not greater than 0, return false.
     1. If |options|.{{MLResample2dOptions/axes}} does not [=map/exists=], set it to the [=/list=] « 2, 3 ».
     1. Otherwise, if its value is not one of « 0, 1», « 1, 2», « 2, 3 », return false.
     1. Return true.
-  </div>
 </details>
 
 <details open algorithm>
-
   <summary>
     To <dfn for="MLGraphBuilder">calculate resample output sizes</dfn> given {{MLOperand}} |input| and {{MLResample2dOptions}} |options|, run the following steps:
   </summary>
-  <div class=algorithm-steps>
     1. Let |desc| be a new {{MLOperandDescriptor}} initialized to |input|.{{MLOperand/[[descriptor]]}}.
     1. For |index| in [=the range=] 0 to |options|.{{MLResample2dOptions/axes}}'s [=list/size=], exclusive:
         1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], set |desc|'s [=MLOperand/shape=][|options|.{{MLResample2dOptions/axes}}[|index|]] to |options|.{{MLResample2dOptions/sizes}}[|index|] and return |desc|.
         1. Otherwise, set |desc|'s [=MLOperand/shape=][|options|.{{MLResample2dOptions/axes}}[|index|]] to |input|'s [=MLOperand/shape=][|index|] multiplied by |options|.{{MLResample2dOptions/scales}}.
     1. Return |desc|.
-  </div>
 </details>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>resample2d(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If |input|'s [=MLOperand/rank=] is not 4, then [=exception/throw=] a {{TypeError}}.
     1. If [=MLGraphBuilder/checking resample options=] given |options| returns false, then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| be the result of [=MLGraphBuilder/calculating resample output sizes=] given |input| and |options|.
@@ -5261,7 +5029,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 ### reshape ### {#api-mlgraphbuilder-reshape-method}
@@ -5287,7 +5054,6 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder>reshape(|input|, |newShape|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |outputShape| be an empty array of {{unsigned long}}.
     1. If |newShape|'s [=list/size=] is 0, set |outputShape| to an empty [=/list=] for a scalar.
     1. If any value in |newShape| is 0, then [=exception/throw=] a {{TypeError}}.
@@ -5305,7 +5071,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <div class="note">
@@ -5382,11 +5147,9 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>sigmoid(|input|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
@@ -5397,7 +5160,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 #### {{MLGraphBuilder/sigmoid()}} #### {#api-mlgraphbuilder-sigmoid}
@@ -5413,11 +5175,9 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder id=sigmoid-noargs>sigmoid()</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=] and "sigmoid".
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
-  </div>
 </details>
 
 ### slice ### {#api-mlgraphbuilder-slice}
@@ -5439,11 +5199,9 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>slice(|input|, |starts|, |sizes|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If |sizes|'s [=list/size=] is 0, then [=exception/throw=] a {{TypeError}}.
     1. If |starts|'s [=list/size=] and |sizes|'s [=list/size=] are not both equal to |input|'s [=MLOperand/rank=], then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -5456,7 +5214,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 ### softmax ### {#api-mlgraphbuilder-softmax-method}
@@ -5503,7 +5260,6 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder>softmax(|input|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If |input|'s [=MLOperand/rank=] is not 2, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
@@ -5515,7 +5271,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 #### {{MLGraphBuilder/softmax()}} #### {#api-mlgraphbuilder-softmax}
@@ -5531,11 +5286,9 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder id=softmax-noargs>softmax()</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=] and  "softmax".
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
-  </div>
 </details>
 
 ### softplus ### {#api-mlgraphbuilder-softplus-method}
@@ -5588,11 +5341,9 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>softplus(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
@@ -5603,7 +5354,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 #### {{MLGraphBuilder/softplus(options)}} #### {#api-mlgraphbuilder-softplus-options}
@@ -5616,15 +5366,12 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>softplus(|options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=], "softplus" and |options|.
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
-  </div>
 </details>
 
 ### softsign ### {#api-mlgraphbuilder-softsign-method}
@@ -5660,11 +5407,9 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>softsign(|input|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
@@ -5675,7 +5420,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 #### {{MLGraphBuilder/softsign()}} #### {#api-mlgraphbuilder-softsign}
@@ -5691,11 +5435,9 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder id=softsign-noargs>softsign()</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=] and "softsign".
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
-  </div>
 </details>
 
 ### split ### {#api-mlgraphbuilder-split}
@@ -5732,7 +5474,6 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder>split(|input|, |splits|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If |splits| is an {{unsigned long}}, and |input|'s [=MLOperand/shape=][|options|.{{MLSplitOptions/axis}}] % |splits| is not 0, then [=exception/throw=] a {{TypeError}}.
     1. If |splits| is a sequence of {{unsigned long}}, and the sum of its elements is not equal to |input|'s [=MLOperand/shape=][|options|.{{MLSplitOptions/axis}}], then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -5745,7 +5486,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <div class="note">
@@ -5808,11 +5548,9 @@ partial interface MLGraphBuilder {
 </div>
 
 <details open algorithm>
-
   <summary>
     The <dfn method for=MLGraphBuilder>tanh(|input|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Make a request to the underlying platform to:
@@ -5823,7 +5561,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 #### {{MLGraphBuilder/tanh()}} #### {#api-mlgraphbuilder-tanh}
@@ -5839,11 +5576,9 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder id=tanh-noargs>tanh()</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=] and "tanh".
         1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
-  </div>
 </details>
 
 ### transpose ### {#api-mlgraphbuilder-transpose}
@@ -5879,7 +5614,6 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder>transpose(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If |options|.{{MLTransposeOptions/permutation}} does not [=map/exist=], let |options|.{{MLTransposeOptions/permutation}} be the reversed sequence of all indices for |input|'s [=MLOperand/shape=].
     1. Otherwise if |options|.{{MLTransposeOptions/permutation}} [=map/exists=]:
         1. If |options|.{{MLTransposeOptions/permutation}}'s [=MLOperand/rank=] is not the same as |input|'s [=MLOperand/rank=], then [=exception/throw=] a {{TypeError}}.
@@ -5895,7 +5629,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 ### triangular ### {#api-mlgraphbuilder-triangular}
@@ -5934,7 +5667,6 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder>triangular(|input|, |options|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If |input|'s [=MLOperand/rank=] is less than 2, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
@@ -5946,7 +5678,6 @@ partial interface MLGraphBuilder {
         1. Connect |input|.{{MLOperand/[[operand]]}} as input to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <div class="example">
@@ -6035,7 +5766,6 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder>where(|condition|, |input|, |other|)</dfn> method steps are:
   </summary>
-  <div class=algorithm-steps>
     1. If |condition|'s [=MLOperand/dataType=] is not equal to {{MLOperandDataType/"uint8"}}, then [=exception/throw=] a {{TypeError}}.
     1. If |input|'s [=MLOperand/dataType=] is not equal to |other|'s [=MLOperand/dataType=], then [=exception/throw=] a {{TypeError}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
@@ -6053,7 +5783,6 @@ partial interface MLGraphBuilder {
         1. Connect |condition|.{{MLOperand/[[operand]]}}, |input| and |other|.{{MLOperand/[[operand]]}} as inputs to |opImpl|.
         1. Connect |output|.{{MLOperand/[[operand]]}} as output to |opImpl|.
     1. Return |output|.
-  </div>
 </details>
 
 <div class="note">
@@ -6083,8 +5812,10 @@ Algorithms {#algorithms}
 
 Broadcasting refers to how operations treat tensors with different shapes, and follow the precedent set by [[!numpy-broadcasting-rule]].
 
-<div algorithm>
+<details open algorithm>
+<summary>
 To <dfn data-lt="unidirectionally broadcasting the shapes">unidirectionally broadcast the shapes</dfn> |A| and |B|, perform the following steps. |A| and |B| are [=/lists=] of positive integers, representing the dimensions of tensors, and the steps return a new [=/list=] of positive integers, or failure.
+</summary>
 
 1. Let |sizeA| be |A|'s [=list/size=].
 1. Let |sizeB| be |B|'s [=list/size=].
@@ -6099,14 +5830,16 @@ To <dfn data-lt="unidirectionally broadcasting the shapes">unidirectionally broa
     1. [=list/Append=] |dimA| to |outputShape|.
 1. Return |outputShape|.
 
-</div>
+</details>
 
-<div algorithm>
+<p algorithm>
 |A| is <dfn>unidirectionally broadcastable</dfn> to |B| if [=unidirectionally broadcasting the shapes=] |A| and |B| does not result in failure.
-</div>
+</p>
 
-<div algorithm>
+<details open algorithm>
+<summary>
 To <dfn data-lt="bidirectionally broadcasting the shapes">bidirectionally broadcast the shapes</dfn> |A| and |B|, perform the following steps. |A| and |B| are [=/lists=] of positive integers, representing the dimensions of tensors, and the steps return a new [=/list=] of positive integers, or failure.
+</summary>
 
 1. Let |sizeA| be |A|'s [=list/size=].
 1. Let |sizeB| be |B|'s [=list/size=].
@@ -6123,11 +5856,11 @@ To <dfn data-lt="bidirectionally broadcasting the shapes">bidirectionally broadc
     1. [=list/Append=] the maximum of |dimA| and |dimB| to |outputShape|.
 1. Return |outputShape|.
 
-</div>
+</details>
 
-<div algorithm>
+<p algorithm>
 |A| is <dfn>bidirectionally broadcastable</dfn> to |B| if [=bidirectionally broadcasting the shapes=] |A| and |B| does not result in failure.
-</div>
+</p>
 
 Examples {#examples}
 =====================


### PR DESCRIPTION
* Bikeshed styles W3C spec substeps (and sub-substeps, etc) with bars to make the indentation level clearer. The explicit markup used for `class=algorithm-steps` was preventing the selector from matching. Simplify the markup and CSS to get *more* by doing *less*.

* The default `<summary>` element style is bold, which was making the specific definition within an algorithm's intro difficult to see. Override this for algorithms, so that the defined algorithm name "pops" more.

* Recently introduced broadcast algorithms weren't using the `<details>` / `<summary>` markup. Apply this to match the rest of the spec.

* Remove now-unused CSS `validusage` and `informalsteps` styling.

No content changes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/594.html" title="Last updated on Mar 13, 2024, 4:35 PM UTC (14082a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/594/1d1b531...inexorabletash:14082a9.html" title="Last updated on Mar 13, 2024, 4:35 PM UTC (14082a9)">Diff</a>