### PR TITLE
Float16Array has landed in Web IDL - remove workarounds

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -44,9 +44,6 @@ urlPrefix: https://tc39.es/ecma262/; spec: ECMA-262
         text: element size; url: table-the-typedarray-constructors
         text: element type; url: table-the-typedarray-constructors
         text: view constructor; url: table-the-typedarray-constructors
-urlPrefix: https://tc39.es/proposal-float16array/; spec: float16array
-    type: interface
-        text: Float16Array; url: sec-float16array
 </pre>
 
 <pre class="link-defaults">
@@ -6023,8 +6020,6 @@ const graph = await builder.build({'output': output});
         <td>{{MLOperandDataType/uint8}}
         <td>{{Uint8Array}}
 </table>
-
-<p class="note">{{Float16Array}} is at <a href="https://tc39.es/process-document/">ECMA Stage 3</a> signaling its design is finished. Implementers wanting to enable this type ahead native implementations can emulate the type by passing raw bits via {{Uint16Array}}. <a href="https://github.com/webmachinelearning/webnn/issues/373">[Issue webnn#373]</a></p>
 
 <h2 id="acknowledgements">Acknowledgements</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -6021,6 +6021,8 @@ const graph = await builder.build({'output': output});
         <td>{{Uint8Array}}
 </table>
 
+<p class="note">{{Float16Array}} is at <a href="https://tc39.es/process-document/">ECMA Stage 3</a> signaling its design is finished. Implementers wanting to enable this type ahead native implementations can emulate the type by passing raw bits via {{Uint16Array}}. <a href="https://github.com/webmachinelearning/webnn/issues/373">[Issue webnn#373]</a></p>
+
 <h2 id="acknowledgements">Acknowledgements</h2>
 
 This specification follows the concepts of the Android Neural Networks API C


### PR DESCRIPTION
As of https://github.com/whatwg/webidl/issues/1310 Web IDL has Float16Array listed alongside the other typed array types. For WebNN we can now just defer to Web IDL for the link now.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/640.html" title="Last updated on Apr 10, 2024, 4:43 PM UTC (18fae72)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/640/1f60107...inexorabletash:18fae72.html" title="Last updated on Apr 10, 2024, 4:43 PM UTC (18fae72)">Diff</a>