### PR TITLE
Bug fix: softmax()'s axis argument should EnforceRange

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5441,7 +5441,7 @@ the N-D input tensor along the given axis.
 <script type=idl>
 partial interface MLGraphBuilder {
   MLOperand softmax(MLOperand input,
-                    unsigned long axis,
+                    [EnforceRange] unsigned long axis,
                     optional MLOperatorOptions options = {});
 };
 </script>


### PR DESCRIPTION
All input integers have [EnforceRange] applied to prevent weirdness... except softmax()'s axis argument. Already present in the Chromium prototype implementation; it looks like this argument was just missed in 6023741.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/746.html" title="Last updated on Jul 30, 2024, 8:41 PM UTC (2027157)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/746/4697a0d...inexorabletash:2027157.html" title="Last updated on Jul 30, 2024, 8:41 PM UTC (2027157)">Diff</a>