### PR TITLE
Build fix: Correct link for "transferred" term

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1377,7 +1377,7 @@ Build a composed graph up to a given output operand into a computational graph a
     1. [=set/For each=] |operand| in |inputs|:
         1. Set |graph|.{{MLGraph/[[inputDescriptors]]}}[|operand|.{{MLOperand/[[name]]}}] to |operand|.{{MLOperand/[[descriptor]]}}.
 
-            Issue(566): If {{MLGraphBuilder/constant(descriptor, bufferView)|constants'}} {{ArrayBuffer}}s are not [=transferred=], make copies for [=MLGraphBuilder/graph=]'s [=computational graph/constants=] here.
+            Issue(566): If {{MLGraphBuilder/constant(descriptor, bufferView)|constants'}} {{ArrayBuffer}}s are not [=ArrayBuffer/transferred=], make copies for [=MLGraphBuilder/graph=]'s [=computational graph/constants=] here.
 
     1. [=map/For each=] |name| → |operand| of |outputs|:
         1. Set |graph|.{{MLGraph/[[outputDescriptors]]}}[|name|] to |operand|.{{MLOperand/[[descriptor]]}}.


### PR DESCRIPTION
Previously, a link to "transferred" was not scoped, and Bikeshed was silently linking to Verifiable Credentials Data Model v2.0's definition of the term. That term went away, so Bikeshed will now emit an error.

Fix by correctly scoping the link.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/679.html" title="Last updated on May 6, 2024, 6:32 PM UTC (ad6631c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/679/266eae1...inexorabletash:ad6631c.html" title="Last updated on May 6, 2024, 6:32 PM UTC (ad6631c)">Diff</a>