### PR TITLE
Editorial: Don't reference IDL boolean for values in tensors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2368,7 +2368,7 @@ partial interface MLGraphBuilder {
 </details>
 
 ### Element-wise logical operations ### {#api-mlgraphbuilder-logical}
-Compare input tensors element-wise and return a uint8 tensor of values 0 or 1 for the comparisons. For single-operand operations, return the logical results of the operation.
+Compare input tensors element-wise and return a {{MLOperandDataType/"uint8"}} tensor of values 0 (false) or 1 (true) for the comparisons. For single-operand operations, return the logical results of the operation.
 
 The input tensor will be broadcasted according to [[!numpy-broadcasting-rule]]. The [=MLOperand/rank=] of the output tensor is the maximum
 [=MLOperand/rank=] of the input tensors.
@@ -2398,7 +2398,7 @@ partial interface MLGraphBuilder {
         - *greaterOrEqual*: Compare if the values of the first input tensor is greater or equal, element-wise.
         - *lesser*: Compare if the values of the first input tensor is lesser, element-wise.
         - *lesserOrEqual*: Compare if the values of the first input tensor is lesser or equal, element-wise.
-        - *logicalNot*: Invert the values of the input tensor to values 0 or 1, element-wise. Specifically, when the input value is non-zero, invert it to a {{boolean}} value 0. Conversely, for a zero input value, invert it to a {{boolean}} value 1.
+        - *logicalNot*: Invert the values of the input tensor to values 0 or 1, element-wise. Specifically, when the input value is non-zero, invert it to 0. Conversely, for a zero input value, invert it to 1.
 </div>
 
 <div class="note">
@@ -5845,7 +5845,7 @@ partial interface MLGraphBuilder {
 </div>
 
 ### where ### {#api-mlgraphbuilder-where}
-Select the values from the trueValue or the falseValue tensor depending on the corresponding {{boolean}} values of the condition tensor. The condition tensor is often the output of one of the element-wise logical operations.
+Select the values from the trueValue or the falseValue tensor depending on the corresponding values of the condition tensor, where non-zero is true and zero is false. The condition tensor is often the output of one of the element-wise logical operations.
 
 The input tensors will be broadcasted according to [[!numpy-broadcasting-rule]] to the final output shape. The [=MLOperand/rank=] of the output tensor is the maximum [=MLOperand/rank=] of the input tensors.
 For each dimension of the output tensor, its size is the maximum size along that dimension of the input tensors.


### PR DESCRIPTION
The spec should only reference IDL types in prose when dealing with binding, e.g. in unions, and maybe internal slots. When discussing values in tensors, just be explicit and don't try to link to a definition that doesn't really apply.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/735.html" title="Last updated on Jul 22, 2024, 11:55 PM UTC (3a6f73d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/735/487a992...inexorabletash:3a6f73d.html" title="Last updated on Jul 22, 2024, 11:55 PM UTC (3a6f73d)">Diff</a>