### PR TITLE
Restrict padding options to better match backend limits

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7338,6 +7338,7 @@ partial dictionary MLOpSupportLimits {
             <dl class=switch>
                 : {{MLPaddingMode/"constant"}}
                 :: Do nothing.
+                
                 : {{MLPaddingMode/"edge"}}
                 ::
                     1. If |beginningPadding|[|index|] is greater than |outputShape|[|index|], then [=exception/throw=] a {{TypeError}}.

--- a/index.bs
+++ b/index.bs
@@ -7253,8 +7253,7 @@ Inflate the tensor with constant or mirrored values on the edges.
 enum MLPaddingMode {
   "constant",
   "edge",
-  "reflection",
-  "symmetric"
+  "reflection"
 };
 
 dictionary MLPadOptions : MLOperatorOptions {
@@ -7334,7 +7333,23 @@ partial dictionary MLOpSupportLimits {
     1. If |beginningPadding|'s [=list/size=] and |endingPadding|'s [=list/size=] are not both equal to |input|'s [=MLOperand/rank=], then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
     1. Let |outputShape| be a copy of |input|'s [=MLOperand/shape=].
-    1. [=list/For each=] |index| in [=the range=] 0 to |outputShape|'s [=MLOperand/rank=], exclusive:
+    1. [=list/For each=] |index| in [=the exclusive range|the range=] 0 to |outputShape|'s [=MLOperand/rank=], exclusive:
+        1. Switch on |options|.{{MLPadOptions/mode}}:
+            <dl class=switch>
+                : {{MLPaddingMode/"constant"}}
+                :: Do nothing.
+                : {{MLPaddingMode/"edge"}}
+                ::
+                    1. If |beginningPadding|[|index|] is greater than |outputShape|[|index|], then [=exception/throw=] a {{TypeError}}.
+                    1. If |endingPadding|[|index|] is greater than |outputShape|[|index|], then [=exception/throw=] a {{TypeError}}.
+
+                    Issue: Restricting {{MLPaddingMode/"edge"}} was not discussed fully with the WG. Should we?
+
+                : {{MLPaddingMode/"reflection"}}
+                ::
+                    1. If |beginningPadding|[|index|] is greater than or equal to |outputShape|[|index|], then [=exception/throw=] a {{TypeError}}.
+                    1. If |endingPadding|[|index|] is greater than or equal to |outputShape|[|index|], then [=exception/throw=] a {{TypeError}}.
+            </dl>
         1. Add to |outputShape|[|index|] the value of |beginningPadding|[|index|].
         1. Add to |outputShape|[|index|] the value of |endingPadding|[|index|].
     1. If any [=list/item=] in |outputShape| is not a [=valid dimension=], then [=exception/throw=] a {{TypeError}}.
@@ -7352,7 +7367,7 @@ partial dictionary MLOpSupportLimits {
 <div class="example">
 <details open>
   <summary>
-    Examples for constant, edge, reflection and symmetric padding:
+    Examples for constant, edge, and reflection padding:
   </summary>
   <pre highlight="js">
     // input: [[1,2,3], [4,5,6]]
@@ -7382,13 +7397,6 @@ partial dictionary MLOpSupportLimits {
     //     [6,5,4,5,6,5,4],
     //     [3,2,1,2,3,2,1]]
     builder.pad(input, beginningPadding, endingPadding, {mode: 'reflection'});
-
-    // "symmetric" padded:
-    //    [[2,1,1,2,3,3,2],
-    //     [2,1,1,2,3,3,2],
-    //     [5,4,4,5,6,6,5],
-    //     [5,4,4,5,6,6,5]]
-    builder.pad(input, beginningPadding, endingPadding, {mode: 'symmetric'});
   </pre>
 </details>
 </div>

--- a/index.bs
+++ b/index.bs
@@ -7338,13 +7338,9 @@ partial dictionary MLOpSupportLimits {
             <dl class=switch>
                 : {{MLPaddingMode/"constant"}}
                 :: Do nothing.
-                
-                : {{MLPaddingMode/"edge"}}
-                ::
-                    1. If |beginningPadding|[|index|] is greater than |outputShape|[|index|], then [=exception/throw=] a {{TypeError}}.
-                    1. If |endingPadding|[|index|] is greater than |outputShape|[|index|], then [=exception/throw=] a {{TypeError}}.
 
-                    Issue: Restricting {{MLPaddingMode/"edge"}} was not discussed fully with the WG. Should we?
+                : {{MLPaddingMode/"edge"}}
+                :: Do nothing.
 
                 : {{MLPaddingMode/"reflection"}}
                 ::


### PR DESCRIPTION
Per discussion in the linked issues and working group, drop "symmetric" padding since it is not widely supported by backends, isn't used by notable models, and can be emulated. Also for non-constant padding, backends typically impose restrictions on the amount of padding to reasonable values based on the input size, so incorporate those limits too.

Resolves #377. Resolves #739.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/inexorabletash/webnn/pull/843.html" title="Last updated on Apr 29, 2025, 11:31 PM UTC (9129a11)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/843/b152d46...inexorabletash:9129a11.html" title="Last updated on Apr 29, 2025, 11:31 PM UTC (9129a11)">Diff</a>