### PR TITLE
Remove MLActivations definitely not usable with recurrent ops

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2755,6 +2755,7 @@ Compute the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)#G
 <script type=idl>
 partial interface MLGraphBuilder {
   MLOperand gelu(MLOperand input);
+  MLActivation gelu();
 };
 </script>
 
@@ -2796,6 +2797,23 @@ partial interface MLGraphBuilder {
         1. Set |operator|'s [=operator/input=] to |input|.
         1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
+</details>
+
+#### {{MLGraphBuilder/gelu()}} #### {#api-mlgraphbuilder-gelu}
+<div>
+    **Arguments:**
+        - None.
+
+    **Returns:**
+        - an {{MLActivation}}. The activation function representing the gelu operation.
+</div>
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLGraphBuilder id=gelu-noargs>gelu()</dfn> method steps are:
+  </summary>
+    1. Let |op| be the result of [=creating an MLActivation=] given [=this=] and "gelu".
+    1. Return |op|.
 </details>
 
 ### gemm ### {#api-mlgraphbuilder-gemm}

--- a/index.bs
+++ b/index.bs
@@ -640,7 +640,7 @@ The {{MLGraphBuilder}} interface serves as a builder (factory) to construct a [=
 
 In WebNN, a [=computational graph=] is composed of <dfn>operators</dfn> which act on data, and are the nodes of the graph. {{MLOperand}}s are a representation of data that flows within the computational graph, and are the edges of the graph. {{MLOperand}}s include a [=computational graph=]'s <dfn for="computational graph">input</dfn> values for inference, <dfn for="computational graph">constants</dfn> (including trained weights) used for inference, intermediate values (often referred to as activations) computed during inference, as well as the output values of inference. An [=operator=]'s <dfn for=operator>input</dfn> is one or more {{MLOperand}}s. An [=operator=]'s <dfn for=operator>output</dfn> is one or more {{MLOperand}}s. [=Operators=] have operator-specific parameters that control their behavior, which can include zero or more <dfn for=operator lt="activation|activation function">activation functions</dfn>, which are {{MLActivation}}s.
 
-A key part of the {{MLGraphBuilder}} interface are methods such as {{MLGraphBuilder/gemm()}} and {{MLGraphBuilder/softmax(axis)|softmax()}} which create an [=operator=] which represents the actual operation to perform on the input data when the computation is run, and return a new {{MLOperand}} or {{MLActivation}} holding the operator. Methods that create an {{MLOperand}} connect any [=operator/inputs=] and [=operator/activations=] to the operator. Each method invocation returns a distinct new value, without changing the value of any other {{MLOperand}}.
+A key part of the {{MLGraphBuilder}} interface are methods such as {{MLGraphBuilder/gemm()}} and {{MLGraphBuilder/softmax()}} which create an [=operator=] which represents the actual operation to perform on the input data when the computation is run, and return a new {{MLOperand}} or {{MLActivation}} holding the operator. Methods that create an {{MLOperand}} connect any [=operator/inputs=] and [=operator/activations=] to the operator. Each method invocation returns a distinct new value, without changing the value of any other {{MLOperand}}.
 
 At inference time, every {{MLOperand}} will be bound to a tensor (the actual data), which are essentially multidimensional arrays. The representation of the tensors is implementation dependent, but it typically includes the array data stored in some buffer (memory) and some metadata describing the array data (such as its shape).
 
@@ -1603,7 +1603,6 @@ dictionary MLClampOptions {
 
 partial interface MLGraphBuilder {
   MLOperand clamp(MLOperand input, optional MLClampOptions options = {});
-  MLActivation clamp(optional MLClampOptions options = {});
 };
 </script>
 
@@ -1672,23 +1671,6 @@ partial interface MLGraphBuilder {
         1. Set |operator|'s [=operator/input=] to |input|.
         1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
-</details>
-
-#### {{MLGraphBuilder/clamp(options)}} #### {#api-mlgraphbuilder-clamp-options}
-<div>
-    **Arguments:**
-        - *options*: an optional {{MLClampOptions}}. The optional parameters of the operation.
-    **Returns:**
-        - an {{MLActivation}}. The operator representing the clamp operation.
-</div>
-
-<details open algorithm>
-  <summary>
-    The <dfn method for=MLGraphBuilder>clamp(|options|)</dfn> method steps are:
-  </summary>
-    1. If [=checking clamp options=] given |options| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. Let |op| be the result of [=creating an MLActivation=] given [=this=], "clamp" and |options|.
-    1. Return |op|.
 </details>
 
 ### concat ### {#api-mlgraphbuilder-concat}
@@ -2781,7 +2763,6 @@ Compute the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)#G
 <script type=idl>
 partial interface MLGraphBuilder {
   MLOperand gelu(MLOperand input);
-  MLActivation gelu();
 };
 </script>
 
@@ -2823,23 +2804,6 @@ partial interface MLGraphBuilder {
         1. Set |operator|'s [=operator/input=] to |input|.
         1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
-</details>
-
-#### {{MLGraphBuilder/gelu()}} #### {#api-mlgraphbuilder-gelu}
-<div>
-    **Arguments:**
-        - None.
-
-    **Returns:**
-        - an {{MLActivation}}. The activation function representing the gelu operation.
-</div>
-
-<details open algorithm>
-  <summary>
-    The <dfn method for=MLGraphBuilder id=gelu-noargs>gelu()</dfn> method steps are:
-  </summary>
-    1. Let |op| be the result of [=creating an MLActivation=] given [=this=] and "gelu".
-    1. Return |op|.
 </details>
 
 ### gemm ### {#api-mlgraphbuilder-gemm}
@@ -5334,7 +5298,6 @@ the N-D input tensor along the given axis.
 <script type=idl>
 partial interface MLGraphBuilder {
   MLOperand softmax(MLOperand input, unsigned long axis);
-  MLActivation softmax(unsigned long axis);
 };
 </script>
 
@@ -5380,26 +5343,6 @@ partial interface MLGraphBuilder {
         1. Set |operator|'s [=operator/input=] to |input|.
         1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
-</details>
-
-#### {{MLGraphBuilder/softmax(axis)}} #### {#api-mlgraphbuilder-softmax-axis}
-<div>
-    **Arguments:**
-        - None.
-
-    **Returns:**
-        - an {{MLActivation}}. The activation function representing the softmax operation.
-</div>
-
-<details open algorithm>
-  <summary>
-    The <dfn method for=MLGraphBuilder>softmax(|axis|)</dfn> method steps are:
-  </summary>
-    1. Let |validationSteps| given {{MLOperandDescriptor}} |descriptor| be these steps:
-        1. If |axis| is greater than or equal to |descriptor|.{{MLOperandDescriptor/dimensions}}'s [=list/size=], then return false;
-        1. Otherwise, return true.
-    1. Let |op| be the result of [=creating an MLActivation=] given [=this=], "softmax", «[ "axis" → |axis| ]», and |validationSteps|.
-    1. Return |op|.
 </details>
 
 ### softplus ### {#api-mlgraphbuilder-softplus-method}

--- a/index.bs
+++ b/index.bs
@@ -640,7 +640,7 @@ The {{MLGraphBuilder}} interface serves as a builder (factory) to construct a [=
 
 In WebNN, a [=computational graph=] is composed of <dfn>operators</dfn> which act on data, and are the nodes of the graph. {{MLOperand}}s are a representation of data that flows within the computational graph, and are the edges of the graph. {{MLOperand}}s include a [=computational graph=]'s <dfn for="computational graph">input</dfn> values for inference, <dfn for="computational graph">constants</dfn> (including trained weights) used for inference, intermediate values (often referred to as activations) computed during inference, as well as the output values of inference. An [=operator=]'s <dfn for=operator>input</dfn> is one or more {{MLOperand}}s. An [=operator=]'s <dfn for=operator>output</dfn> is one or more {{MLOperand}}s. [=Operators=] have operator-specific parameters that control their behavior, which can include zero or more <dfn for=operator lt="activation|activation function">activation functions</dfn>, which are {{MLActivation}}s.
 
-A key part of the {{MLGraphBuilder}} interface are methods such as {{MLGraphBuilder/gemm()}} and {{MLGraphBuilder/softmax()}} which create an [=operator=] which represents the actual operation to perform on the input data when the computation is run, and return a new {{MLOperand}} or {{MLActivation}} holding the operator. Methods that create an {{MLOperand}} connect any [=operator/inputs=] and [=operator/activations=] to the operator. Each method invocation returns a distinct new value, without changing the value of any other {{MLOperand}}.
+A key part of the {{MLGraphBuilder}} interface are methods such as {{MLGraphBuilder/gemm()}} and {{MLGraphBuilder/relu()}} which create an [=operator=] which represents the actual operation to perform on the input data when the computation is run, and return a new {{MLOperand}} or {{MLActivation}} holding the operator. Methods that create an {{MLOperand}} connect any [=operator/inputs=] and [=operator/activations=] to the operator. Each method invocation returns a distinct new value, without changing the value of any other {{MLOperand}}.
 
 At inference time, every {{MLOperand}} will be bound to a tensor (the actual data), which are essentially multidimensional arrays. The representation of the tensors is implementation dependent, but it typically includes the array data stored in some buffer (memory) and some metadata describing the array data (such as its shape).
 
@@ -1641,14 +1641,6 @@ partial interface MLGraphBuilder {
 </details>
 </div>
 
-<details open algorithm>
-  <summary>
-    To <dfn>check clamp options</dfn> given {{MLClampOptions}} |options|, run the following steps:
-  </summary>
-    1. If |options|.{{MLClampOptions/minValue}} is greater than |options|.{{MLClampOptions/maxValue}}, then return false.
-    1. Return true.
-</details>
-
 #### {{MLGraphBuilder/clamp(input, options)}} #### {#api-mlgraphbuilder-clamp-operand-options}
 <div>
     **Arguments:**
@@ -1663,7 +1655,7 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>clamp(|input|, |options|)</dfn> method steps are:
   </summary>
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If [=checking clamp options=] given |options| returns false, then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLClampOptions/minValue}} is greater than |options|.{{MLClampOptions/maxValue}}, then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Let |operator| be an [=operator=] for the "clamp" operation, given |options|.{{MLClampOptions/minValue}} and |options|.{{MLClampOptions/maxValue}}.


### PR DESCRIPTION
Follow-up to #664, without going so far as #689

Prior to #664, an `MLActivation` may be used for either op fusion or with recurrent operators (`lstm` and `gru`). Now it's only the latter, and some operators which may be created as an `MLActivation` no longer make sense to be passed as activations:
- `clamp`
- ~~`gelu`~~ (no longer being removed after feedback from reviewers)
- `softmax`

Note that this PR is not a _replacement_ for #689. That issue still stands on its own. Until we reach consensus on that issue, we should remove the `MLActivation`s which were clearly targeted at the op fusion use case.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/a-sully/webnn/pull/703.html" title="Last updated on Jun 7, 2024, 4:29 PM UTC (e948f7e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/703/4eda710...a-sully:e948f7e.html" title="Last updated on Jun 7, 2024, 4:29 PM UTC (e948f7e)">Diff</a>