### PR TITLE
Note Unicode sequences in Security Considerations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -629,6 +629,8 @@ The API design minimizes the attack surface for the compiled computational graph
 
 Purpose-built Web APIs for measuring high-resolution time mitigate against timing attacks using techniques such as resolution reduction, adding jitter, detection of abuse and API call throttling [[hr-time-3]]. The practical deployment of WebNN implementations are likely to bring enough jitter to make timing attacks impractical (e.g. because they would use IPC) but implementers are advised to consider and test their implementations against timing attacks.
 
+Note: Security risks related to Unicode sequences are discussed in context of the {{MLOperatorOptions/label}} {{USVString}} definition.
+
 ## Guidelines for new operations ## {#security-new-ops}
 
 *This section is non-normative.*


### PR DESCRIPTION
Fix #837

Do we have other Unicode strings in this specification that could be affected similarly to `label`?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/pull/851.html" title="Last updated on May 22, 2025, 10:06 AM UTC (7788774)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/851/9b84267...7788774.html" title="Last updated on May 22, 2025, 10:06 AM UTC (7788774)">Diff</a>