### PR TITLE
Fixed typo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1443,7 +1443,7 @@ Build a composed graph up to a given output operand into a computational graph a
 NOTE: Specifying an [=computational graph/input=] operand or [=computational graph/constant=] operand as a graph {{MLGraphBuilder/build(outputs)/outputs|output}} results in an error, as this is usually an incorrect usage of the API. Callers can work around this by introducing an {{MLGraphBuilder/identity()}} operator.
 
 ### argMin/argMax operations ### {#api-mlgraphbuilder-argminmax}
-Return the index location of the minimum or maxmium values of all the input values along the axis. In case of ties, the identity of the return value is implementation dependent.
+Return the index location of the minimum or maximum values of all the input values along the axis. In case of ties, the identity of the return value is implementation dependent.
 
 <script type=idl>
 dictionary MLArgMinMaxOptions {


### PR DESCRIPTION
This typo issue was caught by https://chromium-review.googlesource.com/c/chromium/src/+/5668527/comment/b4a20d72_b987e05c/.

@huningxin @anssiko PTAL, thanks.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/BruceDai/webnn/pull/736.html" title="Last updated on Jul 23, 2024, 10:01 AM UTC (5c97f54)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/736/dcc423d...BruceDai:5c97f54.html" title="Last updated on Jul 23, 2024, 10:01 AM UTC (5c97f54)">Diff</a>