### PR TITLE
Add missing definitions of inputShape to conv2d algorithms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1872,6 +1872,7 @@ partial interface MLGraphBuilder {
     1. Otherwise, if |options|.{{MLConv2dOptions/dilations}}'s [=list/size=] is not 2, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/groups}} is 0, then [=exception/throw=] a {{TypeError}}.
     1. *Calculate the output shape:*
+        1. Let |inputShape| be |input|'s [=MLOperand/shape=].
         1. Switch on |options|.{{MLConv2dOptions/inputLayout}}:
             <dl class=switch>
                 : {{MLInputOperandLayout/"nchw"}}
@@ -2085,6 +2086,7 @@ partial interface MLGraphBuilder {
     1. Otherwise:
         1. If |options|.{{MLConvTranspose2dOptions/outputPadding}}[0] is greater than or equal to |options|.{{MLConvTranspose2dOptions/strides}}[0], or |options|.{{MLConvTranspose2dOptions/outputPadding}}[1] is greater than or equal to |options|.{{MLConvTranspose2dOptions/strides}}[1], then [=exception/throw=] a {{TypeError}}.
     1. *Calculate the output shape:*
+        1. Let |inputShape| be |input|'s [=MLOperand/shape=].
         1. Switch on |options|.{{MLConvTranspose2dOptions/inputLayout}}:
             <dl class=switch>
                 : {{MLInputOperandLayout/"nchw"}}


### PR DESCRIPTION
The algorithms for both conv2d() and convTranspose2d() used an `inputShape` local variable, but never defined it. Oops! The meaning was obvious, but we do need to define and initialize it to keep tooling happy.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/680.html" title="Last updated on May 6, 2024, 6:39 PM UTC (293ecef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/680/266eae1...inexorabletash:293ecef.html" title="Last updated on May 6, 2024, 6:39 PM UTC (293ecef)">Diff</a>