### PR TITLE
Editorial: Make "generically emulated" text a macro, update wording

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -36,7 +36,7 @@ Status Text: <p>
   <li>it has at least two independent, interoperable implementations of every feature defined in the specification, where interoperability can be verified by passing open test suites, and two or more implementations interoperating with each other;</li>
   <li>it has an open test suite of every feature defined in the specification.</li>
   </ul>
-
+Text Macro: EMULATED generically emulated from the usage of other operations as follows, although user agents typically have a more efficient implementation. In cases where the underlying platform does not directly support an operation, this decomposition can be used as a template to guide the implementation.
 </pre>
 <pre class="anchors">
 urlPrefix: https://tc39.es/ecma262/; spec: ECMA-262
@@ -1582,7 +1582,7 @@ partial interface MLGraphBuilder {
 <div class="note">
   <details open>
     <summary>
-    The behavior of this operation when the input tensor is 4-D of the {{MLInputOperandLayout/"nchw"}} layout and the activation is {{MLGraphBuilder/relu()}} can be generically emulated from the usage of other operations as follow. However, user agents typically have a more efficient implementation for it, therefore its usage is encouraged from the performance standpoint.
+    The behavior of this operation when the input tensor is 4-D of the {{MLInputOperandLayout/"nchw"}} layout and the activation is {{MLGraphBuilder/relu()}} can be [EMULATED]
     </summary>
     <pre highlight="js">
     const shape = [1,null,1,1];
@@ -1654,10 +1654,7 @@ partial interface MLGraphBuilder {
 <div class="note">
 <details open>
   <summary>
-    The behavior of this operation can be generically emulated from the usage of
-    other operations as follow. However, user agents typically have a more
-    efficient implementation for it, therefore its usage is encouraged from the
-    performance standpoint.
+    The behavior of this operation can be [EMULATED]
   </summary>
   <pre highlight="js">
     if (options.minValue === undefined) {
@@ -2599,10 +2596,7 @@ partial interface MLGraphBuilder {
 <div class="note">
   <details open>
     <summary>
-    The behavior of this operation can be generically emulated from the usage of
-    other operations as follow. However, user agents typically have a more
-    efficient implementation for it, therefore its usage is encouraged from the
-    performance standpoint.
+    The behavior of this operation can be [EMULATED]
     </summary>
     <pre highlight="js">
     return builder.add(
@@ -2831,10 +2825,7 @@ partial interface MLGraphBuilder {
 <div class="note">
   <details open>
     <summary>
-    The behavior of this operation can be generically emulated from the usage of
-    other operations as follows. However, user agents typically have a more
-    efficient implementation for it. Therefore its usage is encouraged from the
-    performance standpoint.
+    The behavior of this operation can be [EMULATED]
     </summary>
     <pre highlight="js">
     return builder.mul(
@@ -2969,7 +2960,7 @@ partial interface MLGraphBuilder {
 <div class="note">
 <details open>
   <summary>
-    The behavior of this operation can be generically emulated from the usage of other operations as follow. However, user agents typically have a more efficient implementation for it, therefore its usage is encouraged from the performance standpoint.
+    The behavior of this operation can be [EMULATED]
   </summary>
   <pre highlight="js">
     if (options.aTranspose)
@@ -3112,7 +3103,7 @@ partial interface MLGraphBuilder {
 <div class="note">
 <details open>
   <summary>
-    The behavior of this operation can be generically emulated from the usage of other operations as follows. However, user agents typically have a more efficient implementation for it, therefore its usage is encouraged from the performance standpoint.
+    The behavior of this operation can be [EMULATED]
   </summary>
   <pre highlight="js">
     function squeeze(builder, op) {
@@ -3267,7 +3258,7 @@ partial interface MLGraphBuilder {
 <div class="note">
 <details open>
   <summary>
-    The behavior of this operation can be generically emulated via other operations as shown below, when the weight layout is the default {{MLGruWeightLayout/"zrn"}} layout, and the activation functions of the update/reset gate and new gate are {{MLGraphBuilder/sigmoid()}} and {{MLGraphBuilder/tanh()}} respectively.
+    The behavior of this operation when the weight layout is the default {{MLGruWeightLayout/"zrn"}} layout, and the activation functions of the update/reset gate and new gate are {{MLGraphBuilder/sigmoid()}} and {{MLGraphBuilder/tanh()}} respectively can be [EMULATED]
   </summary>
   <pre highlight="js">
     const one = builder.constant(1);
@@ -3382,10 +3373,7 @@ partial interface MLGraphBuilder {
 <div class="note">
   <details open>
     <summary>
-    The behavior of this operation can be generically emulated from the usage of
-    other operations as follow. However, user agents typically have a more
-    efficient implementation for it, therefore its usage is encouraged from the
-    performance standpoint.
+    The behavior of this operation can be [EMULATED]
     </summary>
     <pre highlight="js">
     return builder.max(
@@ -3462,10 +3450,7 @@ partial interface MLGraphBuilder {
 <div class="note">
 <details open>
   <summary>
-    The behavior of this operation can be generically emulated from the usage of
-    other operations as follow. However, user agents typically have a more
-    efficient implementation for it, therefore its usage is encouraged from the
-    performance standpoint.
+    The behavior of this operation can be [EMULATED]
   </summary>
   <pre highlight="js">
     return builder.div(
@@ -3589,9 +3574,7 @@ partial interface MLGraphBuilder {
 <div class="note">
 <details open>
   <summary>
-    The behavior of this operation when the input tensor is 4-D of the {{MLInputOperandLayout/"nchw"}} layout can be generically emulated from
-    the usage of other operations as follow. However, user agents typically have a more efficient implementation for it,
-    therefore its usage is encouraged from the performance standpoint.
+    The behavior of this operation when the input tensor is 4-D of the {{MLInputOperandLayout/"nchw"}} layout can be [EMULATED]
   </summary>
   <pre highlight="js">
     // The reduction of the mean and variance values happens over the spatial dimensions of the input
@@ -3693,9 +3676,7 @@ partial interface MLGraphBuilder {
 <div class="note">
 <details open>
   <summary>
-    The behavior of this operation when the axes parameter is set to [1,2,3] can be generically emulated from
-    the usage of other operations as follow. However, user agents typically have a more efficient implementation for it,
-    therefore its usage is encouraged from the performance standpoint.
+    The behavior of this operation when the axes parameter is set to [1,2,3] can be [EMULATED]
   </summary>
   <pre highlight="js">
     // The reduction of the mean and variance values happens over the spatial dimensions 
@@ -3742,10 +3723,7 @@ partial interface MLGraphBuilder {
 <div class="note">
   <details open>
     <summary>
-    The behavior of this operation can be generically emulated from the usage of
-    other operations as follow. However, user agents typically have a more
-    efficient implementation for it, therefore its usage is encouraged from the
-    performance standpoint.
+    The behavior of this operation can be [EMULATED]
     </summary>
     <pre highlight="js">
     return builder.add(builder.max(builder.constant(0), x),
@@ -3820,10 +3798,7 @@ partial interface MLGraphBuilder {
 <div class="note">
   <details open>
     <summary>
-    The behavior of this operation can be generically emulated from the usage of
-    other operations as follow. However, user agents typically have a more
-    efficient implementation for it, therefore its usage is encouraged from the
-    performance standpoint.
+    The behavior of this operation can be [EMULATED]
     </summary>
     <pre highlight="js">
     return builder.add(
@@ -4032,7 +4007,7 @@ partial interface MLGraphBuilder {
 <div class="note">
 <details open>
   <summary>
-    The behavior of this operation can be generically emulated from the usage of other operations as follow. However, user agents typically have a more efficient implementation for it, therefore its usage is encouraged from the performance standpoint.
+    The behavior of this operation can be [EMULATED]
   </summary>
   <pre highlight="js">
     function squeeze(builder, op) {
@@ -4212,7 +4187,7 @@ partial interface MLGraphBuilder {
 <div class="note">
 <details open>
   <summary>
-    The behavior of this operation can be generically emulated via other operations as shown below, when the weight layout is the default {{MLLstmWeightLayout/"iofg"}} layout, and the activation functions of the input/forget/output gate and the cell gate/the cell state's filter for the output hidden state are {{MLGraphBuilder/sigmoid()}} and {{MLGraphBuilder/tanh()}} respectively.
+    The behavior of this operation when the weight layout is the default {{MLLstmWeightLayout/"iofg"}} layout, and the activation functions of the input/forget/output gate and the cell gate/the cell state's filter for the output hidden state are {{MLGraphBuilder/sigmoid()}} and {{MLGraphBuilder/tanh()}} respectively can be [EMULATED]
   </summary>
   <pre highlight="js">
     const zero = builder.constant(0);
@@ -4596,7 +4571,7 @@ partial interface MLGraphBuilder {
 </div>
 
 <div class="note">
-    A *global* pooling operation such as one for the max pooling operation is a variant of pooling where the window dimensions is the spatial dimensions (last two dimensions) of the input shape, as follow.
+    A *global* pooling operation such as one for the max pooling operation is a variant of pooling where the window dimensions is the spatial dimensions (last two dimensions) of the input shape, as follows.
     <pre highlight="js">
     // 'global' max pooling
     builder.maxPool2d(input);
@@ -4753,10 +4728,7 @@ partial interface MLGraphBuilder {
 <div class="note">
   <details open>
     <summary>
-    The behavior of this operation can be generically emulated from the usage of
-    other operations as follow. However, user agents typically have a more
-    efficient implementation for it, therefore its usage is encouraged from the
-    performance standpoint.
+    The behavior of this operation can be [EMULATED]
     </summary>
     <pre highlight="js">
     return builder.add(builder.max(builder.constant(0), x),
@@ -4945,10 +4917,7 @@ partial interface MLGraphBuilder {
 <div class="note">
   <details open>
     <summary>
-    The behavior of this operation can be generically emulated from the usage of
-    other operations as follow. However, user agents typically have a more
-    efficient implementation for it, therefore its usage is encouraged from the
-    performance standpoint.
+    The behavior of this operation can be [EMULATED]
     </summary>
     <pre highlight="js">
     return builder.max(builder.constant(0), x);
@@ -5176,10 +5145,7 @@ partial interface MLGraphBuilder {
 <div class="note">
   <details open>
     <summary>
-    The behavior of this operation can be generically emulated from the usage of
-    other operations as follow. However, user agents typically have a more
-    efficient implementation for it, therefore its usage is encouraged from the
-    performance standpoint.
+    The behavior of this operation can be [EMULATED]
     </summary>
     <pre highlight="js">
     return builder.div(
@@ -5278,10 +5244,7 @@ partial interface MLGraphBuilder {
 <div class="note">
 <details open>
   <summary>
-    The behavior of this operation can be generically emulated from the usage of
-    other operations as follow. However, user agents typically have a more
-    efficient implementation for it, therefore its usage is encouraged from the
-    performance standpoint.
+    The behavior of this operation can be [EMULATED]
   </summary>
   <pre highlight="js">
     // This sample deploys a well-known implementation trick [1] to compute the
@@ -5353,10 +5316,7 @@ partial interface MLGraphBuilder {
 <div class="note">
   <details open>
     <summary>
-    The behavior of this operation can be generically emulated from the usage of
-    other operations as follow. However, user agents typically have a more
-    efficient implementation for it, therefore its usage is encouraged from the
-    performance standpoint.
+    The behavior of this operation can be [EMULATED]
     </summary>
     <pre highlight="js">
     return builder.div(
@@ -5429,10 +5389,7 @@ partial interface MLGraphBuilder {
 <div class="note">
   <details open>
     <summary>
-    The behavior of this operation can be generically emulated from the usage of
-    other operations as follow. However, user agents typically have a more
-    efficient implementation for it, therefore its usage is encouraged from the
-    performance standpoint.
+    The behavior of this operation can be [EMULATED]
     </summary>
     <pre highlight="js">
     return builder.div(x, builder.add(builder.constant(1), builder.abs(x)));
@@ -5541,10 +5498,7 @@ partial interface MLGraphBuilder {
 <div class="note">
 <details open>
   <summary>
-    The behavior of this operation can be generically emulated from the usage of
-    other operations as follow. However, user agents typically have a more
-    efficient implementation for it, therefore its usage is encouraged from the
-    performance standpoint.
+    The behavior of this operation can be [EMULATED]
   </summary>
   <pre highlight="js">
     // This sample shows the case that the splits parameter is an array.
@@ -5575,10 +5529,7 @@ partial interface MLGraphBuilder {
 <div class="note">
   <details open>
     <summary>
-    The behavior of this operation can be generically emulated from the usage of
-    other operations as follow. However, user agents typically have a more
-    efficient implementation for it, therefore its usage is encouraged from the
-    performance standpoint.
+    The behavior of this operation can be [EMULATED]
     </summary>
     <pre highlight="js">
     return builder.div(
@@ -5826,7 +5777,7 @@ partial interface MLGraphBuilder {
 <div class="note">
   <details open>
     <summary>
-    The behavior of this operation can be generically emulated from the usage of other operations as follow. However, user agents typically have a more efficient implementation for it, therefore its usage is encouraged from the performance standpoint.
+    The behavior of this operation can be [EMULATED]
     </summary>
     <pre highlight="js">
     const c = builder.clamp(condition, {'minValue': 0, 'maxValue': 1});


### PR DESCRIPTION
Many complex operations in the spec are given decompositions, showing how the operation could be replaced through the use of more primitive operations. This text is repeated in many places. Improve this in two ways:

* Use Bikeshed's Text Macro[1] to reduce the repetition.

* Streamline the text, and make it explicit that if the underlying platform doesn't support an operation, WebNN API implementations can use the decomposition as a guide to emulate it.

The macro [EMULATED] is used at the end of an intro sentence since there are variations - some of the decompositions are grouped, and some make assumptions (e.g. activation functions, layouts, etc).

If we assume that implementations must implement all operations in the spec, either via the underlying platform or emulation, this fixes #187

[1] https://speced.github.io/bikeshed/#metadata-text-macro


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/638.html" title="Last updated on Apr 5, 2024, 9:13 PM UTC (61355d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/638/1f60107...inexorabletash:61355d9.html" title="Last updated on Apr 5, 2024, 9:13 PM UTC (61355d9)">Diff</a>