### PR TITLE
Allow arbitrary axes for resample2d

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5202,7 +5202,7 @@ partial interface MLGraphBuilder {
 </div>
 
 ### resample2d ### {#api-mlgraphbuilder-resample2d-method}
-Resample the tensor values from the source to the destination spatial dimensions according to the scaling factors.
+Resample the tensor values from the source to the destination dimensions according to the axes and scaling factors.
 <script type=idl>
 enum MLInterpolationMode {
   "nearest-neighbor",
@@ -5237,18 +5237,18 @@ partial interface MLGraphBuilder {
     : <dfn>scales</dfn>
     ::
         A list of length 2.
-        Specifies the scaling factor in each spatial dimensions of the input: *[scaleHeight, scaleWidth]*.
+        Specifies the scaling factor in each dimensions of the input in {{MLResample2dOptions/axes}} : *[scaleForFirstAxis, scaleForSecondAxis]*.
         The default value is [1.0, 1.0].
 
     : <dfn>sizes</dfn>
     ::
         A list of length 2.
-        Specifies the target sizes for each spatial dimensions of the input: *[sizeHeight, sizeWidth]*. When the target sizes are specified, the {{MLResample2dOptions/scales}} argument is ignored, since the scaling factor values are derived from the target sizes of each spatial dimension of the input.
+        Specifies the target sizes for each dimensions of the input in {{MLResample2dOptions/axes}} : *[sizeForFirstAxis, ForSecondAxis]*. When the target sizes are specified, the {{MLResample2dOptions/scales}} argument is ignored, since the scaling factor values are derived from the target sizes of the input.
 
     : <dfn>axes</dfn>
     ::
         A list of length 2.
-        Specifies the two consecutive dimensions of the input tensor to which the interpolation algorithm applies. The valid values are [0, 1], [1, 2] or [2, 3].
+        Specifies the two dimensions of the input tensor to which the interpolation algorithm applies.
         The default value is [2, 3].
 </dl>
 
@@ -5260,7 +5260,7 @@ partial interface MLGraphBuilder {
     1. Otherwise, if any of its values is not greater than 0, or if its [=list/size=] is not 2, return false.
     1. If |options|.{{MLResample2dOptions/sizes}} [=map/exists=], and if its size is not 2, or if any of its values is not greater than 0, return false.
     1. If |options|.{{MLResample2dOptions/axes}} does not [=map/exists=], set it to the [=/list=] « 2, 3 ».
-    1. Otherwise, if its value is not one of « 0, 1», « 1, 2», « 2, 3 », return false.
+    1. Otherwise, if |options|.{{MLResample2dOptions/axes}} contains duplicate values, or if any of its elements is not in [=the range=] 0 to |input|'s [=MLOperand/rank=], exclusive, then return false.
     1. Return true.
 </details>
 

--- a/index.bs
+++ b/index.bs
@@ -5254,7 +5254,7 @@ partial interface MLGraphBuilder {
 
 <details open algorithm>
   <summary>
-    To <dfn for="MLGraphBuilder">check resample options</dfn> given |options|, run the following steps:
+    To <dfn for="MLGraphBuilder">check resample options</dfn> given |options| and |input|, run the following steps:
   </summary>
     1. If |options|.{{MLResample2dOptions/scales}} does not [=map/exist=], set it to the [=/list=] « 1.0, 1.0 ».
     1. Otherwise, if any of its values is not greater than 0, or if its [=list/size=] is not 2, return false.
@@ -5286,7 +5286,7 @@ partial interface MLGraphBuilder {
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
     1. If |input|'s [=MLOperand/dataType=] is not {{MLOperandDataType/"float32"}} or {{MLOperandDataType/"float16"}}, then [=exception/throw=] a {{TypeError}}.
     1. If |input|'s [=MLOperand/rank=] is not 4, then [=exception/throw=] a {{TypeError}}.
-    1. If [=MLGraphBuilder/checking resample options=] given |options| returns false, then [=exception/throw=] a {{TypeError}}.
+    1. If [=MLGraphBuilder/checking resample options=] given |options| and |input| returns false, then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| be the result of [=MLGraphBuilder/calculating resample output sizes=] given |input| and |options|. If that returns failure, then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.

--- a/index.bs
+++ b/index.bs
@@ -5237,13 +5237,13 @@ partial interface MLGraphBuilder {
     : <dfn>scales</dfn>
     ::
         A list of length 2.
-        Specifies the scaling factor in each dimensions of the input in {{MLResample2dOptions/axes}} : *[scaleForFirstAxis, scaleForSecondAxis]*.
+        Specifies the scaling factor for each input dimension from {{MLResample2dOptions/axes}} : *[scaleForFirstAxis, scaleForSecondAxis]*.
         The default value is [1.0, 1.0].
 
     : <dfn>sizes</dfn>
     ::
         A list of length 2.
-        Specifies the target sizes for each dimensions of the input in {{MLResample2dOptions/axes}} : *[sizeForFirstAxis, ForSecondAxis]*. When the target sizes are specified, the {{MLResample2dOptions/scales}} argument is ignored, since the scaling factor values are derived from the target sizes of the input.
+        Specifies the target sizes for each input dimension from {{MLResample2dOptions/axes}} : *[sizeForFirstAxis, ForSecondAxis]*. When the target sizes are specified, the {{MLResample2dOptions/scales}} argument is ignored, since the scaling factor values are derived from the target sizes of the input.
 
     : <dfn>axes</dfn>
     ::


### PR DESCRIPTION
Fixs #624

This allow any arbitrary axes as long as they are valid dimensions for resample2d. Remove restriction on it to be the spacial dimensions.

[Chromium prototype](https://chromium-review.googlesource.com/c/chromium/src/+/5798093)

@fdwr @huningxin


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/philloooo/webnn/pull/752.html" title="Last updated on Aug 22, 2024, 5:39 PM UTC (471cc12)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/752/d7d0363...philloooo:471cc12.html" title="Last updated on Aug 22, 2024, 5:39 PM UTC (471cc12)">Diff</a>