### PR TITLE
Add outputDataType to argmin/argmax

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1517,6 +1517,7 @@ Return the index location of the minimum or maxmium values of all the input valu
 <script type=idl>
 dictionary MLArgMinMaxOptions {
   boolean keepDimensions = false;
+  MLOperandDataType outputDataType = "int32";
 };
 
 partial interface MLGraphBuilder {
@@ -1532,6 +1533,10 @@ partial interface MLGraphBuilder {
     : <dfn>keepDimensions</dfn>
     ::
         If true, retains reduced dimensions with [=list/size=] 1.
+    
+    : <dfn>outputDataType</dfn>
+    ::
+        An {{MLOperandDataType}}. The output data type.
 </dl>
 
 <div dfn-for="MLGraphBuilder/argMin(input, axis, options), MLGraphBuilder/argMax(input, axis, options)" dfn-type=argument>
@@ -1552,7 +1557,7 @@ partial interface MLGraphBuilder {
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
     1. Let |outputShape| be the result of [=MLGraphBuilder/calculating reduction output sizes=] given |input|'s [=MLOperand/shape=], « |axis| », and |options|.{{MLArgMinMaxOptions/keepDimensions}}. If that returns failure, then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| be a new {{MLOperandDescriptor}}.
-    1. Set |desc|.{{MLOperandDescriptor/dataType}} to {{MLOperandDataType/"int64"}}.
+    1. Set |desc|.{{MLOperandDescriptor/dataType}} to |options|.{{MLArgMinMaxOptions/outputDataType}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |outputShape|.
     1. *Make graph connections:*
         1. Let |operator| be an [=operator=] for the |op| operation, given |options|.

--- a/index.bs
+++ b/index.bs
@@ -1545,7 +1545,7 @@ partial interface MLGraphBuilder {
         - <dfn>axis</dfn>: The dimension to reduce. The value must be in the range [0, N-1] where N is the [=MLOperand/rank=] of the input tensor.
         - <dfn>options</dfn>: an optional {{MLArgMinMaxOptions}}. The optional parameters of the operation.
 
-    **Returns:** an {{MLOperand}}. The N-D tensor of the reduced shape. The values must be of type {{MLOperandDataType/"int64"}} in the range [0, N-1] where N is the size of the input dimension specified by axis.
+    **Returns:** an {{MLOperand}}. The N-D tensor of the reduced shape. The values must be of type |options|.{{MLArgMinMaxOptions/outputDataType}} in the range [0, N-1] where N is the size of the input dimension specified by axis.
 </div>
 
 <details open algorithm>

--- a/index.bs
+++ b/index.bs
@@ -1555,6 +1555,7 @@ partial interface MLGraphBuilder {
     1. [=Assert=]: |op| is one of "argMin", "argMax".
     1. If [=this=].{{MLGraphBuilder/[[hasBuilt]]}} is true, then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/shape=][|axis|] is greater than |options|.{{MLArgMinMaxOptions/outputDataType}}'s maximum value, [=exception/throw=] a {{TypeError}}.
     1. Let |outputShape| be the result of [=MLGraphBuilder/calculating reduction output sizes=] given |input|'s [=MLOperand/shape=], « |axis| », and |options|.{{MLArgMinMaxOptions/keepDimensions}}. If that returns failure, then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| be a new {{MLOperandDescriptor}}.
     1. Set |desc|.{{MLOperandDescriptor/dataType}} to |options|.{{MLArgMinMaxOptions/outputDataType}}.


### PR DESCRIPTION
fixes #653

Add outputDataType to `MLArgMinMaxOptions` and defaults to `int32`. Given `opSupportLimits` is not added to spec yet, no validation steps is done to `outputDataType` right now.

@fdwr @huningxin


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/philloooo/webnn/pull/730.html" title="Last updated on Jul 23, 2024, 12:06 AM UTC (26aa1fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/730/92ff390...philloooo:26aa1fd.html" title="Last updated on Jul 23, 2024, 12:06 AM UTC (26aa1fd)">Diff</a>