### PR TITLE
Workflow: Add steps to run tools/lint.mjs after spec is built

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -23,3 +23,21 @@ jobs:
           W3C_BUILD_OVERRIDE: |
             TR: https://www.w3.org/TR/webnn/
             status: CRD
+      - name: WebNN - Lint Bikeshed Source and Generated HTML
+        id: webnn-lint
+        shell: bash
+        env:
+          BIKESHED_SOURCE: "index.bs"
+          GENERATED_HTML: "index.bs.built.html"
+        run: |
+          echo "::group::Install Lint Tool Dependencies"
+          cd tools
+          npm install
+          cd ..
+          echo "::endgroup::"
+          echo "::group::Generate Static HTML"
+          bikeshed --die-on=warning spec $BIKESHED_SOURCE $GENERATED_HTML
+          echo "::endgroup::"
+          echo "::group::Run Lint Tool"
+          node tools/lint.mjs --verbose --bikeshed $BIKESHED_SOURCE --html $GENERATED_HTML
+          echo "::endgroup::"

--- a/tools/lint.mjs
+++ b/tools/lint.mjs
@@ -9,7 +9,11 @@
 // Note that the '.mjs' extension is necessary for Node.js to treat the file as
 // a module. There is an `--experimental-default-type=module` flag but
 // specifying that in the #! line requires trickery that confuses some editors.
-
+//
+// Options:
+//   --verbose                    Log progress.
+//   --bikeshed PATH_TO_BS_FILE   Bikeshed source path. (default: "index.bs")
+//   --html PATH_TO_HTML_FILE     Generated HTML path. (default: "index.html")
 
 'use strict';
 import fs from 'node:fs/promises';
@@ -21,14 +25,20 @@ import {parse} from 'node-html-parser';
 
 const options = {
   verbose: false,
+  bikeshed: 'index.bs',
+  html: 'index.html',
 };
 
 // First two args are interpreter and script
-globalThis.process.argv.slice(2).forEach(arg => {
+globalThis.process.argv.slice(2).forEach((arg, index, array) => {
   if (arg === '--verbose' || arg === '-v') {
     options.verbose = true;
+  } else if (arg === '--bikeshed' && array.length > index + 1) {
+    options.bikeshed = array.splice(index + 1, 1)[0];
+  } else if (arg === '--html' && array.length > index + 1) {
+    options.html = array.splice(index + 1, 1)[0];
   } else {
-    console.error(`Unknown argment: ${arg}`);
+    console.error(`Unknown or incomplete argument: ${arg}`);
     globalThis.process.exit(1);
   }
 });
@@ -43,9 +53,11 @@ function log(string) {
 // Load and parse file
 // --------------------------------------------------
 
-log('loading files...');
-const source = await fs.readFile('index.bs', 'utf8');
-let file = await fs.readFile('index.html', 'utf8');
+log(`loading Bikeshed source "${options.bikeshed}"...`);
+const source = await fs.readFile(options.bikeshed, 'utf8');
+
+log(`loading generated HTML "${options.html}"...`);
+let file = await fs.readFile(options.html, 'utf8');
 
 log('massaging HTML...');
 // node-html-parser doesn't understand that DT and DD are mutually self-closing;


### PR DESCRIPTION
Help catch errors by running our bespoke lint tool after the normal publish/deploy. Ideally, in the future this would be integrated into spec-prod to avoid some duplicate work, and made more modular and robust. But hopefully it's better than nothing!