### PR TITLE
Bugfix: Support `int64` for `abs`, `neg`, `sign`, `prelu` and `relu`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3714,7 +3714,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     <div algorithm>
     The <dfn method for=MLGraphBuilder>abs(|input|, |options|)</dfn> method steps are:
-        1. Let |output| be the result of [=MLGraphBuilder/element-wise-unary-op|creating an element-wise unary operation=] given "abs", |input|, « {{MLOperandDataType/"float32"}}, {{MLOperandDataType/"float16"}}, {{MLOperandDataType/"int32"}}, {{MLOperandDataType/"int8"}} », and |options|.
+        1. Let |output| be the result of [=MLGraphBuilder/element-wise-unary-op|creating an element-wise unary operation=] given "abs", |input|, « {{MLOperandDataType/"float32"}}, {{MLOperandDataType/"float16"}}, {{MLOperandDataType/"int64"}}, {{MLOperandDataType/"int32"}}, {{MLOperandDataType/"int8"}} », and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
     </div>
@@ -3770,7 +3770,7 @@ partial dictionary MLOpSupportLimits {
 
     <div algorithm>
     The <dfn method for=MLGraphBuilder>neg(|input|, |options|)</dfn> method steps are:
-        1. Let |output| be the result of [=MLGraphBuilder/element-wise-unary-op|creating an element-wise unary operation=] given "neg", |input|, « {{MLOperandDataType/"float32"}}, {{MLOperandDataType/"float16"}}, {{MLOperandDataType/"int32"}}, {{MLOperandDataType/"int8"}} », and |options|.
+        1. Let |output| be the result of [=MLGraphBuilder/element-wise-unary-op|creating an element-wise unary operation=] given "neg", |input|, « {{MLOperandDataType/"float32"}}, {{MLOperandDataType/"float16"}}, {{MLOperandDataType/"int64"}}, {{MLOperandDataType/"int32"}}, {{MLOperandDataType/"int8"}} », and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
     </div>
@@ -3791,7 +3791,7 @@ partial dictionary MLOpSupportLimits {
 
     <div algorithm>
     The <dfn method for=MLGraphBuilder>sign(|input|, |options|)</dfn> method steps are:
-        1. Let |output| be the result of [=MLGraphBuilder/element-wise-unary-op|creating an element-wise unary operation=] given "sign", |input|, « {{MLOperandDataType/"float32"}}, {{MLOperandDataType/"float16"}}, {{MLOperandDataType/"int32"}}, {{MLOperandDataType/"int8"}} », and |options|.
+        1. Let |output| be the result of [=MLGraphBuilder/element-wise-unary-op|creating an element-wise unary operation=] given "sign", |input|, « {{MLOperandDataType/"float32"}}, {{MLOperandDataType/"float16"}}, {{MLOperandDataType/"int64"}}, {{MLOperandDataType/"int32"}}, {{MLOperandDataType/"int8"}} », and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
     </div>
@@ -7683,7 +7683,7 @@ partial dictionary MLOpSupportLimits {
   </thead>
   <tr>
     <td>{{input}}</td>
-    <td>{{MLOperandDataType/"float32"}}, {{MLOperandDataType/"float16"}}, {{MLOperandDataType/"int32"}}, {{MLOperandDataType/"int8"}}</td>
+    <td>{{MLOperandDataType/"float32"}}, {{MLOperandDataType/"float16"}}, {{MLOperandDataType/"int64"}}, {{MLOperandDataType/"int32"}}, {{MLOperandDataType/"int8"}}</td>
     <td>[=/any rank|N=]</td>
   <tr>
     <td>{{slope}}</td>
@@ -8038,7 +8038,7 @@ partial dictionary MLOpSupportLimits {
   </thead>
   <tr>
     <td>{{input}}</td>
-    <td>{{MLOperandDataType/"float32"}}, {{MLOperandDataType/"float16"}}, {{MLOperandDataType/"int32"}}, {{MLOperandDataType/"int8"}}</td>
+    <td>{{MLOperandDataType/"float32"}}, {{MLOperandDataType/"float16"}}, {{MLOperandDataType/"int64"}}, {{MLOperandDataType/"int32"}}, {{MLOperandDataType/"int8"}}</td>
     <td>[=/any rank|N=]</td>
   </tr>
   <tr>


### PR DESCRIPTION
Fix #845


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/848.html" title="Last updated on May 16, 2025, 2:16 AM UTC (fe7fa56)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/848/2baa084...huningxin:fe7fa56.html" title="Last updated on May 16, 2025, 2:16 AM UTC (fe7fa56)">Diff</a>