### PR TITLE
Remove pool2d MLRoundingType - Simplify the operand layout support of conv2d and pooling 2d operations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4575,10 +4575,6 @@ partial interface MLGraphBuilder {
 ### Pooling operations ### {#api-mlgraphbuilder-pool2d}
 Compute a pooling operation across all the elements within the moving window over the input tensor.
 <script type=idl>
-enum MLRoundingType {
-  "floor",
-  "ceil"
-};
 
 dictionary MLPool2dOptions {
   sequence<[EnforceRange] unsigned long> windowDimensions;
@@ -4586,7 +4582,6 @@ dictionary MLPool2dOptions {
   sequence<[EnforceRange] unsigned long> strides;
   sequence<[EnforceRange] unsigned long> dilations;
   MLInputOperandLayout layout = "nchw";
-  MLRoundingType roundingType = "floor";
   sequence<[EnforceRange] unsigned long> outputSizes;
 };
 
@@ -4638,10 +4633,14 @@ partial interface MLGraphBuilder {
 
     : <dfn>outputSizes</dfn>
     ::
-        A list of length 2.
-        Specifies the sizes of the two spacial dimensions of the output tensor. When the output sizes are explicitly specified, the {{MLPool2dOptions/roundingType}} is ignored.
+        A list of length 2: *[outputHeight, outputWidth]*
+        Specifies the sizes of the two spatial dimensions of the output tensor.
 
-        If not specified, the output sizes are automatically computed.
+        The spatial dimensions of the output tensor can be calculated as follows:
+
+        *output size = ((input size - filter size + beginning padding + ending padding) / stride) + 1*
+
+        Then the caller either applies a floor or ceiling depending on whether partial window results are desired.
 </dl>
 
 <div>
@@ -4652,13 +4651,8 @@ partial interface MLGraphBuilder {
 
     **Returns:** an {{MLOperand}}. The output 4-D tensor that contains the
     result of the reduction. The logical shape is interpreted according to the
-    value of *layout*. More specifically, if the *options.roundingType* is {{MLRoundingType/"floor"}}, the spatial dimensions of the output tensor can be calculated as follow:
-
-    *output size = floor(1 + (input size - filter size + beginning padding + ending padding) / stride)*
-
-    or if *options.roundingType* is {{MLRoundingType/"ceil"}}:
-
-    *output size = ceil(1 + (input size - filter size + beginning padding + ending padding) / stride)*
+    value of *layout*, taking the batch and channel count from the input with
+    the spatial sizes from *outputSizes*.
 </div>
 
 <div class="note">
@@ -4671,7 +4665,7 @@ partial interface MLGraphBuilder {
 
 <details open algorithm>
   <summary>
-    To <dfn for=MLGraphBuilder>calculate pool2d output sizes</dfn> given {{MLInputOperandLayout}} |layout|, [=/list=] of 4 unsigned integers |inputShape|, {{MLRoundingType}} |roundingType|, [=/list=] of 2 unsigned integers |windowDimensions|, [=/list=] of 4 unsigned integers |padding|, [=/list=] of 2 unsigned integers |strides|, [=/list=] of 2 unsigned integers |dilations|, and optional [=/list=] of 2 unsigned integers |outputSizes|, perform these steps. They return a [=/list=] of 4 unsigned integers.
+    To <dfn for=MLGraphBuilder>calculate pool2d output sizes</dfn> given {{MLInputOperandLayout}} |layout|, [=/list=] of 4 unsigned integers |inputShape|, [=/list=] of 2 unsigned integers |windowDimensions|, [=/list=] of 4 unsigned integers |padding|, [=/list=] of 2 unsigned integers |strides|, [=/list=] of 2 unsigned integers |dilations|, and optional [=/list=] of 2 unsigned integers |outputSizes|, perform these steps. They return a [=/list=] of 4 unsigned integers.
   </summary>
     1. Switch on |layout|:
         <dl class=switch>
@@ -4688,24 +4682,8 @@ partial interface MLGraphBuilder {
                 1. Let |inputWidth| be |inputShape|[2].
                 1. Let |channels| be |inputShape|[3].
         </dl>
-    1. If |outputSizes| is not given, then:
-        1. Let |outputHeight| be |outputSizes|[0].
-        1. Let |outputWidth| be |outputSizes|[1].
-    1. Otherwise:
-        1. Let |outputSizes| be the result of [=MLGraphBuilder/calculating conv2d output sizes=] given |inputHeight|, |inputWidth|, |windowDimensions|[0], |windowDimensions|[1], |padding|, |strides|, and |dilations|.
-        1. Let |outputHeight| be |outputSizes|[0].
-        1. Let |outputWidth| be |outputSizes|[1].
-        1. Switch on |roundingType|:
-            <dl class=switch>
-                : {{MLRoundingType/"floor"}}
-                ::
-                    1. Set |outputWidth| to floor(|outputWidth|).
-                    1. Set |outputHeight| to floor(|outputHeight|).
-                : {{MLRoundingType/"ceil"}}
-                ::
-                    1. Set |outputWidth| to ceiling(|outputWidth|).
-                    1. Set |outputHeight| to ceiling(|outputHeight|).
-            </dl>
+    1. Let |outputHeight| be |outputSizes|[0].
+    1. Let |outputWidth| be |outputSizes|[1].
     1. Switch on |layout|:
         <dl class=switch>
             : {{MLInputOperandLayout/"nchw"}}
@@ -4737,7 +4715,7 @@ partial interface MLGraphBuilder {
     1. If |options|.{{MLPool2dOptions/dilations}}'s [=list/size=] is not 2, then [=exception/throw=] a {{TypeError}}.
     1. If any value in |options|.{{MLPool2dOptions/dilations}} is not greater than 0, then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
-    1. Let |outputShape| be the result of [=MLGraphBuilder/calculating pool2d output sizes=] given |options|.{{MLPool2dOptions/layout}}, |input|'s [=MLOperand/shape=], |options|.{{MLPool2dOptions/roundingType}}, |options|.{{MLPool2dOptions/windowDimensions}}, |options|.{{MLPool2dOptions/padding}}, |options|.{{MLPool2dOptions/strides}}, |options|.{{MLPool2dOptions/dilations}}, and |options|.{{MLPool2dOptions/outputSizes}} (if it [=map/exists=]).
+    1. Let |outputShape| be the result of [=MLGraphBuilder/calculating pool2d output sizes=] given |options|.{{MLPool2dOptions/layout}}, |input|'s [=MLOperand/shape=], |options|.{{MLPool2dOptions/windowDimensions}}, |options|.{{MLPool2dOptions/padding}}, |options|.{{MLPool2dOptions/strides}}, |options|.{{MLPool2dOptions/dilations}}, and |options|.{{MLPool2dOptions/outputSizes}} (if it [=map/exists=]).
     1. If any [=list/item=] in |outputShape| is not a [=valid dimension=], then [=exception/throw=] a {{TypeError}}.
     1. Set |desc|.{{MLOperandDescriptor/dimensions}} to |outputShape|.
     1. *Make graph connections:*


### PR DESCRIPTION
Rather than have both an output rounding field *and* spatial output dimensions, be more explicit in WebNN where the caller computes this ahead of time.

For https://github.com/webmachinelearning/webnn/issues/324