### PR TITLE
reshape(): Remove "nullable" in prose description of newShape

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5183,7 +5183,7 @@ partial interface MLGraphBuilder {
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input tensor.
-        - *newShape*: a sequence of [=nullable type|nullable=] {{unsigned long}}. The shape of the output tensor.
+        - *newShape*: a sequence of {{unsigned long}}. The shape of the output tensor.
             The number of elements implied by *newShape* must be the same as the
             number of elements in the input tensor.
 


### PR DESCRIPTION
Per #388, the change #505 removed null value support in reshape()'s newShape parameter. That pull request missed updating the prose description to match.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/601.html" title="Last updated on Mar 13, 2024, 7:36 PM UTC (360cc2f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/601/1d1b531...inexorabletash:360cc2f.html" title="Last updated on Mar 13, 2024, 7:36 PM UTC (360cc2f)">Diff</a>