### PR TITLE
Validate restriction of output padding in convTranspose2d

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2129,6 +2129,8 @@ partial interface MLGraphBuilder {
     1. Else if |options|.{{MLConvTranspose2dOptions/outputPadding}}'s [=list/size=] is not 2, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/outputSizes}} [=map/exists=]:
         1. If |options|.{{MLConvTranspose2dOptions/outputSizes}}'s [=list/size=] is not 2, then [=exception/throw=] a {{TypeError}}.
+    1. Otherwise:
+        1. If |options|.{{MLConvTranspose2dOptions/outputPadding}}[0] is greater than or equal to |options|.{{MLConvTranspose2dOptions/strides}}[0], or |options|.{{MLConvTranspose2dOptions/outputPadding}}[1] is greater than or equal to |options|.{{MLConvTranspose2dOptions/strides}}[1], then [=exception/throw=] a {{TypeError}}.
     1. *Calculate the output shape:*
         1. Switch on |options|.{{MLConvTranspose2dOptions/inputLayout}}:
             <dl class=switch>


### PR DESCRIPTION
When outputShapes is not specified, the output padding must be smaller than the stride along the same dimension.

This matches the Chromium prototype implementation.

Fixes #630


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/631.html" title="Last updated on Apr 2, 2024, 5:23 PM UTC (7c342d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/631/60b8e0a...inexorabletash:7c342d8.html" title="Last updated on Apr 2, 2024, 5:23 PM UTC (7c342d8)">Diff</a>