### PR TITLE
Lint: Improve logic for validating algorithm steps.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6066,7 +6066,7 @@ partial interface MLGraphBuilder {
     The <dfn method for=MLGraphBuilder>where(|condition|, |trueValue|, |falseValue|)</dfn> method steps are:
   </summary>
     1. If [=this=].{{MLGraphBuilder/[[hasBuilt]]}} is true, then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
-    1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |condition|, |input|, and |other| returns false, then [=exception/throw=] a {{TypeError}}.
+    1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |condition|, |trueValue|, and |falseValue| returns false, then [=exception/throw=] a {{TypeError}}.
     1. If |condition|'s [=MLOperand/dataType=] is not equal to {{MLOperandDataType/"uint8"}}, then [=exception/throw=] a {{TypeError}}.
     1. If |trueValue|'s [=MLOperand/dataType=] is not equal to |falseValue|'s [=MLOperand/dataType=], then [=exception/throw=] a {{TypeError}}.
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.

--- a/tools/lint.mjs
+++ b/tools/lint.mjs
@@ -258,18 +258,15 @@ for (const pre of root.querySelectorAll('pre.highlight:not(.idl)')) {
 }
 
 // Ensure algorithm steps end in '.' or ':'.
-for (const match of source.matchAll(/^ *\d+\. .*$/mg)) {
-  let str = match[0].trim();
+for (const p of root.querySelectorAll('.algorithm li > p')) {
+  let str = p.innerText;
 
-  // Strip asterisks from things like "1. *Make graph connections.*"
-  const match2 = str.match(/^(\d+\. )\*(.*)\*$/);
-  if (match2) {
-    str = match2[1] + match2[2];
-  }
+  // Strip "[Issue #123]" suffix.
+  str = str.replace(/\s+\[Issue #\d+\]/, '');
 
-  const match3 = str.match(/[^.:]$/);
-  if (match3) {
-    error(`Algorithm steps should end with '.' or ':': ${format(match3)}`);
+  const match = str.match(/[^.:]$/);
+  if (match) {
+    error(`Algorithm steps should end with '.' or ':': ${format(match)}`);
   }
 }
 


### PR DESCRIPTION
Previously, the test ensuring that algorithm steps end in '.' or ':' looked at the Bikeshed source. This didn't handle word wrapping. While we prefer not to word wrap, that shouldn't cause this test to fail.

Make the test analyse the DOM instead.

Also, fix some unrelated Bikeshed/lint failures introduced in f08f9f7382a5db03566205825174a3204eb90a8f


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/727.html" title="Last updated on Jul 16, 2024, 11:56 PM UTC (8ae6441)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/727/f08f9f7...inexorabletash:8ae6441.html" title="Last updated on Jul 16, 2024, 11:56 PM UTC (8ae6441)">Diff</a>