### PR TITLE
Add deprecation warning for compute() -> dispatch()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -962,6 +962,9 @@ When the {{MLContext/[[contextType]]}} is set to [=context type/default=] with t
 </details>
 
 ### {{MLContext/compute()}}  ### {#api-mlcontext-compute}
+
+ISSUE: {{MLContext/compute()}} will be deprecated and removed in favor of <code>[dispatch()](https://github.com/webmachinelearning/webnn/blob/main/mltensor-explainer.md#compute-vs-dispatch)</code>.
+
 Asynchronously carries out the computational workload of a compiled graph {{MLGraph}} on a separate timeline, either on a worker thread for the CPU execution, or on a GPU/NPU timeline for submitting a workload onto the command queue. The asynchronous nature of this call avoids blocking the calling thread while the computation for result is ongoing. This method of execution requires an {{MLContext}} created with {{MLContextOptions}}. Otherwise, it [=exception/throws=] an "{{OperationError}}" {{DOMException}}.
 
 <div class="note">


### PR DESCRIPTION
This will help direct readers who see the console.warn deprecation messages to the right place. To be removed when the specification patches land.

FYI @a-sully


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/pull/781.html" title="Last updated on Nov 7, 2024, 8:54 AM UTC (5b6e8eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/781/673c6b5...5b6e8eb.html" title="Last updated on Nov 7, 2024, 8:54 AM UTC (5b6e8eb)">Diff</a>