### PR TITLE
Remove note about interop issues with clamp()'s minValue == maxValue

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1645,9 +1645,6 @@ partial interface MLGraphBuilder {
     To <dfn>check clamp options</dfn> given {{MLClampOptions}} |options|, run the following steps:
   </summary>
     1. If |options|.{{MLClampOptions/minValue}} is greater than |options|.{{MLClampOptions/maxValue}}, then return false.
-
-        Issue(396): Not all implementations support {{MLClampOptions/minValue}} equal to {{MLClampOptions/maxValue}}.
-
     1. Return true.
 </details>
 


### PR DESCRIPTION
Per discussion in the issue, now that XNNPACK is updated there are no backends that disallow minValue == maxValue, so the issue can be resolved and spec note can be removed.

Resolves #396


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/684.html" title="Last updated on May 9, 2024, 6:59 PM UTC (31ce312)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/684/191a9de...inexorabletash:31ce312.html" title="Last updated on May 9, 2024, 6:59 PM UTC (31ce312)">Diff</a>