### PR TITLE
Bugfix: Fix the error of opSupportLimits for split op

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6432,7 +6432,7 @@ dictionary MLSplitSupportLimits {
 };
 
 partial dictionary MLOpSupportLimits {
-  MLSingleInputSupportLimits split;
+  MLSplitSupportLimits split;
 };
 </script>
 


### PR DESCRIPTION
Fixes #775


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/BruceDai/webnn/pull/776.html" title="Last updated on Oct 30, 2024, 12:52 AM UTC (0a64a13)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/776/9287c0b...BruceDai:0a64a13.html" title="Last updated on Oct 30, 2024, 12:52 AM UTC (0a64a13)">Diff</a>