### PR TITLE
Remove sequential filling overload of constant()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1343,40 +1343,6 @@ Data truncation will occur when the specified value exceeds the range of the spe
     1. Return |operand|.
 </details>
 
-#### {{MLGraphBuilder/constant(start, end, step, type)}} #### {#api-mlgraphbuilder-constant-range}
-Create a constant {{MLOperand}} of the specified data type and shape that contains the data as specified by the range. 
-
-<div class="note">
-Data truncation will occur when the values in the range exceed the range of the specified output data type e.g. when a float value is assigned to an {{MLOperandDataType/"int8"}} data type, etc.
-</div>
-
-<div>
-    **Arguments:**
-        - *start*: a {{float}} scalar. The starting value of the range.
-        - *end*: a {{float}} scalar. The ending value of the range.
-        - *step*: a {{float}} scalar. The gap value between two data points in the range.
-        - *type*: an optional {{MLOperandDataType}}. If not specified, it is assumed to be {{MLOperandDataType/"float32"}}.
-    **Returns:** an {{MLOperand}}. The constant 1-D output tensor of size `max(0, ceil((end - start)/step))`.
-</div>
-
-<details open algorithm>
-  <summary>
-    The <dfn method for=MLGraphBuilder>constant(|start|, |end|, |step|, |type|)</dfn> method steps are:
-  </summary>
-    1. Let |descriptor| be a new {{MLOperandDescriptor}}.
-        1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |type|.
-        1. Let |size| be max(0, ceil((|end| - |start|)/|step|)).
-        1. If |size| is not a [=valid dimension=], then [=exception/throw=] a {{TypeError}}.
-        1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to the [=/list=] « |size| ».
-    1. *Make graph connections:*
-        1. Let |operand| be the result of [=creating an MLOperand=] given [=this=] and |descriptor|.
-        1. Let |buffer| be an [=implementation-defined=] platform memory buffer the size of |size| multiplied by sizeof(|descriptor|.{{MLOperandDescriptor/dataType}}).
-        1. [=list/For each=] |index| in [=the range=] 0 to |size|, exclusive:
-            1. Set |buffer|[|index|] to |start| + (|index| * |step|).
-        1. Add |operand| to [=this=]'s [=MLGraphBuilder/graph=]'s [=computational graph/constants=] with |buffer| as value.
-    1. Return |operand|.
-</details>
-
 ### build method ### {#api-mlgraphbuilder-build}
 Build a composed graph up to a given output operand into a computational graph asynchronously.
 


### PR DESCRIPTION
Discussion on #492 (specifically, this comment https://github.com/webmachinelearning/webnn/issues/492#issuecomment-2076061596) concluded that this overload was not needed. Its behavior can be emulated by filling a buffer in JavaScript to be passed in with the buffer-based `constant()` overload


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/a-sully/webnn/pull/656.html" title="Last updated on Apr 25, 2024, 4:33 PM UTC (36e73bc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/656/d57e4ef...a-sully:36e73bc.html" title="Last updated on Apr 25, 2024, 4:33 PM UTC (36e73bc)">Diff</a>