### PR TITLE
Remove uses of null as parameter to reshape() in code samples

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1562,7 +1562,7 @@ partial interface MLGraphBuilder {
     The behavior of this operation when the input tensor is 4-D of the {{MLInputOperandLayout/"nchw"}} layout and the activation is {{MLGraphBuilder/relu()}} can be [EMULATED]
     </summary>
     <pre highlight="js">
-    const shape = [1,null,1,1];
+    const shape = [1, input.shape()[options.axis], 1, 1];
     return builder.relu(
       builder.add(
         builder.mul(
@@ -3161,7 +3161,7 @@ partial interface MLGraphBuilder {
             currentHidden[dir], hiddenSize, { bias: currentBias[dir],
             recurrentBias: currentRecurrentBias[dir], resetAfter: options.resetAfter,
             layout: options.layout, activations: options.activations }),
-          [1, null, hiddenSize]);
+          [1, batchSize, hiddenSize]);
 
         currentOutput = (currentOutput ? builder.concat([currentOutput, result], 0) : result);
       }
@@ -3169,7 +3169,7 @@ partial interface MLGraphBuilder {
       hiddenState = currentOutput;
 
       if (options.returnSequence) {
-        currentOutput = builder.reshape(currentOutput, [1, numDirections, null, hiddenSize]);
+        currentOutput = builder.reshape(currentOutput, [1, numDirections, batchSize, hiddenSize]);
         sequence = (sequence ? builder.concat([sequence, currentOutput], 0) : currentOutput);
       }
     }
@@ -3617,7 +3617,7 @@ partial interface MLGraphBuilder {
 
     // The scale and bias values are applied per input feature
     // e.g. axis 1 of the input tensor.
-    const shape = [1,null,1,1];
+    const shape = [1, input.shape()[1], 1, 1];
     return builder.add(
       builder.mul(
         builder.reshape(options.scale, shape),
@@ -4121,8 +4121,8 @@ partial interface MLGraphBuilder {
           recurrentBias: currentRecurrentBias[dir], peepholeWeight: currentPeepholeWeight[dir],
           layout: options.layout, activations: options.activations });
 
-        let output = builder.reshape(results[0], [1, null, hiddenSize]);
-        let cell = builder.reshape(results[1], [1, null, hiddenSize]);
+        let output = builder.reshape(results[0], [1, batchSize, hiddenSize]);
+        let cell = builder.reshape(results[1], [1, batchSize, hiddenSize]);
 
         nextHidden = (nextHidden ? builder.concat([nextHidden, output], 0) : output);
         nextCell = (nextCell ? builder.concat([nextCell, cell], 0) : cell);
@@ -4132,7 +4132,7 @@ partial interface MLGraphBuilder {
       cellState = nextCell;
 
       if (options.returnSequence) {
-        nextHidden = builder.reshape(nextHidden, [1, numDirections, null, hiddenSize]);
+        nextHidden = builder.reshape(nextHidden, [1, numDirections, batchSize, hiddenSize]);
         sequence = (sequence ? builder.concat([sequence, nextHidden], 0) : nextHidden);
       }
     }


### PR DESCRIPTION
Fixes #667


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/a-sully/webnn/pull/671.html" title="Last updated on May 1, 2024, 5:59 PM UTC (782afc7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/671/ecc55a3...a-sully:782afc7.html" title="Last updated on May 1, 2024, 5:59 PM UTC (782afc7)">Diff</a>