### PR TITLE
Rename where()'s parameters "input" and "other" to "trueValue" and "falseValue"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5942,42 +5942,42 @@ partial interface MLGraphBuilder {
 </div>
 
 ### where ### {#api-mlgraphbuilder-where}
-Select the values from the input or the other tensor depending on the corresponding {{boolean}} values of the condition tensor. The condition tensor is often the output of one of the element-wise logical operations.
+Select the values from the trueValue or the falseValue tensor depending on the corresponding {{boolean}} values of the condition tensor. The condition tensor is often the output of one of the element-wise logical operations.
 
 The input tensors will be broadcasted according to [[!numpy-broadcasting-rule]] to the final output shape. The [=MLOperand/rank=] of the output tensor is the maximum [=MLOperand/rank=] of the input tensors.
 For each dimension of the output tensor, its size is the maximum size along that dimension of the input tensors.
 
 <script type=idl>
 partial interface MLGraphBuilder {
-  MLOperand where(MLOperand condition, MLOperand input, MLOperand other);
+  MLOperand where(MLOperand condition, MLOperand trueValue, MLOperand falseValue);
 };
 </script>
 
 <div>
     **Arguments:**
         - *condition*: an {{MLOperand}}. The condition tensor.
-        - *input*: an {{MLOperand}}. The input tensor from which the value is selected when the condition of the corresponding element is set to true.
-        - *other*: an {{MLOperand}}. The other tensor from which the value is selected when the condition of the corresponding element is set to false.
+        - *trueValue*: an {{MLOperand}}. The trueValue tensor from which the value is selected when the condition of the corresponding element is set to true.
+        - *falseValue*: an {{MLOperand}}. The falseValue tensor from which the value is selected when the condition of the corresponding element is set to false.
 
-    **Returns:** an {{MLOperand}}. The output tensor that contains the values selected element-wise from either the input or the other tensor.
+    **Returns:** an {{MLOperand}}. The output tensor that contains the values selected element-wise from either the trueValue or the falseValue tensor.
 </div>
 
 <details open algorithm>
   <summary>
-    The <dfn method for=MLGraphBuilder>where(|condition|, |input|, |other|)</dfn> method steps are:
+    The <dfn method for=MLGraphBuilder>where(|condition|, |trueValue|, |falseValue|)</dfn> method steps are:
   </summary>
     1. If |condition|'s [=MLOperand/dataType=] is not equal to {{MLOperandDataType/"uint8"}}, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not equal to |other|'s [=MLOperand/dataType=], then [=exception/throw=] a {{TypeError}}.
+    1. If |trueValue|'s [=MLOperand/dataType=] is not equal to |falseValue|'s [=MLOperand/dataType=], then [=exception/throw=] a {{TypeError}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
-    1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |input|'s [=MLOperand/dataType=].
-    1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to the result of [=bidirectionally broadcasting the shapes=] |input|'s [=MLOperand/shape=] and |other|'s [=MLOperand/shape=].
+    1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |trueValue|'s [=MLOperand/dataType=].
+    1. Set |descriptor|.{{MLOperandDescriptor/dimensions}} to the result of [=bidirectionally broadcasting the shapes=] |trueValue|'s [=MLOperand/shape=] and |falseValue|'s [=MLOperand/shape=].
         1. If that returns failure, then [=exception/throw=] a {{TypeError}}.
     1. If |condition| is not [=bidirectionally broadcastable=] to |descriptor|.{{MLOperandDescriptor/dimensions}}, then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |descriptor|.
-        1. Let |operator| be an [=operator=] for the "where" operation, given |condition|, |input| and |other|.
+        1. Let |operator| be an [=operator=] for the "where" operation, given |condition|, |trueValue| and |falseValue|.
         1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
-        1. Set |operator|'s [=operator/inputs=] to |condition|, |input| and |other|.
+        1. Set |operator|'s [=operator/inputs=] to |condition|, |trueValue| and |falseValue|.
         1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
 </details>
@@ -5988,12 +5988,12 @@ partial interface MLGraphBuilder {
     The behavior of this operation can be [EMULATED]
     </summary>
     <pre highlight="js">
-    function where(builder, condition, input, other) {
+    function where(builder, condition, trueValue, falseValue) {
       const c = builder.clamp(condition, {'minValue': 0, 'maxValue': 1});
       builder.add(
-        builder.mul(input, builder.cast(c, input.dataType())),
+        builder.mul(trueValue, builder.cast(c, trueValue.dataType())),
         builder.mul(
-          other, builder.cast(builder.logicalNot(c), other.dataType())));
+          falseValue, builder.cast(builder.logicalNot(c), falseValue.dataType())));
     }
     </pre>
   </details>


### PR DESCRIPTION
(This PR was raised by @philloooo in [CL-5679616 review](https://chromium-review.googlesource.com/c/chromium/src/+/5679616/6/third_party/blink/renderer/modules/ml/ml_context.idl#43))

@wacky6 suggested using `trueValue` `falseValue` to indicate the values are picked based on true/false of `condition` in [CL-5039655 review](https://chromium-review.googlesource.com/c/chromium/src/+/5039655/2/third_party/blink/renderer/modules/ml/webnn/ml_graph_builder.idl#218). Also the current Chromium implementation uses names `trueValue` and `falseValue`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shiyi9801/webnn/pull/719.html" title="Last updated on Jul 9, 2024, 5:43 AM UTC (a8e5d89)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/719/3a916f2...shiyi9801:a8e5d89.html" title="Last updated on Jul 9, 2024, 5:43 AM UTC (a8e5d89)">Diff</a>