### PR TITLE
Content: Define output for gru()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3124,12 +3124,24 @@ partial interface MLGraphBuilder {
         1. If its [=MLOperand/rank=] is not 3, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLGruOptions/activations}} [=map/exists=] and its [=list/size=] is not 2, then [=exception/throw=] a {{TypeError}}.
     1. If |steps| is not equal to |input|'s [=MLOperand/shape=][0], then [=exception/throw=] a {{TypeError}}.
+    1. *Calculate the output shape:*
+        1. Let |desc0| be a new {{MLOperandDescriptor}}.
+        1. Set |desc0|.{{MLOperandDescriptor/dimensions}} to the [=/list=] « |numDirections|, |batchSize|, |hiddenSize| ».
+        1. Set |desc0|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].
+        1. If |options|.{{MLLstmOptions/returnSequence}} is true:
+            1. Let |desc1| be a new {{MLOperandDescriptor}}.
+            1. Set |desc1|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].
+            1. Set |desc1|.{{MLOperandDescriptor/dimensions}} to the [=/list=] « |steps|, |numDirections|, |batchSize|, |hiddenSize| ».
     1. *Make graph connections:*
         1. Let |operator| be an [=operator=] for "gru", given |weight|, |recurrentWeight|, |steps|, |hiddenSize| and |options| as parameters.
-        1. Let |output| be an empty sequence of {{MLOperand}} objects.
-
-            Issue: Populate |output|
-
+        1. Let |output0| be the result of [=creating an MLOperand=] given [=this=] and |desc0|.
+        1. If |options|.{{MLGruOptions/returnSequence}} is true:
+            1. Let |output1| be the result of [=creating an MLOperand=] given [=this=] and |desc1|.
+            1. Let |output| be the [=/list=] « |output0|, |output1| ».
+            1. Set |output0|.{{MLOperand/[[operator]]}} and |output1|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Otherwise:
+            1. Let |output| be the [=/list=] « |output0| ».
+            1. Set |output0|.{{MLOperand/[[operator]]}} to |operator|.
         1. Set |operator|'s [=operator/inputs=] to |input|, |weight|, and |recurrentWeight|.
         1. If |options|.{{MLGruOptions/bias=] [=map/exists=], then add it to |operator|'s [=operator/inputs=].
         1. If |options|.{{MLGruOptions/recurrentBias=] [=map/exists=], then add it to |operator|'s [=operator/inputs=].
@@ -4067,9 +4079,10 @@ partial interface MLGraphBuilder {
         1. If |options|.{{MLLstmOptions/returnSequence}} is true:
             1. Let |output2| be the result of [=creating an MLOperand=] given [=this=] and |desc2|.
             1. Let |output| be the [=/list=] « |output0|, |output1|, |output2| ».
+            1. Set |output0|.{{MLOperand/[[operator]]}}, |output1|.{{MLOperand/[[operator]]}} and |output2|.{{MLOperand/[[operator]]}} to |operator|.
         1. Otherwise:
             1. Let |output| be the [=/list=] « |output0|, |output1| ».
-        1. Set |output0|.{{MLOperand/[[operator]]}}, |output1|.{{MLOperand/[[operator]]}} and |output2|.{{MLOperand/[[operator]]}} to |operator|.
+            1. Set |output0|.{{MLOperand/[[operator]]}} and |output1|.{{MLOperand/[[operator]]}} to |operator|.
         1. Set |operator|'s [=operator/inputs=] to |input|, |weight|, and |recurrentWeight|.
         1. If |options|.{{MLLstmOptions/bias}} [=map/exists=], then add it to |operator|'s [=operator/inputs=].
         1. If |options|.{{MLLstmOptions/recurrentBias}} [=map/exists=], then add it to |operator|'s [=operator/inputs=].

--- a/index.bs
+++ b/index.bs
@@ -3128,7 +3128,7 @@ partial interface MLGraphBuilder {
         1. Let |desc0| be a new {{MLOperandDescriptor}}.
         1. Set |desc0|.{{MLOperandDescriptor/dimensions}} to the [=/list=] « |numDirections|, |batchSize|, |hiddenSize| ».
         1. Set |desc0|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].
-        1. If |options|.{{MLLstmOptions/returnSequence}} is true:
+        1. If |options|.{{MLGruOptions/returnSequence}} is true:
             1. Let |desc1| be a new {{MLOperandDescriptor}}.
             1. Set |desc1|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].
             1. Set |desc1|.{{MLOperandDescriptor/dimensions}} to the [=/list=] « |steps|, |numDirections|, |batchSize|, |hiddenSize| ».


### PR DESCRIPTION
Explicit steps were missing. Fill them in, following the precedent of lstm().

Also, fix a reference to a non-initialized variable in one branch within the lstm() steps.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/600.html" title="Last updated on Mar 14, 2024, 4:54 AM UTC (c38746c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/600/1d1b531...inexorabletash:c38746c.html" title="Last updated on Mar 14, 2024, 4:54 AM UTC (c38746c)">Diff</a>