### PR TITLE
Fix #713: DOMString to USVString

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -801,7 +801,7 @@ The <dfn dfn-for=MLContextOptions dfn-type=dict-member>powerPreference</dfn> opt
 The {{MLContext}} interface represents a global state of neural network compute workload and execution processes. Each {{MLContext}} object has associated [=context type=], {{MLDeviceType}} and {{MLPowerPreference}}.
 
 <script type=idl>
-typedef record<DOMString, ArrayBufferView> MLNamedArrayBufferViews;
+typedef record<USVString, ArrayBufferView> MLNamedArrayBufferViews;
 
 dictionary MLComputeResult {
   MLNamedArrayBufferViews inputs;
@@ -997,11 +997,11 @@ interface MLGraph {};
     ::
         The context of type {{MLContext}} associated with this {{MLGraph}}.
 
-    : <dfn>\[[inputDescriptors]]</dfn> of type [=record=]&lt;{{DOMString}}, {{MLOperandDescriptor}}&gt;
+    : <dfn>\[[inputDescriptors]]</dfn> of type [=record=]&lt;{{USVString}}, {{MLOperandDescriptor}}&gt;
     ::
         Maps the name of an input {{MLOperand}} to its {{MLOperandDescriptor}} for all input {{MLOperand}}s of this {{MLGraph}}.
 
-    : <dfn>\[[outputDescriptors]]</dfn> of type [=record=]&lt;{{DOMString}}, {{MLOperandDescriptor}}&gt;
+    : <dfn>\[[outputDescriptors]]</dfn> of type [=record=]&lt;{{USVString}}, {{MLOperandDescriptor}}&gt;
     ::
         Maps the name of an output {{MLOperand}} to its {{MLOperandDescriptor}} for all output {{MLOperand}}s of this {{MLGraph}}.
 
@@ -1233,7 +1233,7 @@ To <dfn for="MLGraphBuilder">validate activation</dfn> given {{MLGraphBuilder}} 
 The {{MLGraphBuilder}} interface defines a set of operations as identified by the [[#usecases]] that can be composed into a computational graph. It also represents the intermediate state of a graph building session.
 
 <script type=idl>
-typedef record<DOMString, MLOperand> MLNamedOperands;
+typedef record<USVString, MLOperand> MLNamedOperands;
 
 [SecureContext, Exposed=(Window, DedicatedWorker)]
 interface MLGraphBuilder {
@@ -1241,7 +1241,7 @@ interface MLGraphBuilder {
   constructor(MLContext context);
 
   // Create an operand for a graph input.
-  MLOperand input(DOMString name, MLOperandDescriptor descriptor);
+  MLOperand input(USVString name, MLOperandDescriptor descriptor);
 
   // Create an operand for a graph constant.
   MLOperand constant(MLOperandDescriptor descriptor, ArrayBufferView bufferView);
@@ -2262,7 +2262,7 @@ partial interface MLGraphBuilder {
 </details>
 
 ### Element-wise logical operations ### {#api-mlgraphbuilder-logical}
-Compare input tensors element-wise and return a uint8 tensor of values 0 or 1 for the comparisons. For single-operand operations, return the logical results of the operation. 
+Compare input tensors element-wise and return a uint8 tensor of values 0 or 1 for the comparisons. For single-operand operations, return the logical results of the operation.
 
 The input tensor will be broadcasted according to [[!numpy-broadcasting-rule]]. The [=MLOperand/rank=] of the output tensor is the maximum
 [=MLOperand/rank=] of the input tensors.
@@ -3686,7 +3686,7 @@ partial interface MLGraphBuilder {
         The N-D tensor of the bias values whose shape is determined by the |axes| member in that each value in |axes| indicates the dimension of the input tensor with bias values. For example, for an |axes| values of [1,2,3], the shape of this tensor is the list of the corresponding sizes of the input dimension 1, 2 and 3. When this member is not present, the bias value is assumed to be 0.
 
     : <dfn>axes</dfn>
-    ::  
+    ::
         The indices to the input dimensions to reduce. When this member is not present, it is treated as if all dimensions except the first were given (e.g. for a 4-D input tensor, axes = [1,2,3]). That is, the reduction for the mean and variance values are calculated across all the input features for each independent batch. If empty, no dimensions are reduced.
     : <dfn>epsilon</dfn>
     ::


### PR DESCRIPTION
Fixes #713 : trivial replacement of DOMString (names) with USVString.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zolkis/webnn/pull/715.html" title="Last updated on Jul 2, 2024, 7:32 AM UTC (5a614bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/715/08719e1...zolkis:5a614bd.html" title="Last updated on Jul 2, 2024, 7:32 AM UTC (5a614bd)">Diff</a>