### PR TITLE
Define error handling of MLNamedArrayBufferViews transfer algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -910,7 +910,7 @@ Issue(351): Move the above algorithm into [[WEBIDL]].
     1. Let |transferredViews| be a new {{MLNamedArrayBufferViews}}.
     1. [=map/For each=] |name| → |view| of |views|:
         1. Let |transferredBuffer| be the result of [=ArrayBuffer/transfer|transferring=] |view|'s [=BufferSource/underlying buffer=].
-        1. Assert: The above step never throws an exception.
+        1. [=Assert=]: The above step never throws an exception.
         1. Let |constructor| be the appropriate [=view constructor=] for the type of {{ArrayBufferView}} |view| from |realm|.
         1. Let |elementsNumber| be the result of |view|'s [=BufferSource/byte length=] / |view|'s [=element size=].
         1. Let |transferredView| be [$Construct$](|constructor|, |transferredBuffer|, |view|.\[[ByteOffset]], |elementsNumber|).

--- a/index.bs
+++ b/index.bs
@@ -886,11 +886,31 @@ When the {{MLContext/[[contextType]]}} is set to [=context type/default=] with t
 
 <details open algorithm>
   <summary>
+    A [=buffer source type=] instance |bufferSource| is
+    <dfn for="BufferSource">detachable</dfn> if the following steps return true:
+  </summary>
+    1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
+        |bufferSource| to a JavaScript value.
+    1.  If |jsArrayBuffer| has a \[[ViewedArrayBuffer]] internal slot, then set |jsArrayBuffer| to
+        |jsArrayBuffer|.\[[ViewedArrayBuffer]].
+    1.  If [$IsSharedArrayBuffer$](|jsArrayBuffer|) is true, then return false.
+    1.  If [$IsDetachedBuffer$](|jsArrayBuffer|) is true, return false.
+    1.  If |jsArrayBuffer|.\[[ArrayBufferDetachKey]] is not undefined, return false.
+    1.  Return true.
+</details>
+
+Issue(351): Move the above algorithm into [[WEBIDL]].
+
+<details open algorithm>
+  <summary>
     To <dfn for="MLNamedArrayBufferViews">transfer</dfn> an {{MLNamedArrayBufferViews}} |views| with [=realm=] |realm|:
   </summary>
+    1. [=map/For each=] |name| → |view| of |views|:
+        1. If |view| is not [=BufferSource/detachable=], then throw a {{TypeError}}.
     1. Let |transferredViews| be a new {{MLNamedArrayBufferViews}}.
     1. [=map/For each=] |name| → |view| of |views|:
         1. Let |transferredBuffer| be the result of [=ArrayBuffer/transfer|transferring=] |view|'s [=BufferSource/underlying buffer=].
+        1. Assert: The above step never throws an exception.
         1. Let |constructor| be the appropriate [=view constructor=] for the type of {{ArrayBufferView}} |view| from |realm|.
         1. Let |elementsNumber| be the result of |view|'s [=BufferSource/byte length=] / |view|'s [=element size=].
         1. Let |transferredView| be [$Construct$](|constructor|, |transferredBuffer|, |view|.\[[ByteOffset]], |elementsNumber|).


### PR DESCRIPTION
* Throw if the passed buffer source is detached.
* Explicitly rethrow if transfering throws.

The callers already handle failure.

Fixes #351


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/723.html" title="Last updated on Jul 12, 2024, 6:08 PM UTC (6edc5e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/723/af67a72...inexorabletash:6edc5e8.html" title="Last updated on Jul 12, 2024, 6:08 PM UTC (6edc5e8)">Diff</a>