### PR TITLE
Bug fix: Drop "... have been checked..." notes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1261,9 +1261,6 @@ Create a named {{MLOperand}} based on a descriptor, that can be used as an input
   <summary>
     The <dfn method for=MLGraphBuilder>input(|name|, |descriptor|)</dfn> method steps are:
   </summary>
-    <div class="note">
-        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
-    </div>
     1. If |name| is empty, then [=exception/throw=] a {{TypeError}}.
     1. If [=MLOperandDescriptor/checking dimensions=] given |descriptor| returns false, then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
@@ -1290,9 +1287,6 @@ Create a constant {{MLOperand}} of the specified data type and shape that contai
   <summary>
     The <dfn method for=MLGraphBuilder>constant(|descriptor|, |bufferView|)</dfn> method steps are:
   </summary>
-    <div class="note">
-        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
-    </div>
     1. If [=MLOperandDescriptor/checking dimensions=] given |descriptor| returns false, then [=exception/throw=] a {{TypeError}}.
     1. If [=validating buffer with descriptor=] given |bufferView| and |descriptor| returns false, then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
@@ -1320,9 +1314,6 @@ Data truncation will occur when the specified value exceeds the range of the spe
   <summary>
     The <dfn method for=MLGraphBuilder>constant(|value|, |type|)</dfn> method steps are:
   </summary>
-    <div class="note">
-        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
-    </div>
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
         1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |type|.
         1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to an empty [=/list=].
@@ -1352,9 +1343,6 @@ Data truncation will occur when the values in the range exceed the range of the 
   <summary>
     The <dfn method for=MLGraphBuilder>constant(|start|, |end|, |step|, |type|)</dfn> method steps are:
   </summary>
-    <div class="note">
-        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
-    </div>
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
         1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |type|.
         1. Let |size| be max(0, ceil((|end| - |start|)/|step|)).
@@ -1741,9 +1729,6 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder>concat(|inputs|, |axis|)</dfn> method steps are:
   </summary>
-    <div class="note">
-        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
-    </div>
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any [=list/item=] in |inputs| returns false, then [=exception/throw=] a {{TypeError}}.
     1. If |inputs| [=list/is empty=], then [=exception/throw=] a {{TypeError}}.
     1. Let |first| be |inputs|[0].
@@ -2663,9 +2648,6 @@ partial interface MLGraphBuilder {
   <summary>
     The <dfn method for=MLGraphBuilder>expand(|input|, |newShape|)</dfn> method steps are:
   </summary>
-    <div class="note">
-        The permissions and context validity have been checked by [[#api-mlgraphbuilder-constructor]] steps.
-    </div>
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
     1. Let |outputDescriptor| be a new {{MLOperandDescriptor}}.
     1. Set |outputDescriptor|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].


### PR DESCRIPTION
A smattering of methods on MLGraphBuilder (build, buildSync, concat, constant, expand, and input) had a note about permissions and context validity at the start of the steps. This is implicit, and applies to all methods so it was confusing - was there something special about these methods?

Nope. So remove the notes.

Fixes #501


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/620.html" title="Last updated on Mar 26, 2024, 5:49 PM UTC (af931d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/620/2f32429...inexorabletash:af931d2.html" title="Last updated on Mar 26, 2024, 5:49 PM UTC (af931d2)">Diff</a>