### PR TITLE
Revise graph resource validation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -848,17 +848,6 @@ When the {{MLContext/[[contextType]]}} is set to [=context type/default=] with t
 
 <details open algorithm>
   <summary>
-    To <dfn>validate graph resources</dfn>, given {{MLNamedArrayBufferViews}} |resources| and [=ordered map=] |descriptors|, run the following steps:
-  </summary>
-    1. If |resources|'s [=map/size=] does not equal |descriptors|'s [=map/size=], then return false.
-    1. [=map/For each=] |name| → |resource| of |resources|:
-        1. If |descriptors|[|name|] does not [=map/exist=], return false.
-        1. If [=validating buffer with descriptor=] given |resource| and |descriptors|[|name|] returns false, then return false.
-    1. Return true.
-</details>
-
-<details open algorithm>
-  <summary>
     To <dfn>validate buffer with descriptor</dfn> given {{ArrayBufferView}} |bufferView| and {{MLOperandDescriptor}} |descriptor|, run the following steps:
   </summary>
     1. If |bufferView|'s [=element type=] does not match to |descriptor|.{{MLOperandDescriptor/dataType}}  according to [this table](#appendices-mloperanddatatype-arraybufferview-compatibility), return false.
@@ -920,6 +909,8 @@ In accordance with the [=ArrayBufferView/write|Web IDL warning=], to prevent the
     **Returns:** Promise<{{MLComputeResult}}>.
 </div>
 
+Note: Invocations of {{MLContext/compute()}} will fail if any of the {{MLContext/compute(graph, inputs, outputs)/graph}}'s inputs are not provided as {{MLContext/compute(graph, inputs, outputs)/inputs}}, or if any requested {{MLContext/compute(graph, inputs, outputs)/outputs}} do not match the {{MLContext/compute(graph, inputs, outputs)/graph}}'s outputs.
+
 <details open algorithm>
   <summary>
     The <dfn method for=MLContext>compute(|graph|, |inputs|, |outputs|)</dfn> method steps are:
@@ -928,8 +919,12 @@ In accordance with the [=ArrayBufferView/write|Web IDL warning=], to prevent the
     1. Let |realm| be [=this=]'s [=relevant realm=].
     1. If |graph|.{{MLGraph/[[context]]}} is not [=this=], then return [=a new promise=] [=rejected=] with a {{TypeError}}.
     1. If |graph|.{{MLGraph/[[context]]}}.{{MLContext/[[contextType]]}} is not "[=context type/default=]", then return [=a new promise=] [=rejected=] with an "{{OperationError}}" {{DOMException}}.
-    1. If [=validating graph resources=] given |inputs| and |graph|.{{MLGraph/[[inputDescriptors]]}} returns false, then return [=a new promise=] [=rejected=] with a {{TypeError}}.
-    1. If [=validating graph resources=] given |outputs| and |graph|.{{MLGraph/[[outputDescriptors]]}} returns false, then return [=a new promise=] [=rejected=] with a {{TypeError}}.
+    1. [=map/For each=] |name| → |descriptor| of |graph|.{{MLGraph/[[inputDescriptors]]}}:
+        1. If |inputs|[|name|] does not [=map/exist=], then return [=a new promise=] [=rejected=] with a {{TypeError}}.
+        1. If [=validating buffer with descriptor=] given |inputs|[|name|] and |descriptor| returns false, then return [=a new promise=] [=rejected=] with a {{TypeError}}.
+    1. [=map/For each=] |name| → |resource| of |outputs|:
+        1. If |graph|.{{MLGraph/[[outputDescriptors]]}}[|name|] does not [=map/exist=], then return [=a new promise=] [=rejected=] with a {{TypeError}}.
+        1. If [=validating buffer with descriptor=] given |resource| and |graph|.{{MLGraph/[[outputDescriptors]]}}[|name|] returns false, then return [=a new promise=] [=rejected=] with a {{TypeError}}.
     1. Let |transferredInputs| be the result of [=MLNamedArrayBufferViews/transfer|transferring=] {{MLNamedArrayBufferViews}} |inputs| with |realm|.
     1. Let |transferredOutputs| be the result of [=MLNamedArrayBufferViews/transfer|transferring=] {{MLNamedArrayBufferViews}} |outputs| with |realm|.
     1. Let |promise| be [=a new promise=].

--- a/index.bs
+++ b/index.bs
@@ -840,6 +840,7 @@ When the {{MLContext/[[contextType]]}} is set to [=context type/default=] with t
   <summary>
     To <dfn>validate graph resources</dfn>, given {{MLNamedArrayBufferViews}} |resources| and [=ordered map=] |descriptors|, run the following steps:
   </summary>
+    1. If |resources|'s [=map/size=] does not equal |descriptors|'s [=map/size=], then return false.
     1. [=map/For each=] |name| → |resource| of |resources|:
         1. If |descriptors|[|name|] does not [=map/exist=], return false.
         1. If [=validating buffer with descriptor=] given |resource| and |descriptors|[|name|] returns false, then return false.


### PR DESCRIPTION
`compute()` calls validate graph resources with the passed input/output maps and the graph's input/output descriptors. The intent is to ensure that all of a graph's descriptors are matched to a passed resource. However, the steps were only validating that a passed resource had a corresponding descriptor - it wouldn't flag if a resource was missing!

The Chromium prototype implementation made the test reflexive - all resources much have matching descriptors and vice versa. After deliberation we settled on a more helpful behavior: all inputs must be provided, but extra inputs are ignored. A requested output must be present, but dropping outputs is allowed. 

Fixes #602


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/622.html" title="Last updated on Apr 16, 2024, 7:52 AM UTC (2384d12)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/622/954ed19...inexorabletash:2384d12.html" title="Last updated on Apr 16, 2024, 7:52 AM UTC (2384d12)">Diff</a>