### PR TITLE
Bugfix: Rename member `output` to `outputs` of `MLLstmCellSupportLimits`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4885,7 +4885,7 @@ dictionary MLLstmCellSupportLimits {
   MLSupportLimits bias;
   MLSupportLimits recurrentBias;
   MLSupportLimits peepholeWeight;
-  MLSupportLimits output;
+  MLSupportLimits outputs;
 };
 
 partial dictionary MLOpSupportLimits {
@@ -4947,8 +4947,8 @@ partial dictionary MLOpSupportLimits {
     :: {{MLSupportLimits}} for recurrentBias operand.
     : <dfn>peepholeWeight</dfn>
     :: {{MLSupportLimits}} for peepholeWeight operand.
-    : <dfn>output</dfn>
-    :: {{MLSupportLimits}} for output operand.
+    : <dfn>outputs</dfn>
+    :: {{MLSupportLimits}} for all the output operands.
 </dl>
 
 {{MLOpSupportLimits}} has following member for {{MLGraphBuilder/lstmCell()}}:


### PR DESCRIPTION
`MLLstmCellSupportLimits.outputs` reflects that lstmCell returns a sequence of operands.

Fix https://github.com/webmachinelearning/webnn/pull/755#discussion_r1740347722


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/757.html" title="Last updated on Sep 2, 2024, 5:42 AM UTC (9e2dfc6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/757/49eeebf...huningxin:9e2dfc6.html" title="Last updated on Sep 2, 2024, 5:42 AM UTC (9e2dfc6)">Diff</a>