### PR TITLE
Wording: Use newfangled multiple assignment from lists

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2172,45 +2172,21 @@ partial dictionary MLOpSupportLimits {
         1. Switch on |options|.{{MLConv2dOptions/inputLayout}}:
             <dl class=switch>
                 : {{MLInputOperandLayout/"nchw"}}
-                ::
-                    1. Let |batches| be |inputShape|[0].
-                    1. Let |inputChannels| be |inputShape|[1].
-                    1. Let |inputHeight| be |inputShape|[2].
-                    1. Let |inputWidth| be |inputShape|[3].
+                :: Let « |batches|, |inputChannels|, |inputHeight|, |inputWidth| » be |inputShape|.
                 : {{MLInputOperandLayout/"nhwc"}}
-                ::
-                    1. Let |batches| be |inputShape|[0].
-                    1. Let |inputHeight| be |inputShape|[1].
-                    1. Let |inputWidth| be |inputShape|[2].
-                    1. Let |inputChannels| be |inputShape|[3].
+                :: Let « |batches|, |inputHeight|, |inputWidth|, |inputChannels| » be |inputShape|.
             </dl>
         1. Let |filterShape| be |filter|'s [=MLOperand/shape=].
         1. Switch on |options|.{{MLConv2dOptions/filterLayout}}:
             <dl class=switch>
                 : {{MLConv2dFilterOperandLayout/"hwio"}}
-                ::
-                    1. Let |filterHeight| be |filterShape|[0].
-                    1. Let |filterWidth| be |filterShape|[1].
-                    1. Let |filterInputChannels| be |filterShape|[2].
-                    1. Let |outputChannels| be |filterShape|[3].
+                :: Let « |filterHeight|, |filterWidth|, |filterInputChannels|, |outputChannels| » be |filterShape|.
                 : {{MLConv2dFilterOperandLayout/"ohwi"}}
-                ::
-                    1. Let |outputChannels| be |filterShape|[0].
-                    1. Let |filterHeight| be |filterShape|[1].
-                    1. Let |filterWidth| be |filterShape|[2].
-                    1. Let |filterInputChannels| be |filterShape|[3].
+                :: Let « |outputChannels|, |filterHeight|, |filterWidth|, |filterInputChannels| » be |filterShape|.
                 : {{MLConv2dFilterOperandLayout/"ihwo"}}
-                ::
-                    1. Let |filterInputChannels| be |filterShape|[0].
-                    1. Let |filterHeight| be |filterShape|[1].
-                    1. Let |filterWidth| be |filterShape|[2].
-                    1. Let |outputChannels| be |filterShape|[3].
+                :: Let « |filterInputChannels|, |filterHeight|, |filterWidth|, |outputChannels| » be |filterShape|.
                 : {{MLConv2dFilterOperandLayout/"oihw"}}
-                ::
-                    1. Let |outputChannels| be |filterShape|[0].
-                    1. Let |filterInputChannels| be |filterShape|[1].
-                    1. Let |filterHeight| be |filterShape|[2].
-                    1. Let |filterWidth| be |filterShape|[3].
+                :: Let « |outputChannels|, |filterInputChannels|, |filterHeight|, |filterWidth| » be |filterShape|.
             </dl>
         1. If |inputChannels| % |options|.{{MLConv2dOptions/groups}} is not 0, then [=exception/throw=] a {{TypeError}}.
         1. Otherwise, if |inputChannels| / |options|.{{MLConv2dOptions/groups}} is not equal to |filterInputChannels|, then [=exception/throw=] a {{TypeError}}.
@@ -2397,39 +2373,19 @@ partial dictionary MLOpSupportLimits {
         1. Switch on |options|.{{MLConvTranspose2dOptions/inputLayout}}:
             <dl class=switch>
                 : {{MLInputOperandLayout/"nchw"}}
-                ::
-                    1. Let |batches| be |inputShape|[0].
-                    1. Let |inputChannels| be |inputShape|[1].
-                    1. Let |inputHeight| be |inputShape|[2].
-                    1. Let |inputWidth| be |inputShape|[3].
+                :: Let « |batches|, |inputChannels|, |inputHeight|, |inputWidth| » be |inputShape|.
                 : {{MLInputOperandLayout/"nhwc"}}
-                ::
-                    1. Let |batches| be |inputShape|[0].
-                    1. Let |inputHeight| be |inputShape|[1].
-                    1. Let |inputWidth| be |inputShape|[2].
-                    1. Let |inputChannels| be |inputShape|[3].
+                :: Let « |batches|, |inputHeight|, |inputWidth|, |inputChannels| » be |inputShape|.
             </dl>
         1. Let |filterShape| be |filter|'s [=MLOperand/shape=].
         1. Switch on |options|.{{MLConvTranspose2dOptions/filterLayout}}:
             <dl class=switch>
                 : {{MLConvTranspose2dFilterOperandLayout/"iohw"}}
-                ::
-                    1. Let |filterInputChannels| be |filterShape|[0].
-                    1. Let |filterOutputChannels| be |filterShape[1].
-                    1. Let |filterHeight| be |filterShape|[2].
-                    1. Let |filterWidth| be |filterShape|[3].
+                :: Let « |filterInputChannels|, |filterOutputChannels|, |filterHeight|, |filterWidth| » be |filterShape|.
                 : {{MLConvTranspose2dFilterOperandLayout/"hwoi"}}
-                ::
-                    1. Let |filterHeight| be |filterShape|[0].
-                    1. Let |filterWidth| be |filterShape|[1].
-                    1. Let |filterOutputChannels| be |filterShape[2].
-                    1. Let |filterInputChannels| be |filterShape|[3].
+                :: Let « |filterHeight|, |filterWidth|, |filterOutputChannels|, |filterInputChannels| » be |filterShape|.
                 : {{MLConvTranspose2dFilterOperandLayout/"ohwi"}}
-                ::
-                    1. Let |filterOutputChannels| be |filterShape[0].
-                    1. Let |filterHeight| be |filterShape|[1].
-                    1. Let |filterWidth| be |filterShape|[2].
-                    1. Let |filterInputChannels| be |filterShape|[3].
+                :: Let « |filterOutputChannels|, |filterHeight|, |filterWidth|, |filterInputChannels| » be |filterShape|.
             </dl>
         1. If |inputChannels| is not equal to |filterInputChannels|, then [=exception/throw=] a {{TypeError}}.
         1. Let |outputChannels| be |filterOutputChannels| * |options|.{{MLConvTranspose2dOptions/groups}}.
@@ -5441,25 +5397,14 @@ partial dictionary MLOpSupportLimits {
     1. Switch on |layout|:
         <dl class=switch>
             : {{MLInputOperandLayout/"nchw"}}
-            ::
-                1. Let |batches| be |inputShape|[0].
-                1. Let |channels| be |inputShape|[1].
-                1. Let |inputHeight| be |inputShape|[2].
-                1. Let |inputWidth| be |inputShape|[3].
+            :: Let « |batches|, |channels|, |inputHeight|, |inputWidth| » be |inputShape|.
             : {{MLInputOperandLayout/"nhwc"}}
-            ::
-                1. Let |batches| be |inputShape|[0].
-                1. Let |inputHeight| be |inputShape|[1].
-                1. Let |inputWidth| be |inputShape|[2].
-                1. Let |channels| be |inputShape|[3].
+            :: Let « |batches|, |inputHeight|, |inputWidth|, |channels| » be |inputShape|.
         </dl>
-    1. If |outputSizes| is not given, then:
-        1. Let |outputHeight| be |outputSizes|[0].
-        1. Let |outputWidth| be |outputSizes|[1].
+    1. If |outputSizes| is given, then let « |outputHeight|, |outputWidth| » be |outputSizes|.
     1. Otherwise:
         1. Let |outputSizes| be the result of [=MLGraphBuilder/calculating conv2d output sizes=] given |inputHeight|, |inputWidth|, |windowDimensions|[0], |windowDimensions|[1], |padding|, |strides|, and |dilations|.
-        1. Let |outputHeight| be |outputSizes|[0].
-        1. Let |outputWidth| be |outputSizes|[1].
+        1. Let « |outputHeight|, |outputWidth| » be |outputSizes|.
         1. Switch on |roundingType|:
             <dl class=switch>
                 : {{MLRoundingType/"floor"}}

--- a/tools/lint.mjs
+++ b/tools/lint.mjs
@@ -221,6 +221,9 @@ for (const algorithm of root.querySelectorAll('.algorithm')) {
         // "Let var given ... be ..." (for lambdas)
         'let ' + name + ' given .* be',
 
+        // "Let « ..., var, ... » be ..."
+        'let «( .*,)? ' + name + '(, .*)? » be',
+
         // "For each var ..."
         // "For each ...  → var ..."
         'for each( \\w+ →)? ' + name,


### PR DESCRIPTION
Infra[1] grew syntax "Let « |var1|, |var2|, ... » be |list|." which simplifies enum-driven unpacking. Use it! Also add corresponding lint validation.

One usage guarded by an "if" test appeared to have inverted condition, so fix that too.

1: https://infra.spec.whatwg.org/#example-list-multiple-assignment


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/777.html" title="Last updated on Nov 5, 2024, 7:46 PM UTC (85ab172)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/777/673c6b5...inexorabletash:85ab172.html" title="Last updated on Nov 5, 2024, 7:46 PM UTC (85ab172)">Diff</a>