### PR TITLE
Apply clang-format to JS blocks via tools/reformat-js.py

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -993,7 +993,10 @@ Note: `dispatch()` itself provides no signal that graph execution has completed.
     The following code showcases executing an {{MLGraph}} using {{MLTensor}}s.
   </summary>
   <pre highlight="js">
-    const descriptor = {dataType: 'float32', shape: [2, 2]};
+    const descriptor = {
+      dataType: 'float32',
+      shape: [2, 2]
+    };
     const context = await navigator.ml.createContext();
     const builder = new MLGraphBuilder(context);
 
@@ -1007,18 +1010,11 @@ Note: `dispatch()` itself provides no signal that graph execution has completed.
     const graph = await builder.build({'C': C});
 
     // 3. Create reusable input and output tensors.
-    const [inputTensorA, inputTensorB, outputTensorC] =
-        await Promise.all([
-          context.createTensor({
-            dataType: A.dataType, shape: A.shape, writable: true
-          }),
-          context.createTensor({
-            dataType: B.dataType, shape: B.shape, writable: true
-          }),
-          context.createTensor({
-            dataType: C.dataType, shape: C.shape, readable: true
-          })
-        ]);
+    const [inputTensorA, inputTensorB, outputTensorC] = await Promise.all([
+      context.createTensor({dataType: A.dataType, shape: A.shape, writable: true}),
+      context.createTensor({dataType: B.dataType, shape: B.shape, writable: true}),
+      context.createTensor({dataType: C.dataType, shape: C.shape, readable: true})
+    ]);
 
     // 4. Initialize the inputs.
     context.writeTensor(inputTensorA, new Float32Array(4).fill(1.0));
@@ -3825,10 +3821,7 @@ partial dictionary MLOpSupportLimits {
       return builder.where(
         builder.greater(input, zero),
         positiveOne,
-        builder.where(
-          builder.lesser(input, zero),
-          negativeOne,
-          zero));
+        builder.where(builder.lesser(input, zero), negativeOne, zero));
     }
     </pre>
   </details>
@@ -3951,8 +3944,10 @@ partial dictionary MLOpSupportLimits {
       const floatInput = builder.cast(input, scale.dataType);
       const floatZeroPoint = builder.cast(zeroPoint, scale.dataType);
       const upsampledScale = blockwiseExpand(builder, scale, input.shape);
-      const upsampledZeroPoint = blockwiseExpand(builder, floatZeroPoint, input.shape);
-      return builder.mul(builder.sub(floatInput, upsampledZeroPoint), upsampledScale);
+      const upsampledZeroPoint =
+        blockwiseExpand(builder, floatZeroPoint, input.shape);
+      return builder.mul(
+        builder.sub(floatInput, upsampledZeroPoint), upsampledScale);
     }
 
     function blockwiseExpand(builder, input, outputShape) {
@@ -3977,8 +3972,14 @@ partial dictionary MLOpSupportLimits {
           // full block size, utilizing an inserted dimension of size 1.
           const elementRepeatCount = newDimensionLength / oldDimensionLength;
           const flattenedShape = getFlattenedShapeAroundAxis(oldShape, axis);
-          const unexpandedShape = [flattenedShape[0], flattenedShape[1], 1, flattenedShape[2]];
-          const expandedShape = [flattenedShape[0], flattenedShape[1], elementRepeatCount, flattenedShape[2]];
+          const unexpandedShape =
+            [flattenedShape[0], flattenedShape[1], 1, flattenedShape[2]];
+          const expandedShape = [
+            flattenedShape[0],
+            flattenedShape[1],
+            elementRepeatCount,
+            flattenedShape[2]
+          ];
           const reshapedInput = builder.reshape(output, unexpandedShape);
           output = builder.expand(reshapedInput, expandedShape);
 
@@ -3991,13 +3992,14 @@ partial dictionary MLOpSupportLimits {
       return output;
     }
 
-    // Compute the flattened shape before and after the given axis, yielding a 3-element list.
-    // e.g. inputShape = [2,3,4,5,6] with axis = 2 yields shape [6,4,30].
-    // e.g. inputShape = [4] with axis = 0 yields shape [1,4,1].
+    // Compute the flattened shape before and after the given axis, yielding a
+    // 3-element list. e.g. inputShape = [2,3,4,5,6] with axis = 2 yields shape
+    // [6,4,30]. e.g. inputShape = [4] with axis = 0 yields shape [1,4,1].
     function getFlattenedShapeAroundAxis(inputShape, axis) {
       axis = Math.max(Math.min(axis, input.shape.length - 1), 0);
       const countBefore = axis.slice(0, axis).reduce((a, b) => a * b, 1);
-      const countAfter = axis.slice(axis + 1, input.shape.length).reduce((a, b) => a * b, 1);
+      const countAfter =
+        axis.slice(axis + 1, input.shape.length).reduce((a, b) => a * b, 1);
       return [countBefore, inputShape[axis], countAfter];
     }
     </pre>
@@ -4105,10 +4107,13 @@ partial dictionary MLOpSupportLimits {
 
       const floatZeroPoint = builder.cast(zeroPoint, scale.dataType);
       const upsampledScale = blockwiseExpand(builder, scale, input.shape);
-      const upsampledZeroPoint = blockwiseExpand(builder, floatZeroPoint, input.shape);
+      const upsampledZeroPoint =
+        blockwiseExpand(builder, floatZeroPoint, input.shape);
       const quantizedInput = builder.roundEven(builder.div(input, upsampledScale));
-      const zeroPointAdjustedInput = builder.add(quantizedInput, upsampledZeroPoint);
-      const clampedInput = builder.clamp(zeroPointAdjustedInput, {'minValue': 0, 'maxValue': 255});
+      const zeroPointAdjustedInput =
+        builder.add(quantizedInput, upsampledZeroPoint);
+      const clampedInput =
+        builder.clamp(zeroPointAdjustedInput, {'minValue': 0, 'maxValue': 255});
       return builder.cast(clampedInput, zeroPoint.dataType);
     }
     </pre>
@@ -4568,8 +4573,7 @@ partial dictionary MLOpSupportLimits {
       new Float32Array([0, 1, 2, 10, 11, 12, 20, 21, 22, 30, 31, 32]));
 
     const indices1 = builder.constant(
-      {dataType: 'uint32', shape: [2, 3]},
-      new Uint32Array([3, 1, 1, 2, 0, 3]));
+      {dataType: 'uint32', shape: [2, 3]}, new Uint32Array([3, 1, 1, 2, 0, 3]));
 
     const output1 = builder.gatherElements(input1, indices1);
 
@@ -4591,8 +4595,7 @@ partial dictionary MLOpSupportLimits {
     //    [32]]
 
     const indices2 = builder.constant(
-      {dataType: 'uint32', shape: [4, 1]},
-      new Uint32Array([2, 1, 0, 2]));
+      {dataType: 'uint32', shape: [4, 1]}, new Uint32Array([2, 1, 0, 2]));
 
     const output2 = builder.gatherElements(input1, indices2, {axis: 1});
 
@@ -4613,13 +4616,28 @@ partial dictionary MLOpSupportLimits {
     //   [[[  0, 201],
     //     [110, 311]]]
 
-    const input3 = builder.constant(
-      {dataType: 'float32', shape: [4, 2, 2]},
-      new Float32Array([0, 1, 10, 11, 100, 101, 110, 111, 200, 201, 210, 211, 300, 301, 310, 311]));
+    const input3 =
+      builder.constant({dataType: 'float32', shape: [4, 2, 2]}, new Float32Array([
+                         0,
+                         1,
+                         10,
+                         11,
+                         100,
+                         101,
+                         110,
+                         111,
+                         200,
+                         201,
+                         210,
+                         211,
+                         300,
+                         301,
+                         310,
+                         311
+                       ]));
 
     const indices3 = builder.constant(
-      {dataType: 'uint32', shape: [1, 2, 2]},
-      new Uint32Array([0, 2, 1, 3]));
+      {dataType: 'uint32', shape: [1, 2, 2]}, new Uint32Array([0, 2, 1, 3]));
 
     const output3 = builder.gatherElements(input3, indices3, {axis: 0});
   </pre>
@@ -4732,12 +4750,10 @@ partial dictionary MLOpSupportLimits {
     //   [0, 3, 2]
 
     const input1 = builder.constant(
-      {dataType: 'float32', shape: [2, 2]},
-      new Float32Array([0, 1, 2, 3]));
+      {dataType: 'float32', shape: [2, 2]}, new Float32Array([0, 1, 2, 3]));
 
     const indices1 = builder.constant(
-      {dataType: 'uint32', shape: [3, 2]},
-      new Uint32Array([0, 0, 1, 1, 1, 0]));
+      {dataType: 'uint32', shape: [3, 2]}, new Uint32Array([0, 0, 1, 1, 1, 0]));
 
     const output1 = builder.gatherND(input1, indices1);
 
@@ -4752,8 +4768,7 @@ partial dictionary MLOpSupportLimits {
     //    [0, 1]]   <= row [0, 1] from input coordinates [0, *]
 
     const indices2 = builder.constant(
-      {dataType: 'uint32', shape: [2, 1]},
-      new Uint32Array([1, 0]));
+      {dataType: 'uint32', shape: [2, 1]}, new Uint32Array([1, 0]));
 
     const output2 = builder.gatherND(input1, indices2);
 
@@ -4774,8 +4789,7 @@ partial dictionary MLOpSupportLimits {
       new Float32Array([0, 1, 2, 3, 4, 5, 6, 7]));
 
     const indices3 = builder.constant(
-      {dataType: 'uint32', shape: [2, 2]},
-      new Uint32Array([0, 1, 1, 0]));
+      {dataType: 'uint32', shape: [2, 2]}, new Uint32Array([0, 1, 1, 0]));
 
     const output3 = builder.gatherND(input2, indices3);
 
@@ -4797,8 +4811,7 @@ partial dictionary MLOpSupportLimits {
     //     [6, 7]]]
 
     const indices4 = builder.constant(
-      {dataType: 'uint32', shape: [3, 1]},
-      new Uint32Array([1, 0, 1]));
+      {dataType: 'uint32', shape: [3, 1]}, new Uint32Array([1, 0, 1]));
 
     const output4 = builder.gatherND(input2, indices4);
 
@@ -8566,8 +8579,7 @@ partial dictionary MLOpSupportLimits {
       new Float32Array([0, 1, 2, 10, 11, 12, 20, 21, 22, 30, 31, 32]));
 
     const indices1 = builder.constant(
-      {dataType: 'uint32', shape: [2, 3]},
-      new Uint32Array([3, 1, 1, 2, 0, 3]));
+      {dataType: 'uint32', shape: [2, 3]}, new Uint32Array([3, 1, 1, 2, 0, 3]));
 
     const updates1 = builder.constant(
       {dataType: 'float32', shape: [2, 3]},
@@ -8598,12 +8610,10 @@ partial dictionary MLOpSupportLimits {
     //    [30, 31, -4]]
 
     const indices2 = builder.constant(
-      {dataType: 'uint32', shape: [4, 1]},
-      new Uint32Array([2, 1, 0, 2]));
+      {dataType: 'uint32', shape: [4, 1]}, new Uint32Array([2, 1, 0, 2]));
 
-    const updates2 =
-      builder.constant({dataType: 'float32', shape: [4, 1]},
-      new Uint32Array([-1, -2, -3, -4]));
+    const updates2 = builder.constant(
+      {dataType: 'float32', shape: [4, 1]}, new Uint32Array([-1, -2, -3, -4]));
 
     const output2 = builder.scatterElements(input1, indices2, updates2, {axis: 1});
 
@@ -8633,17 +8643,31 @@ partial dictionary MLOpSupportLimits {
     //    [[300, 301],
     //     [310,  -4]],]
 
-    const input3 = builder.constant(
-      {dataType: 'float32', shape: [4, 2, 2]},
-      new Float32Array([0, 1, 10, 11, 100, 101, 110, 111, 200, 201, 210, 211, 300, 301, 310, 311]));
+    const input3 =
+      builder.constant({dataType: 'float32', shape: [4, 2, 2]}, new Float32Array([
+                         0,
+                         1,
+                         10,
+                         11,
+                         100,
+                         101,
+                         110,
+                         111,
+                         200,
+                         201,
+                         210,
+                         211,
+                         300,
+                         301,
+                         310,
+                         311
+                       ]));
 
     const indices3 = builder.constant(
-      {dataType: 'uint32', shape: [1, 2, 2]},
-      new Uint32Array([0, 2, 1, 3]));
+      {dataType: 'uint32', shape: [1, 2, 2]}, new Uint32Array([0, 2, 1, 3]));
 
-    const updates3 =
-      builder.constant({dataType: 'float32', shape: [1, 2, 2]},
-      new Uint32Array([-1, -2, -3, -4]));
+    const updates3 = builder.constant(
+      {dataType: 'float32', shape: [1, 2, 2]}, new Uint32Array([-1, -2, -3, -4]));
 
     const output3 = builder.scatterElements(input3, indices3, updates3, {axis: 0});
   </pre>
@@ -8771,12 +8795,10 @@ partial dictionary MLOpSupportLimits {
       new Float32Array([0, 1, 2, 3, 4, 5, 6, 7]));
 
     const indices1 = builder.constant(
-      {dataType: 'uint32', shape: [4, 1]},
-      new Uint32Array([4, 3, 1, 7]));
+      {dataType: 'uint32', shape: [4, 1]}, new Uint32Array([4, 3, 1, 7]));
 
     const updates1 = builder.constant(
-      {dataType: 'uint32', shape: [4]},
-      new Uint32Array([-1, -2, -3, -4]));
+      {dataType: 'uint32', shape: [4]}, new Uint32Array([-1, -2, -3, -4]));
 
     const output1 = builder.scatterND(input1, indices1, updates1);
 
@@ -8793,16 +8815,13 @@ partial dictionary MLOpSupportLimits {
     //    [ 2, -2]]   <= -2 written to output coordinate [1, 1]
 
     const input2 = builder.constant(
-      {dataType: 'float32', shape: [2, 2]},
-      new Float32Array([0, 1, 2, 3]));
+      {dataType: 'float32', shape: [2, 2]}, new Float32Array([0, 1, 2, 3]));
 
     const indices2 = builder.constant(
-      {dataType: 'uint32', shape: [2, 2]},
-      new Uint32Array([0, 0, 1, 1]));
+      {dataType: 'uint32', shape: [2, 2]}, new Uint32Array([0, 0, 1, 1]));
 
-    const updates2 = builder.constant(
-      {dataType: 'uint32', shape: [2]},
-      new Uint32Array([-1, -2]));
+    const updates2 =
+      builder.constant({dataType: 'uint32', shape: [2]}, new Uint32Array([-1, -2]));
 
     const output2 = builder.scatterND(input2, indices2, updates2);
 
@@ -8822,16 +8841,13 @@ partial dictionary MLOpSupportLimits {
     //    [-1, -2]]    <= [-1, -2] written to output coordinates [2, *]
 
     const input3 = builder.constant(
-      {dataType: 'float32', shape: [3, 2]},
-      new Float32Array([0, 1, 2, 3, 4, 5]));
+      {dataType: 'float32', shape: [3, 2]}, new Float32Array([0, 1, 2, 3, 4, 5]));
 
     const indices3 = builder.constant(
-      {dataType: 'uint32', shape: [2, 1]},
-      new Uint32Array([1, 0]));
+      {dataType: 'uint32', shape: [2, 1]}, new Uint32Array([1, 0]));
 
     const updates3 = builder.constant(
-      {dataType: 'uint32', shape: [2, 2]},
-      new Uint32Array([-1, -2, -3, 4]));
+      {dataType: 'uint32', shape: [2, 2]}, new Uint32Array([-1, -2, -3, 4]));
 
     const output3 = builder.scatterND(input3, indices3, updates3);
 
@@ -8857,12 +8873,10 @@ partial dictionary MLOpSupportLimits {
       new Float32Array([0, 1, 2, 3, 4, 5, 6, 7]));
 
     const indices4 = builder.constant(
-      {dataType: 'uint32', shape: [2, 2]},
-      new Uint32Array([0, 1, 1, 0]));
+      {dataType: 'uint32', shape: [2, 2]}, new Uint32Array([0, 1, 1, 0]));
 
     const updates4 = builder.constant(
-      {dataType: 'uint32', shape: [2, 2]},
-      new Uint32Array([-1, -2, -3, 4]));
+      {dataType: 'uint32', shape: [2, 2]}, new Uint32Array([-1, -2, -3, 4]));
 
     const output4 = builder.scatterND(input4, indices4, updates4);
   </pre>


### PR DESCRIPTION
Using clang-format 20.1.5

I think this is good for consistency, unless we have a reason to retain manual control over the code block formatting?