### PR TITLE
Editorial: Fix some option links and one typo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3010,7 +3010,7 @@ partial dictionary MLOpSupportLimits {
     1. Otherwise, if |options|.{{MLConvTranspose2dOptions/padding}}'s [=list/size=] is not 4, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/strides}} does not [=map/exist=], then set it to the [=/list=] « 1, 1 ».
     1. Otherwise, if |options|.{{MLConvTranspose2dOptions/strides}}'s [=list/size=] is not 2, then [=exception/throw=] a {{TypeError}}.
-    1. If any [=list/item=] in |options|.{{MLConv2dOptions/strides}} is equal to 0, then [=exception/throw=] a {{TypeError}}.
+    1. If any [=list/item=] in |options|.{{MLConvTranspose2dOptions/strides}} is equal to 0, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/dilations}} does not [=map/exist=], then set it to the [=/list=] « 1, 1 ».
     1. Otherwise, if |options|.{{MLConvTranspose2dOptions/dilations}}'s [=list/size=] is not 2, then [=exception/throw=] a {{TypeError}}.
     1. If any [=list/item=] in |options|.{{MLConvTranspose2dOptions/dilations}} is equal to 0, then [=exception/throw=] a {{TypeError}}.
@@ -3069,7 +3069,7 @@ partial dictionary MLOpSupportLimits {
         1. Let |operator| be an [=operator=] for the "convTranspose2d" operation, given |options| and |filter|.
         1. Set |output|.{{MLOperand/[[operator]]}} to |operator|.
         1. Set |operator|'s [=operator/inputs=] to |input| and |filter|.
-        1. If |options|.{{MLConv2dOptions/bias}} [=map/exists=], then add it to |operator|'s [=operator/inputs=].
+        1. If |options|.{{MLConvTranspose2dOptions/bias}} [=map/exists=], then add it to |operator|'s [=operator/inputs=].
         1. Set |operator|'s [=operator/output=] to |output|.
     1. Return |output|.
 </details>
@@ -7711,7 +7711,7 @@ partial dictionary MLOpSupportLimits {
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input| and |slope| returns false, then [=exception/throw=] a {{TypeError}}.
     1. If the [=MLOperand/dataType=] of any of |input| or |slope| is not one of its [=/allowed data types=] (according to [this table](#constraints-prelu)), then [=exception/throw=] a {{TypeError}}.
-    1. Let |outputShape| be to the result of [=bidirectionally broadcasting=] |slope|'s [=MLOperand/shape=] and |input|'s [=MLOperand/shape=].
+    1. Let |outputShape| be the result of [=bidirectionally broadcasting=] |slope|'s [=MLOperand/shape=] and |input|'s [=MLOperand/shape=].
         1. If that returns failure, then [=exception/throw=] a {{TypeError}}.
     1. Let |descriptor| be the result of [=creating an MLOperandDescriptor=] given |input|'s [=MLOperand/dataType=] and |outputShape|.
     1. *Make graph connections:*
@@ -8513,7 +8513,7 @@ partial dictionary MLOpSupportLimits {
     1. If |indices|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-scatterelements)), then [=exception/throw=] a {{TypeError}}.
     1. If |updates|'s [=MLOperand/dataType=] is not equal to |input|'s [=MLOperand/dataType=], then [=exception/throw=] a {{TypeError}}.
     1. If the [=MLOperand/rank=] of any of |input|, |indices|, or |updates| is not its [=/allowed rank=], then [=exception/throw=] a {{TypeError}}.
-    1. Let |axis| be |options|.{{MLGatherOptions/axis}}.
+    1. Let |axis| be |options|.{{MLScatterOptions/axis}}.
     1. If |axis| is greater than or equal to |input|'s [=MLOperand/rank=], then [=exception/throw=] a {{TypeError}}.
     1. Let |indicesShapeExpected| be a copy of |input|'s [=MLOperand/shape=].
     1. Set |indicesShapeExpected|[|axis|] to |indices|'s [=MLOperand/shape=][|axis|].


### PR DESCRIPTION
Fix three instances where an option was incorrectly linked, e.g. MLGatherOptions/axis when the variable in question was a MLScatterOptions.

Also, fix a simple typo.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/839.html" title="Last updated on Apr 25, 2025, 10:48 PM UTC (2aece7d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/839/4771d50...inexorabletash:2aece7d.html" title="Last updated on Apr 25, 2025, 10:48 PM UTC (2aece7d)">Diff</a>