### PR TITLE
Remove argmin/max selectLastIndex parameter

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1422,13 +1422,12 @@ Build a composed graph up to a given output operand into a computational graph a
 NOTE: Specifying an [=computational graph/input=] operand or [=computational graph/constant=] operand as a graph {{MLGraphBuilder/build(outputs)/outputs|output}} results in an error, as this is usually an incorrect usage of the API. Callers can work around this by introducing an {{MLGraphBuilder/identity()}} operator.
 
 ### argMin/argMax operations ### {#api-mlgraphbuilder-argminmax}
-Return the index location of the minimum or maxmium values of all the input values along the axes.
+Return the index location of the minimum or maxmium values of all the input values along the axes. In case of ties, the identity of the return value is implementation dependent.
 
 <script type=idl>
 dictionary MLArgMinMaxOptions {
   sequence<[EnforceRange] unsigned long> axes;
   boolean keepDimensions = false;
-  boolean selectLastIndex = false;
 };
 
 partial interface MLGraphBuilder {
@@ -1446,10 +1445,6 @@ partial interface MLGraphBuilder {
     : <dfn>keepDimensions</dfn>
     ::
         If true, retains reduced dimensions with [=list/size=] 1.
-
-    : <dfn>selectLastIndex</dfn>
-    ::
-        If true, select the last index instead of the first found along the axes.
 </dl>
 
 <div>


### PR DESCRIPTION
Fixes #652 
This removes the `selectLastIndex` parameter from argMin and argMax, given that the CoreML backend has no guarantee of return value in case of ties.

@fdwr  please take a look :)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/philloooo/webnn/pull/722.html" title="Last updated on Jul 11, 2024, 6:17 PM UTC (1f06e41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/722/fe96a78...philloooo:1f06e41.html" title="Last updated on Jul 11, 2024, 6:17 PM UTC (1f06e41)">Diff</a>