### PR TITLE
Decompositions for reduceLogSum, reduceLogSumExp, and reduceSumSquare

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4942,7 +4942,7 @@ partial interface MLGraphBuilder {
     </summary>
     <pre highlight="js">
     // reduceLogSum(input, options)
-    return builder.log(builder.reduceSum(input, options);
+    return builder.log(builder.reduceSum(input, options));
 
     // reduceLogSumExp(input, options)
     return builder.log(builder.reduceSum(builder.exp(input), options));

--- a/index.bs
+++ b/index.bs
@@ -4932,6 +4932,27 @@ partial interface MLGraphBuilder {
     </div>
 </details>
 
+<div class="note">
+  <details open>
+    <summary>
+    The behavior of several reduction operations can be generically emulated from the usage of
+    other operations as follows. However, user agents typically have a more
+    efficient implementation for them, therefore their usage is encouraged from the
+    performance standpoint.
+    </summary>
+    <pre highlight="js">
+    // reduceLogSum(input, options)
+    return builder.log(builder.reduceSum(input, options);
+
+    // reduceLogSumExp(input, options)
+    return builder.log(builder.reduceSum(builder.exp(input), options));
+
+    // reduceSumSquare(input, options)
+    return builder.reduceSum(builder.pow(input, 2), options);
+    </pre>
+  </details>
+</div>
+
 ### relu ### {#api-mlgraphbuilder-relu-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)">rectified linear function</a> of the input tensor.
 


### PR DESCRIPTION
As noted in #209, not all frameworks/platform APIs support all reduce operations, but these are easily emulated.

Decompositions are provided using the standard phrasing and style currently used throughout the spec. In the future, we may alter the wording to explicitly state that these decompositions can be used as templates for implementations to follow when their underlying frameworks/platform APIs do not support the operations.

Fixes #209


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/637.html" title="Last updated on Apr 6, 2024, 1:53 PM UTC (9469d7d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/637/1f60107...inexorabletash:9469d7d.html" title="Last updated on Apr 6, 2024, 1:53 PM UTC (9469d7d)">Diff</a>