### PR TITLE
Update dimension valid range to signed integer

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1071,7 +1071,7 @@ dictionary MLOperandDescriptor {
 </details>
 
 <p>
-A <dfn>valid dimension</dfn> is an integer greater than zero in the range of {{unsigned long}}. Implementations may impose a smaller upper bound.
+A <dfn>valid dimension</dfn> is an integer greater than zero and in the range of {{long}}. Implementations may impose a smaller upper bound.
 </p>
 
 Issue(391): Should 0-size dimensions be supported?


### PR DESCRIPTION
fixes #734

Update `valid dimension` definition to be in the range of `long` and greater than 0.

@fdwr @huningxin


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/philloooo/webnn/pull/738.html" title="Last updated on Jul 23, 2024, 7:41 PM UTC (11c994f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/738/dbb9d1c...philloooo:11c994f.html" title="Last updated on Jul 23, 2024, 7:41 PM UTC (11c994f)">Diff</a>