### PR TITLE
Tooling: Use WebIDL2 parser when linting to identify dictionaries

### DIFF
--- a/tools/package.json
+++ b/tools/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "node-html-parser": "^6.1.13"
+    "node-html-parser": "^6.1.13",
+    "webidl2": "^24.4.1"
   }
 }


### PR DESCRIPTION
Dictionary types need special treatment in a lint rule verifying that realms are used correctly. This requires knowing which types are dictionaries vs. interfaces. This was previously hard-coded, which is a maintenance burden.

Improve this by pulling in the webidl2.js library and using it to parse (and validate!) the spec's WebIDL, which gives us a list of dictionary types.