### PR TITLE
Bugfix: Duplicate word, variable name consistency

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2843,8 +2843,8 @@ partial interface MLGraphBuilder {
     <div class="note">
         The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
     </div>
-    1. Let |descriptor| be a new {{MLOperandDescriptor}}.
-    1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].
+    1. Let |outputDescriptor| be a new {{MLOperandDescriptor}}.
+    1. Set |outputDescriptor|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].
     1. Set |outputDescriptor|.{{MLOperandDescriptor/dimensions}} to the result of [=unidirectionally broadcasting the shapes=] |input|'s [=MLOperand/shape=] and |newShape|.
         1. If that returns failure, then [=exception/throw=] a {{TypeError}}.
     1. If any of the following sub-steps fail, [=exception/throw=] an "{{OperationError}}" {{DOMException}}.
@@ -5219,7 +5219,7 @@ partial interface MLGraphBuilder {
     To <dfn for="MLGraphBuilder">check resample options</dfn> given |options|, run the following steps:
   </summary>
   <div class=algorithm-steps>
-    1. If |options|.{{MLResample2dOptions/scales}} does not [=map/exist=], set it to to the [=/list=] « 1.0, 1.0 ».
+    1. If |options|.{{MLResample2dOptions/scales}} does not [=map/exist=], set it to the [=/list=] « 1.0, 1.0 ».
     1. Otherwise, if any of its values is not greater than 0, or if its [=list/size=] is not 2, return false.
     1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], and if its size is not 2, or if any of its values is not greater than 0, return false.
     1. If |options|.{{MLResample2dOptions/axes}} does not [=map/exists=], set it to the [=/list=] « 2, 3 ».


### PR DESCRIPTION
- in *check resample options*, remove a duplicate word
- in *expand()*, don't use two names for the same variable


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/597.html" title="Last updated on Mar 7, 2024, 8:14 PM UTC (1842a20)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/597/86081aa...inexorabletash:1842a20.html" title="Last updated on Mar 7, 2024, 8:14 PM UTC (1842a20)">Diff</a>