### PR TITLE
Link fix: Link to "is empty" not "empty" when an adjective is intended

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1367,7 +1367,7 @@ Build a composed graph up to a given output operand into a computational graph a
     1. Let |operators| be a new empty [=/set=].
     1. Let |inputs| be a new empty [=/set=].
     1. Let |queue| be a new [=queue=] containing |outputs|'s [=map/values=].
-    1. While |queue| [=queue/is empty|is not empty=]:
+    1. While |queue| [=queue/is not empty=]:
         1. [=queue/Dequeue=] |operand| from |queue|.
         1. [=set/Append=] |operand| to |operands|.
         1. [=set/Append=] |operand|.{{MLOperand/[[operator]]}} to |operators|.

--- a/index.bs
+++ b/index.bs
@@ -1367,7 +1367,7 @@ Build a composed graph up to a given output operand into a computational graph a
     1. Let |operators| be a new empty [=/set=].
     1. Let |inputs| be a new empty [=/set=].
     1. Let |queue| be a new [=queue=] containing |outputs|'s [=map/values=].
-    1. While |queue| is not [=queue/empty=]:
+    1. While |queue| [=queue/is empty|is not empty=]:
         1. [=queue/Dequeue=] |operand| from |queue|.
         1. [=set/Append=] |operand| to |operands|.
         1. [=set/Append=] |operand|.{{MLOperand/[[operator]]}} to |operators|.

--- a/tools/lint.mjs
+++ b/tools/lint.mjs
@@ -273,4 +273,9 @@ for (const match of source.matchAll(/^ *\d+\. .*$/mg)) {
   }
 }
 
+// Avoid incorrect links to list/empty.
+for (const match of source.matchAll(/is( not)? \[=(list\/|stack\/|queue\/|)empty=\]/g)) {
+  error(`Link to 'is empty' (noun) not 'empty' (verb): ${format(match)}`);
+}
+
 globalThis.process.exit(exitCode);

--- a/tools/lint.mjs
+++ b/tools/lint.mjs
@@ -275,7 +275,7 @@ for (const match of source.matchAll(/^ *\d+\. .*$/mg)) {
 
 // Avoid incorrect links to list/empty.
 for (const match of source.matchAll(/is( not)? \[=(list\/|stack\/|queue\/|)empty=\]/g)) {
-  error(`Link to 'is empty' (noun) not 'empty' (verb): ${format(match)}`);
+  error(`Link to 'is empty' (adjective) not 'empty' (verb): ${format(match)}`);
 }
 
 globalThis.process.exit(exitCode);


### PR DESCRIPTION
The Infra term "list/empty" is a verb (to empty); link to "list/is empty" when that's what is intended.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/708.html" title="Last updated on Jun 14, 2024, 9:31 PM UTC (5afa97c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/708/c00560f...inexorabletash:5afa97c.html" title="Last updated on Jun 14, 2024, 9:31 PM UTC (5afa97c)">Diff</a>