### PR TITLE
Update anchor link for compute() after dropping synchronous execution support

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -975,7 +975,7 @@ When the {{MLContext/[[contextType]]}} is set to [=context type/default=] with t
   </div>
 </details>
 
-### {{MLContext/compute()}}  ### {#api-mlcontext-async-execution}
+### {{MLContext/compute()}}  ### {#api-mlcontext-compute}
 Asynchronously carries out the computational workload of a compiled graph {{MLGraph}} on a separate timeline, either on a worker thread for the CPU execution, or on a GPU timeline for the submission of GPU workload on the command queue. The asynchronous nature of this call avoids blocking the calling thread while the computation for result is ongoing. This method of execution requires an {{MLContext}} created with {{MLContextOptions}}. Otherwise, it [=exception/throws=] an "{{OperationError}}" {{DOMException}}.
 
 <div class="note">
@@ -1015,7 +1015,7 @@ In accordance with the [=ArrayBufferView/write|Web IDL warning=], to prevent the
   </div>
 </details>
 
-#### Examples #### {#api-mlcontext-async-execution-examples}
+#### Examples #### {#api-mlcontext-compute-examples}
 <div class="example">
 <details open>
   <summary>


### PR DESCRIPTION
Fix https://github.com/webmachinelearning/webnn/issues/595 .

After dropping the support of synchronous execution in https://github.com/webmachinelearning/webnn/issues/531 , we'd better to update the anchor link of `compute()` from `https://www.w3.org/TR/webnn/#api-mlcontext-async-execution` to `https://www.w3.org/TR/webnn/#api-mlcontext-compute` .


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ibelem/webnn/pull/596.html" title="Last updated on Mar 7, 2024, 4:07 AM UTC (c01e4c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/596/480b094...ibelem:c01e4c1.html" title="Last updated on Mar 7, 2024, 4:07 AM UTC (c01e4c1)">Diff</a>