### PR TITLE
Bugfix: Drop "re-throw" in MLActivation creation steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1721,7 +1721,6 @@ partial interface MLGraphBuilder {
   </summary>
     1. If [=checking clamp options=] given |options| returns false, then [=exception/throw=] a {{TypeError}}.
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=], "clamp" and |options|.
-        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
 </details>
 
@@ -3373,7 +3372,6 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>hardSigmoid(|options|)</dfn> method steps are:
   </summary>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=], "hardSigmoid" and |options|.
-        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
 </details>
 
@@ -3445,7 +3443,6 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder id=hardswish-noargs>hardSwish()</dfn> method steps are:
   </summary>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=] and "hardSwish".
-        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
 </details>
 
@@ -3726,7 +3723,6 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>leakyRelu(|options|)</dfn> method steps are:
   </summary>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=], "leakyRelu" and |options|.
-        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
 </details>
 
@@ -3809,7 +3805,6 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>linear(|options|)</dfn> method steps are:
   </summary>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=],  "linear" and |options|.
-        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
 </details>
 
@@ -4922,7 +4917,6 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder id=relu-noargs>relu()</dfn> method steps are:
   </summary>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=] and "relu".
-        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
 </details>
 
@@ -5158,7 +5152,6 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder id=sigmoid-noargs>sigmoid()</dfn> method steps are:
   </summary>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=] and "sigmoid".
-        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
 </details>
 
@@ -5265,7 +5258,6 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder id=softmax-noargs>softmax()</dfn> method steps are:
   </summary>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=] and  "softmax".
-        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
 </details>
 
@@ -5346,7 +5338,6 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>softplus(|options|)</dfn> method steps are:
   </summary>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=], "softplus" and |options|.
-        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
 </details>
 
@@ -5410,7 +5401,6 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder id=softsign-noargs>softsign()</dfn> method steps are:
   </summary>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=] and "softsign".
-        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
 </details>
 
@@ -5558,7 +5548,6 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder id=tanh-noargs>tanh()</dfn> method steps are:
   </summary>
     1. Let |op| be the result of [=creating an MLActivation=] given [=this=] and "tanh".
-        1. If that [=exception/throws=] an error, re-[=exception/throw=] the error.
     1. Return |op|.
 </details>
 

--- a/index.bs
+++ b/index.bs
@@ -1165,9 +1165,6 @@ interface MLActivation {};
         The {{MLActivation}}'s name.
     : <dfn>\[[builder]]</dfn> of type {{MLGraphBuilder}}
     ::
-        The graph builder object this {{MLActivation}} belongs to.
-    : <dfn>\[[options]]</dfn> of type [=ordered map=]
-    ::
         A dictionary containing {{MLActivation}} options.
     : <dfn>\[[operator]]</dfn> of type [=operator=]
     ::
@@ -1186,16 +1183,13 @@ The {{MLActivation}} objects (including the ones passed as input to methods) are
 
 <details open algorithm>
   <summary>
-    To <dfn>create an MLActivation</dfn> given {{MLGraphBuilder}} |builder|, [=string=] |name|, optional [=ordered map=] |options| and optional algorithm |init-steps|, run the following steps:
+    To <dfn>create an MLActivation</dfn> given {{MLGraphBuilder}} |builder|, [=string=] |name| and optional [=ordered map=] |options|, run the following steps:
   </summary>
     1. Let |activation| be a new {{MLActivation}}.
     1. Set |activation|.{{MLActivation/[[builder]]}} to |builder|.
     1. Set |activation|.{{MLActivation/[[name]]}} to |name|.
-    1. If |options| is given, set |activation|.{{MLActivation/[[options]]}} to |options|.
-    1. Let |operator| be an [=operator=] for the |name| operation.
+    1. Let |operator| be an [=operator=] for the |name| operation, given |options|.
     1. Set |activation|.{{MLActivation/[[operator]]}} to |operator|.
-    1. If |init-steps| are given, run |init-steps| with |options|.
-    1. Otherwise, initialize |activation|.{{MLActivation/[[operator]]}} given |options| in an [=implementation-defined=] way for the given |name| operation.
     1. Return |activation|.
 </details>
 


### PR DESCRIPTION
The "create an MLActivation" steps don't throw, so there's no need to re-throw.

Also, nothing specifies _init-steps_ so drop those, and simplify how the steps handle _options_, to align with how things are done for `MLOperands`. 

Discussed in https://github.com/webmachinelearning/webnn/pull/591#issuecomment-1970013201


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/619.html" title="Last updated on Mar 23, 2024, 6:37 PM UTC (c6ee63a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/619/91cb734...inexorabletash:c6ee63a.html" title="Last updated on Mar 23, 2024, 6:37 PM UTC (c6ee63a)">Diff</a>