### PR TITLE
Clarify the cast() op behavior between different data types

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1709,9 +1709,11 @@ Casting between {{MLOperandDataType}}s is specified for some cases and [=impleme
     <th class=split>
       <span class=top-right>Target type</span>
       <span class=bottom-left>Input type</span>
+    </th>
     <th>
       {{MLOperandDataType/"float32"}},
       {{MLOperandDataType/"float16"}}
+    </th>
     <th>
       {{MLOperandDataType/"int32"}},
       {{MLOperandDataType/"uint32"}},
@@ -1719,16 +1721,24 @@ Casting between {{MLOperandDataType}}s is specified for some cases and [=impleme
       {{MLOperandDataType/"uint64"}},
       {{MLOperandDataType/"int8"}},
       {{MLOperandDataType/"uint8"}}
+    </th>
+  </tr>
   <tr>
     <th>
       {{MLOperandDataType/"float32"}},
       {{MLOperandDataType/"float16"}}
+    </th>
     <td>
-      <p>If in range, nearest representable value.
-      <p>If out of range, +/-Infinity.
+      If in range, nearest representable value.
+
+      If out of range, +/-Infinity.
+    </td>
     <td>
-      <p>If in range, truncated.
-      <p>If out of range, [=implementation-defined=].
+      If in range, truncated.
+
+      If out of range, [=implementation-defined=].
+    </td>
+  </tr>
   <tr>
     <th>
       {{MLOperandDataType/"int32"}},
@@ -1737,12 +1747,18 @@ Casting between {{MLOperandDataType}}s is specified for some cases and [=impleme
       {{MLOperandDataType/"uint64"}},
       {{MLOperandDataType/"int8"}},
       {{MLOperandDataType/"uint8"}}
+    </th>
     <td>
-      <p>If in range, nearest representable value.
-      <p>If out of range, +/-Infinity.
+      If in range, nearest representable value.
+
+      If out of range, +/-Infinity.
+    </td>
     <td>
-      <p>If in range, same value.
-      <p>If out of range, lowest N bits reinterpreted as target type, assuming two's complement for signed types.
+      If in range, same value.
+
+      If out of range, lowest N bits reinterpreted as target type, assuming two's complement for signed types.
+    </td>
+  </tr>
 </table>
 
 NOTE: For example, casting -1 from {{MLOperandDataType/"int8"}} to {{MLOperandDataType/"uint8"}} is specified to yield 255. But casting -1 from {{MLOperandDataType/"float32"}} to {{MLOperandDataType/"uint8"}} is [=implementation-defined=].

--- a/index.bs
+++ b/index.bs
@@ -200,9 +200,48 @@ th {
 
 th, td {
   border-bottom: 1px solid black;
-  border-collapse: collapse;
+  border-collapse: collapse; /* BUG: This property only applies to TABLE. */
   padding-left: 5px;
   padding-right: 5px;
+}
+
+/*
+ * Grid table format.
+ */
+table.grid {
+  border-collapse: collapse;
+  table-layout: fixed;
+  width: 100%;
+}
+
+table.grid td, table.grid th {
+  border: 1px solid black;
+}
+
+table.grid th {
+  text-align: center;
+}
+
+/* For a table header cell that is split diagonally */
+th.split {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' preserveAspectRatio='none' viewBox='0 0 1 1'><line x1='0' y1='0' x2='1' y2='1' stroke='black' vector-effect='non-scaling-stroke'/></svg>");
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
+  position: relative;
+}
+
+th.split .bottom-left {
+    display: block;
+    position: absolute;
+    bottom: 1px;
+    left: 5px;
+}
+
+th.split .top-right {
+    display: block;
+    position: absolute;
+    top: 1px;
+    right: 5px;
 }
 
 /*
@@ -1648,6 +1687,55 @@ partial interface MLGraphBuilder {
 
     **Returns:** an {{MLOperand}}. The N-D tensor of the same shape as *input* with each element casted to the target data type.
 </div>
+
+
+Casting between {{MLOperandDataType}}s is specified for some cases and [=implementation-defined=] in other cases, according to the following table:
+
+<table class=grid>
+  <caption>
+    Behavior of the {{MLGraphBuilder/cast()}} operation given the {{MLGraphBuilder/cast(input, type)/input}}'s [=MLOperand/dataType=] (rows) and target {{MLGraphBuilder/cast(input, type)/type}} (columns).
+  </caption>
+  <tr>
+    <th class=split>
+      <span class=top-right>Target type</span>
+      <span class=bottom-left>Input type</span>
+    <th>
+      {{MLOperandDataType/"float32"}},
+      {{MLOperandDataType/"float16"}}
+    <th>
+      {{MLOperandDataType/"int32"}},
+      {{MLOperandDataType/"uint32"}},
+      {{MLOperandDataType/"int64"}},
+      {{MLOperandDataType/"uint64"}},
+      {{MLOperandDataType/"int8"}},
+      {{MLOperandDataType/"uint8"}}
+  <tr>
+    <th>
+      {{MLOperandDataType/"float32"}},
+      {{MLOperandDataType/"float16"}}
+    <td>
+      <p>If in range, nearest representable value.
+      <p>If out of range, +/-Infinity.
+    <td>
+      <p>If in range, truncated.
+      <p>If out of range, [=implementation-defined=].
+  <tr>
+    <th>
+      {{MLOperandDataType/"int32"}},
+      {{MLOperandDataType/"uint32"}},
+      {{MLOperandDataType/"int64"}},
+      {{MLOperandDataType/"uint64"}},
+      {{MLOperandDataType/"int8"}},
+      {{MLOperandDataType/"uint8"}}
+    <td>
+      <p>If in range, nearest representable value.
+      <p>If out of range, +/-Infinity.
+    <td>
+      <p>If in range, same value.
+      <p>If out of range, lowest N bits reinterpreted as target type, assuming two's complement for signed types.
+</table>
+
+NOTE: For example, casting -1 from {{MLOperandDataType/"int8"}} to {{MLOperandDataType/"uint8"}} is specified to yield 255. But casting -1 from {{MLOperandDataType/"float32"}} to {{MLOperandDataType/"uint8"}} is [=implementation-defined=].
 
 <details open algorithm>
   <summary>


### PR DESCRIPTION
Inspired by the ONNX documentation[1], outline what inference-time casts are well-defined and which are implementation-defined for out-of-range values.

Fixes #489

1: https://onnx.ai/onnx/operators/onnx__Cast.html


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/726.html" title="Last updated on Jul 17, 2024, 4:44 PM UTC (7dc738d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/726/c9e70f6...inexorabletash:7dc738d.html" title="Last updated on Jul 17, 2024, 4:44 PM UTC (7dc738d)">Diff</a>