### PR TITLE
Reject promises for in-progress operations on an MLTensor if it is destroyed

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1080,10 +1080,16 @@ Reads back the {{MLTensor/[[data]]}} of an {{MLTensor}} from the {{MLContext}}.{
     1. If |tensor|.{{MLTensor/[[isDestroyed]]}} is true, then return [=a new promise=] [=rejected=] with a {{TypeError}}.
     1. If |tensor|.{{MLTensor/[[descriptor]]}}.{{MLTensorDescriptor/readable}} is false, then return [=a new promise=] [=rejected=] with a {{TypeError}}.
     1. Let |promise| be [=a new promise=].
+    1. [=set/Append=] |promise| to |tensor|.{{MLTensor/[[pendingPromises]]}}.
     1. Enqueue the following steps to |tensor|.{{MLGraph/[[context]]}}.{{MLContext/[[timeline]]}}:
         1. Let |bytes| be a [=/byte sequence=] containing a copy of |tensor|.{{MLTensor/[[data]]}}.
-        1. If that fails, then [=queue an ML task=] with |global| to [=reject=] |promise| with an "{{UnknownError}}" {{DOMException}}, and abort these steps.
-        1. Otherwise, [=queue an ML task=] with |global| to [=ArrayBuffer/create=] an {{ArrayBuffer}} |result| given |bytes| and |realm| and then [=resolve=] |promise| with |result|.
+        1. If that fails, then [=queue an ML task=] with |global| and the following steps:
+            1. [=set/Remove=] |promise| from |tensor|.{{MLTensor/[[pendingPromises]]}}.
+            1. [=Reject=] |promise| with an "{{UnknownError}}" {{DOMException}}.
+        1. Otherwise, [=queue an ML task=] with |global| and the following steps:
+            1. [=set/Remove=] |promise| from |tensor|.{{MLTensor/[[pendingPromises]]}}.
+            1. [=ArrayBuffer/Create=] an {{ArrayBuffer}} |result| given |bytes| and |realm|.
+            1. [=Resolve=] |promise| with |result|.
     1. Return |promise|.
 </details>
 
@@ -1109,10 +1115,14 @@ Bring-your-own-buffer variant of {{MLContext/readTensor(tensor)}}. Reads back th
     1. If |tensor|.{{MLTensor/[[descriptor]]}}.{{MLTensorDescriptor/readable}} is false, then return [=a new promise=] [=rejected=] with a {{TypeError}}.
     1. If [=validating buffer with descriptor=] given |outputData| and |tensor|.{{MLTensor/[[descriptor]]}} returns false, then return [=a new promise=] [=rejected=] with a {{TypeError}}.
     1. Let |promise| be [=a new promise=].
+    1. [=set/Append=] |promise| to |tensor|.{{MLTensor/[[pendingPromises]]}}.
     1. Enqueue the following steps to |tensor|.{{MLGraph/[[context]]}}.{{MLContext/[[timeline]]}}:
         1. Let |bytes| be a [=/byte sequence=] containing a copy of |tensor|.{{MLTensor/[[data]]}}.
-        1. If that fails, then [=queue an ML task=] with |global| to [=reject=] |promise| with an "{{UnknownError}}" {{DOMException}}, and abort these steps.
+        1. If that fails, then [=queue an ML task=] with |global| and the following steps:
+            1. [=set/Remove=] |promise| from |tensor|.{{MLTensor/[[pendingPromises]]}}.
+            1. [=Reject=] |promise| with an "{{UnknownError}}" {{DOMException}}.
         1. Otherwise, [=queue an ML task=] with |global| and the following steps:
+            1. [=set/Remove=] |promise| from |tensor|.{{MLTensor/[[pendingPromises]]}}.
             1. If |outputData| is [=BufferSource/detached=], [=reject=] |promise| with a {{TypeError}}, and abort these steps.
 
                 Note: [=Validating buffer with descriptor=] above will fail if |outputData| is detached, but it is possible that |outputData| could be detached between that step and this one.
@@ -1478,6 +1488,10 @@ interface MLTensor {
     ::
         The {{MLTensor}}'s descriptor.
 
+    : <dfn>\[[pendingPromises]]</dfn> of type [=/set=] of {{Promise}}s
+    ::
+        Promises corresponding to {{MLContext}}.{{MLContext/readTensor(tensor)}} method calls which are in-progress and have yet to resolve. All pending promises will be rejected when the {{MLTensor}} is destroyed.
+
     : <dfn>\[[isDestroyed]]</dfn> of type {{boolean}}
     ::
         Whether {{MLTensor}}.{{MLTensor/destroy()}} has been called. Once destroyed, the {{MLTensor}} can no longer be used.
@@ -1528,6 +1542,9 @@ Releases the resources associated with the {{MLTensor}}. This method is idempote
     The <dfn method for=MLTensor>destroy()</dfn> method steps are:
   </summary>
     1. Set [=this=].{{MLTensor/[[isDestroyed]]}} to true.
+    1. [=set/For each=] |promise| in |tensor|.{{MLTensor/[[pendingPromises]]}}:
+        1. [=set/Remove=] |promise| from |tensor|.{{MLTensor/[[pendingPromises]]}}.
+        1. [=Reject=] |promise| with an "{{InvalidStateError}}" {{DOMException}}.
     1. Enqueue the following steps to [=this=].{{MLTensor/[[context]]}}.{{MLContext/[[timeline]]}}:
         1. Release [=this=].{{MLTensor/[[data]]}}.
     1. Return {{undefined}}.


### PR DESCRIPTION
This PR handles the following case:

```js
const promise = context.readTensor(tensor);
// Destroy `tensor` before awaiting `promise`
tensor.destroy();  // This should reject
```

The current spec does not reject `promise` in this example.  This PR updates the spec to match [the Chromium implementation](https://crsrc.org/c/third_party/blink/renderer/modules/ml/webnn/ml_tensor.h;l=127-131;drc=f0cd854ebf521bbeeaf2973266d6f046cf89a45d) and what I assume to be the desired behavior (please speak up otherwise!)

Note that Chromium implements a similar pattern in other cases where the `MLContext` may be destroyed (either intentionally or unexpectedly), but specification of that work should follow #744