### PR TITLE
Add MLDeviceType npu

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -960,7 +960,7 @@ The <dfn>device type</dfn> indicates the kind of device used for the context. It
 <dt>"<dfn enum-value>gpu</dfn>"</dt>
 <dd>Provides the broadest range of achievable performance across graphics hardware platforms from consumer devices to professional workstations.</dd>
 <dt>"<dfn enum-value>npu</dfn>"</dt>
-<dd>Provides narrower functionality on dedicated machine learning devices which can perform between CPU and GPU, favoring other factors over raw performance like lower power usage for longer battery life or lower latency for results. The backend implementation may fall back to other devices for certain operators and parts of the graph.</dd>
+<dd>Provides narrower functionality on dedicated machine learning devices which perform between CPU and GPU, favoring other factors over raw performance like lower power usage for longer battery life or lower latency for results. The backend implementation may fall back to other devices for certain operators and parts of the graph.</dd>
 </dl>
 
 The <dfn>power preference</dfn> indicates preference as related to power consumption. It is one of the following:

--- a/index.bs
+++ b/index.bs
@@ -898,7 +898,7 @@ When the {{MLContext/[[contextType]]}} is set to [=context type/default=] with t
 </details>
 
 ### {{MLContext/compute()}}  ### {#api-mlcontext-compute}
-Asynchronously carries out the computational workload of a compiled graph {{MLGraph}} on a separate timeline, either on a worker thread for the CPU execution, or on a GPU timeline for the submission of GPU workload on the command queue. The asynchronous nature of this call avoids blocking the calling thread while the computation for result is ongoing. This method of execution requires an {{MLContext}} created with {{MLContextOptions}}. Otherwise, it [=exception/throws=] an "{{OperationError}}" {{DOMException}}.
+Asynchronously carries out the computational workload of a compiled graph {{MLGraph}} on a separate timeline, either on a worker thread for the CPU execution, or on a GPU/NPU timeline for submitting a workload onto the command queue. The asynchronous nature of this call avoids blocking the calling thread while the computation for result is ongoing. This method of execution requires an {{MLContext}} created with {{MLContextOptions}}. Otherwise, it [=exception/throws=] an "{{OperationError}}" {{DOMException}}.
 
 <div class="note">
 In accordance with the [=ArrayBufferView/write|Web IDL warning=], to prevent the calling thread from modifying the input and output resources while the computation is ongoing, this method [=MLNamedArrayBufferViews/transfer|transfers=] the input and output {{MLNamedArrayBufferViews}} to new views that share the same backing memory allocations. The transferred views are returned to the caller via the promise fulfillment with the computation result written into the backing memory of the output views.

--- a/index.bs
+++ b/index.bs
@@ -960,7 +960,7 @@ The <dfn>device type</dfn> indicates the kind of device used for the context. It
 <dt>"<dfn enum-value>gpu</dfn>"</dt>
 <dd>Provides the broadest range of achievable performance across graphics hardware platforms from consumer devices to professional workstations.</dd>
 <dt>"<dfn enum-value>npu</dfn>"</dt>
-<dd>Provides narrower functionality on dedicated machine learning devices which can have performance in between CPU and GPU, favoring other factors over raw performance like lower power usage for longer battery life or lower latency for results.</dd>
+<dd>Provides narrower functionality on dedicated machine learning devices which can perform between CPU and GPU, favoring other factors over raw performance like lower power usage for longer battery life or lower latency for results.</dd>
 </dl>
 
 The <dfn>power preference</dfn> indicates preference as related to power consumption. It is one of the following:

--- a/index.bs
+++ b/index.bs
@@ -960,7 +960,7 @@ The <dfn>device type</dfn> indicates the kind of device used for the context. It
 <dt>"<dfn enum-value>gpu</dfn>"</dt>
 <dd>Provides the broadest range of achievable performance across graphics hardware platforms from consumer devices to professional workstations.</dd>
 <dt>"<dfn enum-value>npu</dfn>"</dt>
-<dd>Provides narrower functionality on dedicated machine learning devices which can perform between CPU and GPU, favoring other factors over raw performance like lower power usage for longer battery life or lower latency for results.</dd>
+<dd>Provides narrower functionality on dedicated machine learning devices which can perform between CPU and GPU, favoring other factors over raw performance like lower power usage for longer battery life or lower latency for results. The backend implementation may fall back to other devices for certain operators and parts of the graph.</dd>
 </dl>
 
 The <dfn>power preference</dfn> indicates preference as related to power consumption. It is one of the following:

--- a/index.bs
+++ b/index.bs
@@ -672,7 +672,7 @@ Unlike WebGPU, this API does not intrinsically support custom shader authoring; 
 
 The WebGPU API identifies <a href="https://gpuweb.github.io/gpuweb/#privacy-machine-artifacts">machine-specific artifacts</a> as a privacy consideration. Similarly, the WebNN API's compute unit scheduling may under certain circumstances introduce a fingerprint. However, similarly to WebGPU, such fingerprints are identical across most or all of the devices of each vendor, mitigating the concern. Furthermore, software implementations can be used to further eliminate such artifacts.
 
-The WebNN API defines two developer-settable preferences to help inform [[#programming-model-device-selection]] and allow the implementation to better select the most appropriate underlying execution device for the workload. [=Device type=] normatively indicates the kind of device and is either {{MLDeviceType/"cpu"}} or {{MLDeviceType/"gpu"}}. If this type cannot be satisfied, an "{{OperationError}}" {{DOMException}} is thrown, thus this type can in some cases add two bits of entropy to the fingerprint. [=Power preference=] indicates preference as related to the power consumption and is considered a hint only and as such does not increase entropy of the fingerprint.
+The WebNN API defines two developer-settable preferences to help inform [[#programming-model-device-selection]] and allow the implementation to better select the most appropriate underlying execution device for the workload. [=Device type=] normatively indicates the kind of device is one of: {{MLDeviceType/"cpu"}}, {{MLDeviceType/"gpu"}}, {{MLDeviceType/"npu"}}. If this type cannot be satisfied, an "{{OperationError}}" {{DOMException}} is thrown, and thus this type can in some cases add two bits of entropy to the fingerprint. [=Power preference=] indicates preference as related to the power consumption and is considered a hint only and as such does not increase entropy of the fingerprint.
 
 If a future version of this specification introduces support for new a  [=device type=] that can only support a subset of {{MLOperandDataType}}s, that may introduce a new fingerprint.
 
@@ -782,7 +782,8 @@ WorkerNavigator includes NavigatorML;
 <script type=idl>
 enum MLDeviceType {
   "cpu",
-  "gpu"
+  "gpu",
+  "npu"
 };
 
 enum MLPowerPreference {
@@ -958,6 +959,8 @@ The <dfn>device type</dfn> indicates the kind of device used for the context. It
 <dd>Provides the broadest compatibility and usability across all client devices with varying degrees of performance.</dd>
 <dt>"<dfn enum-value>gpu</dfn>"</dt>
 <dd>Provides the broadest range of achievable performance across graphics hardware platforms from consumer devices to professional workstations.</dd>
+<dt>"<dfn enum-value>npu</dfn>"</dt>
+<dd>Provides narrower functionality on dedicated machine learning devices which can have performance in between CPU and GPU, favoring other factors over raw performance like lower power usage for longer battery life or lower latency for results.</dd>
 </dl>
 
 The <dfn>power preference</dfn> indicates preference as related to power consumption. It is one of the following:

--- a/index.bs
+++ b/index.bs
@@ -726,14 +726,17 @@ interface ML {
 
 ### {{MLContextOptions}} ### {#api-mlcontextoptions}
 
+Issue(623): MLContextOptions is under active development, and the design is expected to change, informed by further implementation experience and new use cases from the wider web community. The Working Group is considering additional API controls to allow the definition of a fallback device, multiple devices in a preferred order, or an exclusion of a specific device. Other considerations under discussion include error handling, ultimate
+fallback, and quantized operators. Feedback is welcome on any of these design considerations from web developers, library authors, OS and hardware vendors, and other stakeholders via GitHub:
+
 The <dfn dfn-for=MLContextOptions dfn-type=dict-member>deviceType</dfn> option is an <dfn dfn-type=enum>MLDeviceType</dfn> and indicates the application's preference for the kind of device used for the context. It is one of the following:
 <dl dfn-for="MLDeviceType">
 <dt>"<dfn enum-value>cpu</dfn>"</dt>
 <dd>Provides the broadest compatibility and usability across all client devices with varying degrees of performance.</dd>
 <dt>"<dfn enum-value>gpu</dfn>"</dt>
-<dd>Provides the broadest range of achievable performance across graphics hardware platforms from consumer devices to professional workstations.</dd>
+<dd>Provides the broadest range of achievable performance across graphics hardware platforms from consumer devices to professional workstations. The backend implementation may fall back to other devices for certain operators and parts of the graph.</dd>
 <dt>"<dfn enum-value>npu</dfn>"</dt>
-<dd>Provides narrower functionality on dedicated machine learning devices which perform between CPU and GPU, favoring other factors over raw performance like lower power usage for longer battery life or lower latency for results. The backend implementation may fall back to other devices for certain operators and parts of the graph.</dd>
+<dd>Provides power efficiency for sustained workloads across hardware platforms with purpose-built accelerators. The backend implementation may fall back to other devices for certain operators and parts of the graph.</dd>
 </dl>
 
 The <dfn dfn-for=MLContextOptions dfn-type=dict-member>powerPreference</dfn> option is an <dfn dfn-type=enum>MLPowerPreference</dfn> and indicates the application's preference as related to power consumption. It is one of the following:

--- a/index.bs
+++ b/index.bs
@@ -726,8 +726,7 @@ interface ML {
 
 ### {{MLContextOptions}} ### {#api-mlcontextoptions}
 
-Issue(623): MLContextOptions is under active development, and the design is expected to change, informed by further implementation experience and new use cases from the wider web community. The Working Group is considering additional API controls to allow the definition of a fallback device, multiple devices in a preferred order, or an exclusion of a specific device. Other considerations under discussion include error handling, ultimate
-fallback, and quantized operators. Feedback is welcome on any of these design considerations from web developers, library authors, OS and hardware vendors, and other stakeholders via GitHub:
+Issue(623): MLContextOptions is under active development, and the design is expected to change, informed by further implementation experience and new use cases from the wider web community. The Working Group is considering additional API controls to allow the definition of a fallback device, multiple devices in a preferred order, or an exclusion of a specific device. Other considerations under discussion include error handling, ultimate fallback, and quantized operators. Feedback is welcome on any of these design considerations from web developers, library authors, OS and hardware vendors, and other stakeholders via GitHub:
 
 The <dfn dfn-for=MLContextOptions dfn-type=dict-member>deviceType</dfn> option is an <dfn dfn-type=enum>MLDeviceType</dfn> and indicates the application's preference for the kind of device used for the context. It is one of the following:
 <dl dfn-for="MLDeviceType">

--- a/index.bs
+++ b/index.bs
@@ -615,6 +615,8 @@ The WebGPU API identifies <a href="https://gpuweb.github.io/gpuweb/#privacy-mach
 
 The WebNN API defines two developer-settable preferences to help inform [[#programming-model-device-selection]] and allow the implementation to better select the most appropriate underlying execution device for the workload. An {{MLDeviceType}} normatively indicates the kind of device and is one of: {{MLDeviceType/"cpu"}}, {{MLDeviceType/"gpu"}}, {{MLDeviceType/"npu"}}. If this type cannot be satisfied, an "{{OperationError}}" {{DOMException}} is thrown, thus this type can in some cases add two bits of entropy to the fingerprint. An {{MLPowerPreference}} indicates preference as related to the power consumption and is considered a hint only and as such does not increase entropy of the fingerprint.
 
+Issue(623): {{MLContextOptions}} is under active development, and the design is expected to change, informed by further implementation experience and new use cases from the wider web community.
+
 If a future version of this specification introduces support for a new {{MLDeviceType}} that can only support a subset of {{MLOperandDataType}}s, that may introduce a new fingerprint.
 
 In general, implementers of this API are expected to apply <a href="https://gpuweb.github.io/gpuweb/#privacy-considerations">WebGPU Privacy Considerations</a> to their implementations where applicable.
@@ -726,16 +728,16 @@ interface ML {
 
 ### {{MLContextOptions}} ### {#api-mlcontextoptions}
 
-Issue(623): MLContextOptions is under active development, and the design is expected to change, informed by further implementation experience and new use cases from the wider web community. The Working Group is considering additional API controls to allow the definition of a fallback device, multiple devices in a preferred order, or an exclusion of a specific device. Other considerations under discussion include error handling, ultimate fallback, and quantized operators. Feedback is welcome on any of these design considerations from web developers, library authors, OS and hardware vendors, and other stakeholders via GitHub:
+Issue(623): {{MLContextOptions}} is under active development, and the design is expected to change, informed by further implementation experience and new use cases from the wider web community. The Working Group is considering additional API controls to allow the definition of a fallback device, multiple devices in a preferred order, or an exclusion of a specific device. Other considerations under discussion include error handling, ultimate fallback, and quantized operators. Feedback is welcome on any of these design considerations from web developers, library authors, OS and hardware vendors, and other stakeholders via GitHub:
 
 The <dfn dfn-for=MLContextOptions dfn-type=dict-member>deviceType</dfn> option is an <dfn dfn-type=enum>MLDeviceType</dfn> and indicates the application's preference for the kind of device used for the context. It is one of the following:
 <dl dfn-for="MLDeviceType">
 <dt>"<dfn enum-value>cpu</dfn>"</dt>
 <dd>Provides the broadest compatibility and usability across all client devices with varying degrees of performance.</dd>
 <dt>"<dfn enum-value>gpu</dfn>"</dt>
-<dd>Provides the broadest range of achievable performance across graphics hardware platforms from consumer devices to professional workstations. The backend implementation may fall back to other devices for certain operators and parts of the graph.</dd>
+<dd>Provides the broadest range of achievable performance across graphics hardware platforms from consumer devices to professional workstations. The underlying platform implementation may fall back to other devices for certain operators and parts of the graph.</dd>
 <dt>"<dfn enum-value>npu</dfn>"</dt>
-<dd>Provides power efficiency for sustained workloads across hardware platforms with purpose-built accelerators. The backend implementation may fall back to other devices for certain operators and parts of the graph.</dd>
+<dd>Provides power efficiency for sustained workloads across hardware platforms with purpose-built accelerators. The underlying platform implementation may fall back to other devices for certain operators and parts of the graph.</dd>
 </dl>
 
 The <dfn dfn-for=MLContextOptions dfn-type=dict-member>powerPreference</dfn> option is an <dfn dfn-type=enum>MLPowerPreference</dfn> and indicates the application's preference as related to power consumption. It is one of the following:


### PR DESCRIPTION
This change only adds the `MLDeviceType` *enum* (currently [implemented in Chromium-based browsers](https://chromium-review.googlesource.com/c/chromium/src/+/5330647) for early testing) and not yet quantize/dequantize operators, as those are valuable but technically orthogonal given they are *also* useful for GPU and given the enum alone is still useful for non-quantized models using float16 weights.

Of the 4 proposals from https://github.com/webmachinelearning/webnn/issues/623, we're starting with the simplest \#‌1 (simple enum with system-decided fallback), and if additional experience warrants more complexity, we'll re-evaluate the other options later.

Wording recommendations for device fallback are welcome. Neural processing units are novel compared with more generic compute devices like CPU's/GPU's, given their limited operator support and inability to execute the *entire* graph at once.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fdwr/webnn/pull/696.html" title="Last updated on Jun 17, 2024, 9:09 PM UTC (3b83466)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/696/c00560f...fdwr:3b83466.html" title="Last updated on Jun 17, 2024, 9:09 PM UTC (3b83466)">Diff</a>