### PR TITLE
Editorial: Add note about keepDimensions of reduction ops

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4940,6 +4940,10 @@ partial interface MLGraphBuilder {
   </details>
 </div>
 
+<div class="note">
+  Some underlying platforms do not support an option like {{MLReduceOptions/keepDimensions}} directly. This does not affect the underlying tensor data, only the shape. For example, if the input shape is *[2, 3, 4]*, the axis is 1, and {{MLReduceOptions/keepDimensions}} is true, the expected output shape is *[2, 1 ,4]*. If the underlying platform never keeps reduced dimensions it will produce an output shape of *[2, 4]*. The implementation can introduce a no-op reshape to *[2, 1, 4]*. A similar no-op reshape can be introduced if {{MLReduceOptions/keepDimensions}} is false but the underlying platform always keeps reduced dimensions.
+</div>
+
 ### relu ### {#api-mlgraphbuilder-relu-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)">rectified linear function</a> of the input tensor.
 


### PR DESCRIPTION
Add a note based on @fdwr's comment: if the backend doesn't support a keepDimensions option, the implementation can insert a no-op reshape to keep or drop the reduced dimension(s) as needed.

Fixes #465


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/648.html" title="Last updated on Apr 18, 2024, 7:56 PM UTC (9beb397)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/648/26982c4...inexorabletash:9beb397.html" title="Last updated on Apr 18, 2024, 7:56 PM UTC (9beb397)">Diff</a>