### PR TITLE
Remove unnecessary subsections, make order consistent

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1623,6 +1623,7 @@ partial interface MLGraphBuilder {
 };
 </script>
 
+{{MLClampOptions}} has the following members:
 <dl dfn-type=dict-member dfn-for=MLClampOptions>
     : <dfn>minValue</dfn>
     :: The minimum value of the range. When it is not specified, the clamping is not performed on the lower limit of the range.
@@ -1630,6 +1631,29 @@ partial interface MLGraphBuilder {
     : <dfn>maxValue</dfn>
     :: The maximum value of the range. When it is not specified, the clamping is not performed on the upper limit of the range.
 </dl>
+
+<div>
+    **Arguments:**
+        - *input*: an {{MLOperand}}. The input tensor.
+        - *options*: an optional {{MLClampOptions}}. The optional parameters of the operation.
+    **Returns:**
+        - an {{MLOperand}}. The output tensor of the same shape as *operand*.
+</div>
+
+<details open algorithm>
+  <summary>
+    The <dfn method for=MLGraphBuilder>clamp(|input|, |options|)</dfn> method steps are:
+  </summary>
+    1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
+    1. If |options|.{{MLClampOptions/minValue}} is greater than |options|.{{MLClampOptions/maxValue}}, then [=exception/throw=] a {{TypeError}}.
+    1. *Make graph connections:*
+        1. Let |output| be the result of [=copying an MLOperand=] given |input|.
+        1. Let |operator| be an [=operator=] for the "clamp" operation, given |options|.{{MLClampOptions/minValue}} and |options|.{{MLClampOptions/maxValue}}.
+        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
+        1. Set |operator|'s [=operator/input=] to |input|.
+        1. Set |operator|'s [=operator/output=] to |output|.
+    1. Return |output|.
+</details>
 
 <div class="note">
 <details open>
@@ -1660,30 +1684,6 @@ partial interface MLGraphBuilder {
   </pre>
 </details>
 </div>
-
-#### {{MLGraphBuilder/clamp(input, options)}} #### {#api-mlgraphbuilder-clamp-operand-options}
-<div>
-    **Arguments:**
-        - *input*: an {{MLOperand}}. The input tensor.
-        - *options*: an optional {{MLClampOptions}}. The optional parameters of the operation.
-    **Returns:**
-        - an {{MLOperand}}. The output tensor of the same shape as *operand*.
-</div>
-
-<details open algorithm>
-  <summary>
-    The <dfn method for=MLGraphBuilder>clamp(|input|, |options|)</dfn> method steps are:
-  </summary>
-    1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |options|.{{MLClampOptions/minValue}} is greater than |options|.{{MLClampOptions/maxValue}}, then [=exception/throw=] a {{TypeError}}.
-    1. *Make graph connections:*
-        1. Let |output| be the result of [=copying an MLOperand=] given |input|.
-        1. Let |operator| be an [=operator=] for the "clamp" operation, given |options|.{{MLClampOptions/minValue}} and |options|.{{MLClampOptions/maxValue}}.
-        1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
-        1. Set |operator|'s [=operator/input=] to |input|.
-        1. Set |operator|'s [=operator/output=] to |output|.
-    1. Return |output|.
-</details>
 
 ### concat ### {#api-mlgraphbuilder-concat}
 Concatenates the input tensors along a given axis.
@@ -5407,28 +5407,6 @@ partial interface MLGraphBuilder {
 };
 </script>
 
-<div class="note">
-<details open>
-  <summary>
-    The behavior of this operation can be [EMULATED]
-  </summary>
-  <pre highlight="js">
-    function softmax(builder, input, axis) {
-      // This sample deploys a well-known implementation trick [1] to compute the
-      // exponentials of the distances to the max value, instead of the exponentials
-      // of the input values itself, in order to increase the numerical stability of
-      // the result.
-      // [1]: https://cs231n.github.io/linear-classify/#softmax
-      const maxX = builder.reduceMax(input, {axes: [axis], keepDimensions: true});
-      const expX = builder.exp(builder.sub(input, maxX));
-      return builder.div(
-        expX, builder.reduceSum(expX, {axes: [axis], keepDimensions: true}));
-    }
-  </pre>
-</details>
-</div>
-
-#### {{MLGraphBuilder/softmax(input, axis)}} #### {#api-mlgraphbuilder-softmax-input-axis}
 <div>
     **Arguments:**
         - *input*: an {{MLOperand}}. The input N-D tensor.
@@ -5453,6 +5431,28 @@ partial interface MLGraphBuilder {
         1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
 </details>
+
+<div class="note">
+<details open>
+  <summary>
+    The behavior of this operation can be [EMULATED]
+  </summary>
+  <pre highlight="js">
+    function softmax(builder, input, axis) {
+      // This sample deploys a well-known implementation trick [1] to compute the
+      // exponentials of the distances to the max value, instead of the exponentials
+      // of the input values itself, in order to increase the numerical stability of
+      // the result.
+      // [1]: https://cs231n.github.io/linear-classify/#softmax
+      const maxX = builder.reduceMax(input, {axes: [axis], keepDimensions: true});
+      const expX = builder.exp(builder.sub(input, maxX));
+      return builder.div(
+        expX, builder.reduceSum(expX, {axes: [axis], keepDimensions: true}));
+    }
+  </pre>
+</details>
+</div>
+
 
 ### softplus ### {#api-mlgraphbuilder-softplus-method}
 Compute the <a href="https://en.wikipedia.org/wiki/Rectifier_(neural_networks)#Softplus">softplus function</a> of the input tensor. The calculation follows the expression `ln(1 + exp(x))`.

--- a/index.bs
+++ b/index.bs
@@ -2550,25 +2550,6 @@ partial interface MLGraphBuilder {
 </dl>
 
 
-<div class="note">
-  <details open>
-    <summary>
-    The behavior of this operation can be [EMULATED]
-    </summary>
-    <pre highlight="js">
-    function elu(builder, input, options) {
-      return builder.add(
-        builder.max(builder.constant(input.dataType(), 0), input),
-        builder.mul(
-          builder.constant(input.dataType(), options.alpha),
-          builder.sub(
-            builder.exp(builder.min(builder.constant(input.dataType(), 0), input)),
-            builder.constant(input.dataType(), 1))));
-    }
-    </pre>
-  </details>
-</div>
-
 #### {{MLGraphBuilder/elu(input, options)}} #### {#api-mlgraphbuilder-elu-input-options}
 <div>
     **Arguments:**
@@ -2593,6 +2574,25 @@ partial interface MLGraphBuilder {
         1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
 </details>
+
+<div class="note">
+  <details open>
+    <summary>
+    The behavior of this operation can be [EMULATED]
+    </summary>
+    <pre highlight="js">
+    function elu(builder, input, options) {
+      return builder.add(
+        builder.max(builder.constant(input.dataType(), 0), input),
+        builder.mul(
+          builder.constant(input.dataType(), options.alpha),
+          builder.sub(
+            builder.exp(builder.min(builder.constant(input.dataType(), 0), input)),
+            builder.constant(input.dataType(), 1))));
+    }
+    </pre>
+  </details>
+</div>
 
 #### {{MLGraphBuilder/elu(options)}} #### {#api-mlgraphbuilder-elu-options}
 <div>
@@ -2784,24 +2784,6 @@ partial interface MLGraphBuilder {
 };
 </script>
 
-<div class="note">
-  <details open>
-    <summary>
-    The behavior of this operation can be [EMULATED]
-    </summary>
-    <pre highlight="js">
-    function gelu(builder, input) {
-      return builder.mul(
-        builder.mul(input, builder.constant(input.dataType(), 0.5)),
-        builder.add(
-          builder.constant(input.dataType(), 1),
-          builder.erf(builder.div(
-            input, builder.sqrt(builder.constant(input.dataType(), 2))))));
-    }
-    </pre>
-  </details>
-</div>
-
 #### {{MLGraphBuilder/gelu(input)}} #### {#api-mlgraphbuilder-gelu-input}
 <div>
     **Arguments:**
@@ -2825,6 +2807,24 @@ partial interface MLGraphBuilder {
         1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
 </details>
+
+<div class="note">
+  <details open>
+    <summary>
+    The behavior of this operation can be [EMULATED]
+    </summary>
+    <pre highlight="js">
+    function gelu(builder, input) {
+      return builder.mul(
+        builder.mul(input, builder.constant(input.dataType(), 0.5)),
+        builder.add(
+          builder.constant(input.dataType(), 1),
+          builder.erf(builder.div(
+            input, builder.sqrt(builder.constant(input.dataType(), 2))))));
+    }
+    </pre>
+  </details>
+</div>
 
 #### {{MLGraphBuilder/gelu()}} #### {#api-mlgraphbuilder-gelu}
 <div>
@@ -3414,25 +3414,6 @@ partial interface MLGraphBuilder {
 };
 </script>
 
-<div class="note">
-  <details open>
-    <summary>
-    The behavior of this operation can be [EMULATED]
-    </summary>
-    <pre highlight="js">
-    function hardSigmoid(builder, input, options) {
-      return builder.max(
-        builder.min(
-          builder.add(
-            builder.mul(builder.constant(input.dataType(), options.alpha), input),
-            builder.constant(input.dataType(), options.beta)),
-          builder.constant(input.dataType(), 1)),
-        builder.constant(input.dataType(), 0));
-    }
-    </pre>
-  </details>
-</div>
-
 {{MLHardSigmoidOptions}} has the following members:
 <dl dfn-type=dict-member dfn-for=MLHardSigmoidOptions>
     : <dfn>alpha</dfn>
@@ -3468,6 +3449,25 @@ partial interface MLGraphBuilder {
     1. Return |output|.
 </details>
 
+<div class="note">
+  <details open>
+    <summary>
+    The behavior of this operation can be [EMULATED]
+    </summary>
+    <pre highlight="js">
+    function hardSigmoid(builder, input, options) {
+      return builder.max(
+        builder.min(
+          builder.add(
+            builder.mul(builder.constant(input.dataType(), options.alpha), input),
+            builder.constant(input.dataType(), options.beta)),
+          builder.constant(input.dataType(), 1)),
+        builder.constant(input.dataType(), 0));
+    }
+    </pre>
+  </details>
+</div>
+
 #### {{MLGraphBuilder/hardSigmoid(options)}} #### {#api-mlgraphbuilder-hardsigmoid-options}
 <div>
     **Arguments:**
@@ -3494,27 +3494,6 @@ partial interface MLGraphBuilder {
 };
 </script>
 
-<div class="note">
-<details open>
-  <summary>
-    The behavior of this operation can be [EMULATED]
-  </summary>
-  <pre highlight="js">
-    function hardSwish(builder, input, options) {
-      return builder.div(
-        builder.mul(
-          input,
-          builder.max(
-            builder.constant(input.dataType(), 0),
-            builder.min(
-              builder.constant(input.dataType(), 6),
-              builder.add(input, builder.constant(input.dataType(), 3))))),
-        builder.constant(input.dataType(), 6));
-    }
-  </pre>
-</details>
-</div>
-
 #### {{MLGraphBuilder/hardSwish(input)}} #### {#api-mlgraphbuilder-hardswish-input}
 <div>
     **Arguments:**
@@ -3538,6 +3517,27 @@ partial interface MLGraphBuilder {
         1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
 </details>
+
+<div class="note">
+<details open>
+  <summary>
+    The behavior of this operation can be [EMULATED]
+  </summary>
+  <pre highlight="js">
+    function hardSwish(builder, input, options) {
+      return builder.div(
+        builder.mul(
+          input,
+          builder.max(
+            builder.constant(input.dataType(), 0),
+            builder.min(
+              builder.constant(input.dataType(), 6),
+              builder.add(input, builder.constant(input.dataType(), 3))))),
+        builder.constant(input.dataType(), 6));
+    }
+  </pre>
+</details>
+</div>
 
 #### {{MLGraphBuilder/hardSwish()}} #### {#api-mlgraphbuilder-hardswish}
 <div>
@@ -3779,23 +3779,6 @@ partial interface MLGraphBuilder {
 };
 </script>
 
-<div class="note">
-  <details open>
-    <summary>
-    The behavior of this operation can be [EMULATED]
-    </summary>
-    <pre highlight="js">
-    function leakyRelu(builder, input, options) {
-      return builder.add(
-        builder.max(builder.constant(input.dataType(), 0), input),
-        builder.mul(
-          builder.constant(input.dataType(), options.alpha),
-          builder.min(builder.constant(input.dataType(), 0), input)));
-    }
-    </pre>
-  </details>
-</div>
-
 {{MLLeakyReluOptions}} has the following members:
 <dl dfn-type=dict-member dfn-for=MLLeakyReluOptions>
     : <dfn>alpha</dfn>
@@ -3828,6 +3811,23 @@ partial interface MLGraphBuilder {
     1. Return |output|.
 </details>
 
+<div class="note">
+  <details open>
+    <summary>
+    The behavior of this operation can be [EMULATED]
+    </summary>
+    <pre highlight="js">
+    function leakyRelu(builder, input, options) {
+      return builder.add(
+        builder.max(builder.constant(input.dataType(), 0), input),
+        builder.mul(
+          builder.constant(input.dataType(), options.alpha),
+          builder.min(builder.constant(input.dataType(), 0), input)));
+    }
+    </pre>
+  </details>
+</div>
+
 #### {{MLGraphBuilder/leakyRelu(options)}} #### {#api-mlgraphbuilder-leaky-relu-options}
 <div>
     **Arguments:**
@@ -3859,21 +3859,6 @@ partial interface MLGraphBuilder {
   MLActivation linear(optional MLLinearOptions options = {});
 };
 </script>
-
-<div class="note">
-  <details open>
-    <summary>
-    The behavior of this operation can be [EMULATED]
-    </summary>
-    <pre highlight="js">
-    function linear(builder, input, options) {
-      return builder.add(
-        builder.mul(input, builder.constant(input.dataType(), options.alpha)),
-        builder.constant(input.dataType(), options.beta));
-    }
-    </pre>
-  </details>
-</div>
 
 {{MLLinearOptions}} has the following members:
 <dl dfn-type=dict-member dfn-for=MLLinearOptions>
@@ -3909,6 +3894,21 @@ partial interface MLGraphBuilder {
         1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
 </details>
+
+<div class="note">
+  <details open>
+    <summary>
+    The behavior of this operation can be [EMULATED]
+    </summary>
+    <pre highlight="js">
+    function linear(builder, input, options) {
+      return builder.add(
+        builder.mul(input, builder.constant(input.dataType(), options.alpha)),
+        builder.constant(input.dataType(), options.beta));
+    }
+    </pre>
+  </details>
+</div>
 
 #### {{MLGraphBuilder/linear(options)}} #### {#api-mlgraphbuilder-linear-options}
 <div>
@@ -5102,19 +5102,6 @@ partial interface MLGraphBuilder {
 };
 </script>
 
-<div class="note">
-  <details open>
-    <summary>
-    The behavior of this operation can be [EMULATED]
-    </summary>
-    <pre highlight="js">
-    function relu(builder, input) {
-      return builder.max(builder.constant(input.dataType(), 0), input);
-    }
-    </pre>
-  </details>
-</div>
-
 #### {{MLGraphBuilder/relu(input)}} #### {#api-mlgraphbuilder-relu-input}
 <div>
     **Arguments:**
@@ -5138,6 +5125,19 @@ partial interface MLGraphBuilder {
         1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
 </details>
+
+<div class="note">
+  <details open>
+    <summary>
+    The behavior of this operation can be [EMULATED]
+    </summary>
+    <pre highlight="js">
+    function relu(builder, input) {
+      return builder.max(builder.constant(input.dataType(), 0), input);
+    }
+    </pre>
+  </details>
+</div>
 
 #### {{MLGraphBuilder/relu()}} #### {#api-mlgraphbuilder-relu}
 <div>
@@ -5300,22 +5300,6 @@ partial interface MLGraphBuilder {
 };
 </script>
 
-<div class="note">
-  <details open>
-    <summary>
-    The behavior of this operation can be [EMULATED]
-    </summary>
-    <pre highlight="js">
-    function sigmoid(builder, input) {
-      return builder.div(
-        builder.constant(input.dataType(), 1),
-        builder.add(
-          builder.exp(builder.neg(input)), builder.constant(input.dataType(), 1)));
-    }
-    </pre>
-  </details>
-</div>
-
 #### {{MLGraphBuilder/sigmoid(input)}} #### {#api-mlgraphbuilder-sigmoid-input}
 <div>
     **Arguments:**
@@ -5339,6 +5323,22 @@ partial interface MLGraphBuilder {
         1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
 </details>
+
+<div class="note">
+  <details open>
+    <summary>
+    The behavior of this operation can be [EMULATED]
+    </summary>
+    <pre highlight="js">
+    function sigmoid(builder, input) {
+      return builder.div(
+        builder.constant(input.dataType(), 1),
+        builder.add(
+          builder.exp(builder.neg(input)), builder.constant(input.dataType(), 1)));
+    }
+    </pre>
+  </details>
+</div>
 
 #### {{MLGraphBuilder/sigmoid()}} #### {#api-mlgraphbuilder-sigmoid}
 <div>
@@ -5463,20 +5463,6 @@ partial interface MLGraphBuilder {
 };
 </script>
 
-<div class="note">
-  <details open>
-    <summary>
-    The behavior of this operation can be [EMULATED]
-    </summary>
-    <pre highlight="js">
-    function softplus(builder, input) {
-      return builder.log(
-        builder.add(builder.exp(input), builder.constant(input.dataType(), 1)));
-    }
-    </pre>
-  </details>
-</div>
-
 #### {{MLGraphBuilder/softplus(input)}} #### {#api-mlgraphbuilder-softplus-input}
 <div>
     **Arguments:**
@@ -5500,6 +5486,20 @@ partial interface MLGraphBuilder {
         1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
 </details>
+
+<div class="note">
+  <details open>
+    <summary>
+    The behavior of this operation can be [EMULATED]
+    </summary>
+    <pre highlight="js">
+    function softplus(builder, input) {
+      return builder.log(
+        builder.add(builder.exp(input), builder.constant(input.dataType(), 1)));
+    }
+    </pre>
+  </details>
+</div>
 
 #### {{MLGraphBuilder/softplus()}} #### {#api-mlgraphbuilder-softplus}
 <div>
@@ -5681,25 +5681,6 @@ partial interface MLGraphBuilder {
 };
 </script>
 
-<div class="note">
-  <details open>
-    <summary>
-    The behavior of this operation can be [EMULATED]
-    </summary>
-    <pre highlight="js">
-    function tanh(builder, input) {
-      return builder.div(
-        builder.sub(
-          builder.exp(builder.mul(builder.constant(input.dataType(), 2), input)),
-          builder.constant(input.dataType(), 1)),
-        builder.add(
-          builder.exp(builder.mul(builder.constant(input.dataType(), 2), input)),
-          builder.constant(input.dataType(), 1)));
-    }
-    </pre>
-  </details>
-</div>
-
 #### {{MLGraphBuilder/tanh(input)}} #### {#api-mlgraphbuilder-tanh-input}
 <div>
     **Arguments:**
@@ -5723,6 +5704,25 @@ partial interface MLGraphBuilder {
         1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
 </details>
+
+<div class="note">
+  <details open>
+    <summary>
+    The behavior of this operation can be [EMULATED]
+    </summary>
+    <pre highlight="js">
+    function tanh(builder, input) {
+      return builder.div(
+        builder.sub(
+          builder.exp(builder.mul(builder.constant(input.dataType(), 2), input)),
+          builder.constant(input.dataType(), 1)),
+        builder.add(
+          builder.exp(builder.mul(builder.constant(input.dataType(), 2), input)),
+          builder.constant(input.dataType(), 1)));
+    }
+    </pre>
+  </details>
+</div>
 
 #### {{MLGraphBuilder/tanh()}} #### {#api-mlgraphbuilder-tanh}
 <div>


### PR DESCRIPTION
With two MLActivation-vending overloads removed, two subsection headers could be removed.

But that pointed out where ordering for the "emulation" section in overloaded methods was inconsistent. So tidy that up too.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/711.html" title="Last updated on Jun 25, 2024, 11:37 PM UTC (32a6437)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/711/588a728...inexorabletash:32a6437.html" title="Last updated on Jun 25, 2024, 11:37 PM UTC (32a6437)">Diff</a>