### PR TITLE
Reference newly landed WebIDL "transferable" definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -939,27 +939,10 @@ When the {{MLContext/[[contextType]]}} is set to [=context type/default=] with t
 
 <details open algorithm>
   <summary>
-    A [=buffer source type=] instance |bufferSource| is
-    <dfn for="BufferSource">detachable</dfn> if the following steps return true:
-  </summary>
-    1.  Let |jsArrayBuffer| be the result of [=converted to a JavaScript value|converting=]
-        |bufferSource| to a JavaScript value.
-    1.  If |jsArrayBuffer| has a \[[ViewedArrayBuffer]] internal slot, then set |jsArrayBuffer| to
-        |jsArrayBuffer|.\[[ViewedArrayBuffer]].
-    1.  If [$IsSharedArrayBuffer$](|jsArrayBuffer|) is true, then return false.
-    1.  If [$IsDetachedBuffer$](|jsArrayBuffer|) is true, return false.
-    1.  If |jsArrayBuffer|.\[[ArrayBufferDetachKey]] is not undefined, return false.
-    1.  Return true.
-</details>
-
-Issue(351): Move the above algorithm into [[WEBIDL]].
-
-<details open algorithm>
-  <summary>
     To <dfn for="MLNamedArrayBufferViews">transfer</dfn> an {{MLNamedArrayBufferViews}} |views| with [=realm=] |realm|:
   </summary>
     1. [=map/For each=] |name| → |view| of |views|:
-        1. If |view| is not [=BufferSource/detachable=], then throw a {{TypeError}}.
+        1. If |view| is not [=BufferSource/transferable=], then throw a {{TypeError}}.
     1. Let |transferredViews| be a new {{MLNamedArrayBufferViews}}.
     1. [=map/For each=] |name| → |view| of |views|:
         1. Let |transferredBuffer| be the result of [=ArrayBuffer/transfer|transferring=] |view|'s [=BufferSource/underlying buffer=].


### PR DESCRIPTION
As promised, the local algorithm "detachable" migrated to WebIDL[1], so we can drop our copy of the algorithm and reference WebIDL's version instead, which is identical except for a name change[3].

(If you're building the spec locally and run into errors, force a Bikeshed update[2] to ensure you have the latest indexes.)

1: https://github.com/whatwg/webidl/commit/d6927d59da4e1d2f9499dae1575c710ae50c3f18
2: https://speced.github.io/bikeshed/#updating-bikeshed
3: https://github.com/whatwg/webidl/pull/1419#discussion_r1681950171

Ref: #351


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/732.html" title="Last updated on Jul 19, 2024, 5:17 PM UTC (da3f620)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/732/6be80a4...inexorabletash:da3f620.html" title="Last updated on Jul 19, 2024, 5:17 PM UTC (da3f620)">Diff</a>