### PR TITLE
Content: Clarify the expected behavior for axes being empty

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1567,7 +1567,7 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLArgMinMaxOptions>
     : <dfn>axes</dfn>
     ::
-        The dimensions to reduce. The values must be in the range [0, N-1] where N is the [=MLOperand/rank=] of the input tensor. If not present, all dimensions are reduced.
+        The dimensions to reduce. The values must be in the range [0, N-1] where N is the [=MLOperand/rank=] of the input tensor. If not present, all dimensions are reduced. If empty, no dimensions are reduced, and the shape of the output tensor is the same as the shape of the input tensor.
 
     : <dfn>keepDimensions</dfn>
     ::
@@ -3760,8 +3760,7 @@ partial interface MLGraphBuilder {
 
     : <dfn>axes</dfn>
     ::  
-        The indices to the input dimensions to reduce. When this member is not present, it is treated as if all dimensions except the first were given (e.g. for a 4-D input tensor, axes = [1,2,3]). That is, the reduction for the mean and variance values are calculated across all the input features for each independent batch.
-
+        The indices to the input dimensions to reduce. When this member is not present, it is treated as if all dimensions except the first were given (e.g. for a 4-D input tensor, axes = [1,2,3]). That is, the reduction for the mean and variance values are calculated across all the input features for each independent batch. If empty, no dimensions are reduced.
     : <dfn>epsilon</dfn>
     ::
         A small value to prevent computational error due to divide-by-zero.
@@ -4941,7 +4940,7 @@ partial interface MLGraphBuilder {
 <dl dfn-type=dict-member dfn-for=MLReduceOptions>
     : <dfn>axes</dfn>
     ::
-        The dimensions to reduce. The values in the list must be in the range [0, N-1] where N is the [=MLOperand/rank=] of the input tensor. If not present, all dimensions are reduced.
+        The dimensions to reduce. The values in the list must be in the range [0, N-1] where N is the [=MLOperand/rank=] of the input tensor. If not present, all dimensions are reduced. If empty, no dimensions are reduced, and the shape of the output tensor is the same as the shape of the input tensor.
 
     : <dfn>keepDimensions</dfn>
     ::


### PR DESCRIPTION
The shape calculation for argMin/argMax and reduction ops is now fully specified, but the implied behavior of {axes:[]} for these ops and layerNormalization was not particularly clear.

Add a little text to make it clearer.

Fixes #493


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/599.html" title="Last updated on Mar 13, 2024, 4:31 PM UTC (48fab65)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/599/1d1b531...inexorabletash:48fab65.html" title="Last updated on Mar 13, 2024, 4:31 PM UTC (48fab65)">Diff</a>