### PR TITLE
Support rankRange for op output tensors in opSupportLimits

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2225,8 +2225,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The output N-D tensor of [=MLOperand/rank=] equal to {{MLGraphBuilder/argMin(input, axis, options)/input}}'s [=MLOperand/rank=] if {{MLArgMinMaxOptions/keepDimensions}} is true or the {{MLGraphBuilder/argMin(input, axis, options)/input}}'s [=MLOperand/rank=] - 1 if {{MLArgMinMaxOptions/keepDimensions}} is false. The values must be of type {{MLArgMinMaxOptions/outputDataType}} in the range [0, N-1] where N is the size of the input dimension specified by {{MLGraphBuilder/argMin(input, axis, options)/axis}}.
 </div>
 
-<table id=constraints-argMin-argMax class='data' link-for="MLGraphBuilder/argMin(input, axis, options), MLGraphBuilder/argMax(input, axis, options)">
-  <caption>Constraints for {{MLGraphBuilder/argMin()}}/{{MLGraphBuilder/argMax()}}</caption>
+<table id=tensor-limits-argMin-argMax class='data' link-for="MLGraphBuilder/argMin(input, axis, options), MLGraphBuilder/argMax(input, axis, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/argMin()}}/{{MLGraphBuilder/argMax()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -2262,7 +2262,7 @@ partial dictionary MLOpSupportLimits {
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
     1. If |axis| is greater than or equal to |input|'s [=MLOperand/rank=], then [=exception/throw=] a {{TypeError}}.
-    1. if |options|.{{MLArgMinMaxOptions/outputDataType}} is not output tensor's [=/allowed data types=] (according to [this table](#constraints-argMin-argMax)), then [=exception/throw=] a {{TypeError}}.
+    1. if |options|.{{MLArgMinMaxOptions/outputDataType}} is not output tensor's [=/allowed data types=] (according to [this table](#tensor-limits-argMin-argMax)), then [=exception/throw=] a {{TypeError}}.
     1. If |input|'s [=MLOperand/shape=][|axis|] is greater than |options|.{{MLArgMinMaxOptions/outputDataType}}'s maximum value, then [=exception/throw=] a {{TypeError}}.
     1. Let |outputShape| be the result of [=MLGraphBuilder/calculating reduction output sizes=] given |input|'s [=MLOperand/shape=], « |axis| », and |options|.{{MLArgMinMaxOptions/keepDimensions}}. If that returns failure, then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| be the result of [=creating an MLOperandDescriptor=] given |options|.{{MLArgMinMaxOptions/outputDataType}} and |outputShape|.
@@ -2353,8 +2353,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The batch-normalized N-D tensor of the same shape as {{MLGraphBuilder/batchNormalization(input, mean, variance, options)/input}}.
 </div>
 
-<table id=constraints-batchNormalization class='data' link-for="MLGraphBuilder/batchNormalization(input, mean, variance, options)">
-  <caption>Constraints for {{MLGraphBuilder/batchNormalization()}}</caption>
+<table id=tensor-limits-batchNormalization class='data' link-for="MLGraphBuilder/batchNormalization(input, mean, variance, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/batchNormalization()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -2422,18 +2422,18 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input|, |mean|, |variance|, |options|.{{MLBatchNormalizationOptions/scale}} (if it [=map/exists=]), and |options|.{{MLBatchNormalizationOptions/bias}} (if it [=map/exists=]) returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-batchNormalization)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-batchNormalization)), then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLBatchNormalizationOptions/axis}} is not in [=the range=] 0 to |input|'s [=MLOperand/rank=], exclusive, then [=exception/throw=] a {{TypeError}}.
-    1. If |mean|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-batchNormalization)), then [=exception/throw=] a {{TypeError}}.
+    1. If |mean|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-batchNormalization)), then [=exception/throw=] a {{TypeError}}.
     1. If |mean|'s [=MLOperand/shape=] is not [=list/equal=] to « |input|'s [=MLOperand/shape=][|options|.{{MLBatchNormalizationOptions/axis}}] », then [=exception/throw=] a {{TypeError}}.
-    1. If |variance|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-batchNormalization)), then [=exception/throw=] a {{TypeError}}.
+    1. If |variance|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-batchNormalization)), then [=exception/throw=] a {{TypeError}}.
     1. If |variance|'s [=MLOperand/shape=] is not [=list/equal=] to « |input|'s [=MLOperand/shape=][|options|.{{MLBatchNormalizationOptions/axis}}] », then [=exception/throw=] a {{TypeError}}.
     1. Set |options|.{{MLBatchNormalizationOptions/epsilon}} to the result of [=casting=] |options|.{{MLBatchNormalizationOptions/epsilon}} to |input|'s [=MLOperand/dataType=].
     1. If |options|.{{MLBatchNormalizationOptions/scale}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-batchNormalization)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-batchNormalization)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/shape=] is not [=list/equal=] to « |input|'s [=MLOperand/shape=][|options|.{{MLBatchNormalizationOptions/axis}}] », then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLBatchNormalizationOptions/bias}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-batchNormalization)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-batchNormalization)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/shape=] is not [=list/equal=] to « |input|'s [=MLOperand/shape=][|options|.{{MLBatchNormalizationOptions/axis}}] », then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
         1. Let |operator| be an [=operator=] for the "batchNormalization" operation, given |input|, |mean|, |variance| and |options|.
@@ -2491,8 +2491,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The N-D tensor of the same shape as {{MLGraphBuilder/cast(input, dataType, options)/input}} with each element casted to the target data type.
 </div>
 
-<table id=constraints-cast class='data' link-for="MLGraphBuilder/cast(input, dataType, options)">
-  <caption>Constraints for {{MLGraphBuilder/cast()}}</caption>
+<table id=tensor-limits-cast class='data' link-for="MLGraphBuilder/cast(input, dataType, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/cast()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -2588,7 +2588,7 @@ NOTE: For example, casting -1 from {{MLOperandDataType/"int8"}} to {{MLOperandDa
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. if |dataType| is not output tensor's [=/allowed data types=] (according to [this table](#constraints-cast)), then [=exception/throw=] a {{TypeError}}.
+    1. if |dataType| is not output tensor's [=/allowed data types=] (according to [this table](#tensor-limits-cast)), then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
         1. Let |operator| be an [=operator=] for the "cast" operation, given |dataType| and |options|.
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
@@ -2632,8 +2632,8 @@ partial dictionary MLOpSupportLimits {
         - an {{MLOperand}}. The output tensor of the same shape as {{MLGraphBuilder/clamp(input, options)/input}}.
 </div>
 
-<table id=constraints-clamp class='data' link-for="MLGraphBuilder/clamp(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/clamp()}}</caption>
+<table id=tensor-limits-clamp class='data' link-for="MLGraphBuilder/clamp(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/clamp()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -2738,8 +2738,8 @@ partial dictionary MLOpSupportLimits {
     computed as the sum of all the input sizes of the same dimension.
 </div>
 
-<table id=constraints-concat class='data' link-for="MLGraphBuilder/concat(inputs, axis, options)">
-  <caption>Constraints for {{MLGraphBuilder/concat()}}</caption>
+<table id=tensor-limits-concat class='data' link-for="MLGraphBuilder/concat(inputs, axis, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/concat()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -2903,8 +2903,8 @@ partial dictionary MLOpSupportLimits {
     `outputSize = 1 + (inputSize - (filterSize - 1) * dilation - 1 + beginningPadding + endingPadding) / stride`
 </div>
 
-<table id=constraints-conv2d class='data' link-for="MLGraphBuilder/conv2d(input, filter, options)">
-  <caption>Constraints for {{MLGraphBuilder/conv2d()}}</caption>
+<table id=tensor-limits-conv2d class='data' link-for="MLGraphBuilder/conv2d(input, filter, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/conv2d()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -2981,10 +2981,10 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input|, |filter|, and |options|.{{MLConv2dOptions/bias}} (if it [=map/exists=]) returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-conv2d)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-conv2d)), then [=exception/throw=] a {{TypeError}}.
     1. If |input|'s [=MLOperand/rank=] is not its [=/allowed rank=], then [=exception/throw=] a {{TypeError}}.
     1. If |filter|'s [=MLOperand/rank=] is not its [=/allowed rank=], then [=exception/throw=] a {{TypeError}}.
-    1. If |filter|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-conv2d)), then [=exception/throw=] a {{TypeError}}.
+    1. If |filter|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-conv2d)), then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/padding}} does not [=map/exist=], then set it to the [=/list=] « 0, 0, 0, 0 ».
     1. Otherwise, if |options|.{{MLConv2dOptions/padding}}'s [=list/size=] is not 4, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConv2dOptions/strides}} does not [=map/exist=], then set it to the [=/list=] « 1, 1 ».
@@ -3019,7 +3019,7 @@ partial dictionary MLOpSupportLimits {
         1. Otherwise, if |inputChannels| / |options|.{{MLConv2dOptions/groups}} is not equal to |filterInputChannels|, then [=exception/throw=] a {{TypeError}}.
         1. If |options|.{{MLConv2dOptions/bias}} [=map/exists=], then:
             1. If its [=MLOperand/shape=] is not [=list/equal=] to « |outputChannels| », then [=exception/throw=] a {{TypeError}}.
-            1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-conv2d)), then [=exception/throw=] a {{TypeError}}.
+            1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-conv2d)), then [=exception/throw=] a {{TypeError}}.
         1. Let « |outputHeight|, |outputWidth| » be the result of [=MLGraphBuilder/calculating conv2d output sizes=] given |inputHeight|, |inputWidth|, |filterHeight|, |filterWidth|, |options|.{{MLConv2dOptions/padding}}, |options|.{{MLConv2dOptions/strides}}, and |options|.{{MLConv2dOptions/dilations}}.
         1. Set |outputHeight| to floor( |outputHeight| ).
         1. Set |outputWidth| to floor( |outputWidth| ).
@@ -3148,8 +3148,8 @@ partial dictionary MLOpSupportLimits {
     `outputSize = (inputSize - 1) * stride + (filterSize - 1) * dilation + 1 - beginningPadding - endingPadding + outputPadding`
 </div>
 
-<table id=constraints-convTranspose2d class='data' link-for="MLGraphBuilder/convTranspose2d(input, filter, options)">
-  <caption>Constraints for {{MLGraphBuilder/convTranspose2d()}}</caption>
+<table id=tensor-limits-convTranspose2d class='data' link-for="MLGraphBuilder/convTranspose2d(input, filter, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/convTranspose2d()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -3201,9 +3201,9 @@ partial dictionary MLOpSupportLimits {
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input|, |filter|, and |options|.{{MLConvTranspose2dOptions/bias}} (if it [=map/exists=]) returns false, then [=exception/throw=] a {{TypeError}}.
     1. If |input|'s [=MLOperand/rank=] is not its [=/allowed rank=], then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-convTranspose2d)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-convTranspose2d)), then [=exception/throw=] a {{TypeError}}.
     1. If |filter|'s [=MLOperand/rank=] is not its [=/allowed rank=], then [=exception/throw=] a {{TypeError}}.
-    1. If |filter|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-convTranspose2d)), then [=exception/throw=] a {{TypeError}}.
+    1. If |filter|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-convTranspose2d)), then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/padding}} does not [=map/exist=], then set it to the [=/list=] « 0, 0, 0, 0 ».
     1. Otherwise, if |options|.{{MLConvTranspose2dOptions/padding}}'s [=list/size=] is not 4, then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLConvTranspose2dOptions/strides}} does not [=map/exist=], then set it to the [=/list=] « 1, 1 ».
@@ -3243,7 +3243,7 @@ partial dictionary MLOpSupportLimits {
         1. If |outputChannels| is not a [=valid dimension=], then [=exception/throw=] a {{TypeError}}.
         1. If |options|.{{MLConvTranspose2dOptions/bias}} [=map/exists=], then:
             1. If its [=MLOperand/shape=] is not [=list/equal=] to « |outputChannels| », then [=exception/throw=] a {{TypeError}}.
-            1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-convTranspose2d)), then [=exception/throw=] a {{TypeError}}.
+            1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-convTranspose2d)), then [=exception/throw=] a {{TypeError}}.
         1. Let |calculatedOutputHeight| be the result of [=MLGraphBuilder/calculating convtranspose output size=] given |inputHeight|, |filterHeight|, |padding|[0], |padding|[1], |strides|[0] and |dilations|[0].
         1. Let |calculatedOutputWidth| be the result of [=MLGraphBuilder/calculating convtranspose output size=] given |inputWidth|, |filterWidth|, |padding|[2], |padding|[3], |strides|[1] and |dilations|[1].
         1. If |options|.{{MLConvTranspose2dOptions/outputSizes}} [=map/exists=], then:
@@ -3292,8 +3292,8 @@ partial dictionary MLOpSupportLimits {
 };
 </script>
 
-<table id=constraints-cumulativesum class='data' link-for="MLGraphBuilder/cumulativeSum(input, axis, options)">
-  <caption>Constraints for {{MLGraphBuilder/cumulativeSum()}}</caption>
+<table id=tensor-limits-cumulativesum class='data' link-for="MLGraphBuilder/cumulativeSum(input, axis, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/cumulativeSum()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -3346,7 +3346,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-cumulativesum)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-cumulativesum)), then [=exception/throw=] a {{TypeError}}.
     1. If |axis| is greater than or equal to |input|'s [=MLOperand/rank=], then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
@@ -3405,8 +3405,8 @@ partial dictionary MLOpSupportLimits {
         - *pow*: Compute the values of the values of the first input tensor to the power of the values of the second input tensor, element-wise.
 </div>
 
-<table id=constraints-elementwise-binary class='data' link-for="MLGraphBuilder/add(a, b, options), MLGraphBuilder/sub(a, b, options), MLGraphBuilder/mul(a, b, options), MLGraphBuilder/div(a, b, options), MLGraphBuilder/max(a, b, options), MLGraphBuilder/min(a, b, options), MLGraphBuilder/pow(a, b, options)">
-  <caption>Constraints for element-wise binary options</caption>
+<table id=tensor-limits-elementwise-binary class='data' link-for="MLGraphBuilder/add(a, b, options), MLGraphBuilder/sub(a, b, options), MLGraphBuilder/mul(a, b, options), MLGraphBuilder/div(a, b, options), MLGraphBuilder/max(a, b, options), MLGraphBuilder/min(a, b, options), MLGraphBuilder/pow(a, b, options)">
+  <caption>Tensor limits for element-wise binary options</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -3592,8 +3592,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The output tensor that contains the result of element-wise comparison of the two input tensors.
 </div>
 
-<table id=constraints-elementwise-logical class='data' link-for="MLGraphBuilder/equal(a, b, options), MLGraphBuilder/notEqual(a, b, options), MLGraphBuilder/greater(a, b, options), MLGraphBuilder/greaterOrEqual(a, b, options), MLGraphBuilder/lesser(a, b, options), MLGraphBuilder/lesserOrEqual(a, b, options), MLGraphBuilder/logicalNot(a, options), MLGraphBuilder/logicalAnd(a, b, options), MLGraphBuilder/logicalOr(a, b, options), MLGraphBuilder/logicalXor(a, b, options), MLGraphBuilder/isNaN(a, options), MLGraphBuilder/isInfinite(a, options)">
-  <caption>Constraints for element-wise logical options</caption>
+<table id=tensor-limits-elementwise-logical class='data' link-for="MLGraphBuilder/equal(a, b, options), MLGraphBuilder/notEqual(a, b, options), MLGraphBuilder/greater(a, b, options), MLGraphBuilder/greaterOrEqual(a, b, options), MLGraphBuilder/lesser(a, b, options), MLGraphBuilder/lesserOrEqual(a, b, options), MLGraphBuilder/logicalNot(a, options), MLGraphBuilder/logicalAnd(a, b, options), MLGraphBuilder/logicalOr(a, b, options), MLGraphBuilder/logicalXor(a, b, options), MLGraphBuilder/isNaN(a, options), MLGraphBuilder/isInfinite(a, options)">
+  <caption>Tensor limits for element-wise logical options</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -3841,8 +3841,8 @@ partial dictionary MLOpSupportLimits {
     tensor is the same as the shape of input tensor.
 </div>
 
-<table id=constraints-elementwise-unary class='data' link-for="MLGraphBuilder/abs(input, options), MLGraphBuilder/ceil(input, options), MLGraphBuilder/cos(input, options), MLGraphBuilder/erf(input, options), MLGraphBuilder/exp(input, options), MLGraphBuilder/floor(input, options), MLGraphBuilder/identity(input, options), MLGraphBuilder/log(input, options), MLGraphBuilder/neg(input, options), MLGraphBuilder/reciprocal(input, options), MLGraphBuilder/roundEven(input, options), MLGraphBuilder/sin(input, options), MLGraphBuilder/sign(input, options), MLGraphBuilder/sqrt(input, options), MLGraphBuilder/tan(input, options)">
-  <caption>Constraints for element-wise unary options</caption>
+<table id=tensor-limits-elementwise-unary class='data' link-for="MLGraphBuilder/abs(input, options), MLGraphBuilder/ceil(input, options), MLGraphBuilder/cos(input, options), MLGraphBuilder/erf(input, options), MLGraphBuilder/exp(input, options), MLGraphBuilder/floor(input, options), MLGraphBuilder/identity(input, options), MLGraphBuilder/log(input, options), MLGraphBuilder/neg(input, options), MLGraphBuilder/reciprocal(input, options), MLGraphBuilder/roundEven(input, options), MLGraphBuilder/sin(input, options), MLGraphBuilder/sign(input, options), MLGraphBuilder/sqrt(input, options), MLGraphBuilder/tan(input, options)">
+  <caption>Tensor limits for element-wise unary options</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -4097,8 +4097,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The output tensor that contains the dequantized values.
 </div>
 
-<table id=constraints-dequantizelinear class='data' link-for="MLGraphBuilder/dequantizeLinear(input, scale, zeroPoint, options)">
-  <caption>Constraints for {{MLGraphBuilder/dequantizeLinear()}}</caption>
+<table id=tensor-limits-dequantizelinear class='data' link-for="MLGraphBuilder/dequantizeLinear(input, scale, zeroPoint, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/dequantizeLinear()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -4152,9 +4152,9 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=].{{MLGraphBuilder/[[hasBuilt]]}} is true, then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input|, |scale|, and |zeroPoint| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-dequantizelinear)), then [=exception/throw=] a {{TypeError}}.
-    1. If |scale|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-dequantizelinear)), then [=exception/throw=] a {{TypeError}}.
-    1. If |zeroPoint|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-dequantizelinear)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-dequantizelinear)), then [=exception/throw=] a {{TypeError}}.
+    1. If |scale|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-dequantizelinear)), then [=exception/throw=] a {{TypeError}}.
+    1. If |zeroPoint|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-dequantizelinear)), then [=exception/throw=] a {{TypeError}}.
     1. If |scale|'s [=MLOperand/rank=] or |zeroPoint|'s [=MLOperand/rank=] is not equal to |input|'s [=MLOperand/rank=], then [=exception/throw=] a {{TypeError}}.
     1. If |scale|'s [=MLOperand/shape=] is not [=list/equal=] to |zeroPoint|'s [=MLOperand/shape=], then [=exception/throw=] a {{TypeError}}.
     1. If [=blockwise broadcasting=] |scale|'s [=MLOperand/shape=] and |input|'s [=MLOperand/shape=] returns false, then [=exception/throw=] a {{TypeError}}.
@@ -4271,8 +4271,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The output tensor that contains the quantized values.
 </div>
 
-<table id=constraints-quantizelinear class='data' link-for="MLGraphBuilder/quantizeLinear(input, scale, zeroPoint, options)">
-  <caption>Constraints for {{MLGraphBuilder/quantizeLinear()}}</caption>
+<table id=tensor-limits-quantizelinear class='data' link-for="MLGraphBuilder/quantizeLinear(input, scale, zeroPoint, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/quantizeLinear()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -4315,9 +4315,9 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=].{{MLGraphBuilder/[[hasBuilt]]}} is true, then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input|, |scale|, and |zeroPoint| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-quantizelinear)), then [=exception/throw=] a {{TypeError}}.
-    1. If |scale|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-quantizelinear)), then [=exception/throw=] a {{TypeError}}.
-    1. If |zeroPoint|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-quantizelinear)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-quantizelinear)), then [=exception/throw=] a {{TypeError}}.
+    1. If |scale|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-quantizelinear)), then [=exception/throw=] a {{TypeError}}.
+    1. If |zeroPoint|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-quantizelinear)), then [=exception/throw=] a {{TypeError}}.
     1. If |scale|'s [=MLOperand/rank=] or |zeroPoint|'s [=MLOperand/rank=] is not equal to |input|'s [=MLOperand/rank=], then [=exception/throw=] a {{TypeError}}.
     1. If |scale|'s [=MLOperand/shape=] is not [=list/equal=] to |zeroPoint|'s [=MLOperand/shape=], then [=exception/throw=] a {{TypeError}}.
     1. If [=blockwise broadcasting=] |scale|'s [=MLOperand/shape=] and |input|'s [=MLOperand/shape=] returns false, then [=exception/throw=] a {{TypeError}}.
@@ -4390,8 +4390,8 @@ partial dictionary MLOpSupportLimits {
         - an {{MLOperand}}. The output tensor of the same shape as {{MLGraphBuilder/elu(input, options)/input}}.
 </div>
 
-<table id=constraints-elu class='data' link-for="MLGraphBuilder/elu(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/elu()}}</caption>
+<table id=tensor-limits-elu class='data' link-for="MLGraphBuilder/elu(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/elu()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -4423,7 +4423,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-elu)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-elu)), then [=exception/throw=] a {{TypeError}}.
     1. Set |options|.{{MLEluOptions/alpha}} to the result of [=casting=] |options|.{{MLEluOptions/alpha}} to |input|'s [=MLOperand/dataType=].
     1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
@@ -4475,8 +4475,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The tensor with expanded size shape.
 </div>
 
-<table id=constraints-expand class='data' link-for="MLGraphBuilder/expand(input, newShape, options)">
-  <caption>Constraints for {{MLGraphBuilder/expand()}}</caption>
+<table id=tensor-limits-expand class='data' link-for="MLGraphBuilder/expand(input, newShape, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/expand()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -4510,7 +4510,7 @@ partial dictionary MLOpSupportLimits {
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
     1. Let |outputShape| be the result of [=unidirectionally broadcasting=] |input|'s [=MLOperand/shape=] and |newShape|.
         1. If that returns failure, then [=exception/throw=] a {{TypeError}}.
-    1. If |outputShape|'s [=list/size=] is not output tensor's [=/allowed ranks=] (according to [this table](#constraints-expand)), then [=exception/throw=] a {{TypeError}}.
+    1. If |outputShape|'s [=list/size=] is not output tensor's [=/allowed ranks=] (according to [this table](#tensor-limits-expand)), then [=exception/throw=] a {{TypeError}}.
     1. Let |outputDescriptor| be the result of [=creating an MLOperandDescriptor=] given |input|'s [=MLOperand/dataType=] and |outputShape|.
     1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |outputDescriptor|.
@@ -4565,8 +4565,8 @@ partial dictionary MLOpSupportLimits {
   The {{MLGraphBuilder/gather(input, indices, options)/indices}} parameter to {{MLGraphBuilder/gather()}} can not be clamped to the allowed range when the graph is built because the inputs are not known until execution. Implementations can introduce {{MLGraphBuilder/clamp()}} in the compiled graph if the specified clamping behavior is not provided by the underlying platform. Similarly, if the underlying platform does not support negative indices, the implementation can introduce operations in the compiled graph to transform a negative index from the end of the dimension into a positive index.
 </div>
 
-<table id=constraints-gather class='data' link-for="MLGraphBuilder/gather(input, indices, options)">
-  <caption>Constraints for {{MLGraphBuilder/gather()}}</caption>
+<table id=tensor-limits-gather class='data' link-for="MLGraphBuilder/gather(input, indices, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/gather()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -4613,7 +4613,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input| and |indices| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |indices|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-gather)), then [=exception/throw=] a {{TypeError}}.
+    1. If |indices|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-gather)), then [=exception/throw=] a {{TypeError}}.
     1. Let |inputShape| be |input|'s [=MLOperand/shape=] and |inputRank| be |input|'s [=MLOperand/rank=].
     1. Let |indicesShape| be |indices|'s [=MLOperand/shape=].
     1. Let |axis| be |options|.{{MLGatherOptions/axis}}.
@@ -4729,8 +4729,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The output N-D tensor of [=MLOperand/rank=] equal to {{MLGraphBuilder/gatherElements(input, indices, options)/input}}'s [=MLOperand/rank=].
 </div>
 
-<table id=constraints-gatherelements class='data' link-for="MLGraphBuilder/gatherElements(input, indices, options)">
-  <caption>Constraints for {{MLGraphBuilder/gatherElements()}}</caption>
+<table id=tensor-limits-gatherelements class='data' link-for="MLGraphBuilder/gatherElements(input, indices, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/gatherElements()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -4771,7 +4771,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input| and |indices| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |indices|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-gatherelements)), then [=exception/throw=] a {{TypeError}}.
+    1. If |indices|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-gatherelements)), then [=exception/throw=] a {{TypeError}}.
     1. If the [=MLOperand/rank=] of any of |input| or |indices| is not its [=/allowed rank=], then [=exception/throw=] a {{TypeError}}.
     1. Let |axis| be |options|.{{MLGatherOptions/axis}}.
     1. If |axis| is greater than or equal to |input|'s [=MLOperand/rank=], then [=exception/throw=] a {{TypeError}}.
@@ -4892,8 +4892,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The output N-D tensor of [=MLOperand/rank=] equal to the {{MLGraphBuilder/gatherND(input, indices, options)/input}}'s [=MLOperand/rank=] + {{MLGraphBuilder/gatherND(input, indices, options)/indices}}'s [=MLOperand/rank=] - {{MLGraphBuilder/gatherND(input, indices, options)/indices}}'s [=MLOperand/shape=][-1] - 1.
 </div>
 
-<table id=constraints-gathernd class='data' link-for="MLGraphBuilder/gatherND(input, indices, options)">
-  <caption>Constraints for {{MLGraphBuilder/gatherND()}}</caption>
+<table id=tensor-limits-gathernd class='data' link-for="MLGraphBuilder/gatherND(input, indices, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/gatherND()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -4934,7 +4934,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input| and |indices| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |indices|'s [=MLOperand/dataType=]'s is not one of the [=/allowed data types=] (according to [this table](#constraints-gathernd)), then [=exception/throw=] a {{TypeError}}.
+    1. If |indices|'s [=MLOperand/dataType=]'s is not one of the [=/allowed data types=] (according to [this table](#tensor-limits-gathernd)), then [=exception/throw=] a {{TypeError}}.
     1. If the [=MLOperand/rank=] of any of |input| or |indices| is not its [=/allowed rank=], then [=exception/throw=] a {{TypeError}}.
     1. Let |inputShape| be |input|'s [=MLOperand/shape=] and |inputRank| be |input|'s [=MLOperand/rank=].
     1. Let |indicesShape| be |indices|'s [=MLOperand/shape=] and |indicesRank| be |indices|'s [=MLOperand/rank=].
@@ -5084,8 +5084,8 @@ partial dictionary MLOpSupportLimits {
         - an {{MLOperand}}. The output tensor of the same shape as {{MLGraphBuilder/gelu(input, options)/input}}.
 </div>
 
-<table id=constraints-gelu class='data' link-for="MLGraphBuilder/gelu(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/gelu()}}</caption>
+<table id=tensor-limits-gelu class='data' link-for="MLGraphBuilder/gelu(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/gelu()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -5117,7 +5117,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-gelu)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-gelu)), then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Let |operator| be an [=operator=] for the "gelu" operation given |options|.
@@ -5205,8 +5205,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The output 2-D tensor of shape *[M, N]* that contains the calculated product of all the inputs.
 </div>
 
-<table id=constraints-gemm class='data' link-for="MLGraphBuilder/gemm(a, b, options)">
-  <caption>Constraints for {{MLGraphBuilder/gemm()}}</caption>
+<table id=tensor-limits-gemm class='data' link-for="MLGraphBuilder/gemm(a, b, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/gemm()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -5260,7 +5260,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |a| and |b| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If the [=MLOperand/dataType=] of any of |a| or |b| is not one of its [=/allowed data types=] (according to [this table](#constraints-gemm)), then [=exception/throw=] a {{TypeError}}.
+    1. If the [=MLOperand/dataType=] of any of |a| or |b| is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-gemm)), then [=exception/throw=] a {{TypeError}}.
     1. If the [=MLOperand/rank=] of any of |a| or |b| is not its [=/allowed rank=], then [=exception/throw=] a {{TypeError}}.
     1. Set |options|.{{MLGemmOptions/alpha}} to the result of [=casting=] |options|.{{MLGemmOptions/alpha}} to |a|'s [=MLOperand/dataType=].
     1. Set |options|.{{MLGemmOptions/beta}} to the result of [=casting=] |options|.{{MLGemmOptions/beta}} to |a|'s [=MLOperand/dataType=].
@@ -5271,7 +5271,7 @@ partial dictionary MLOpSupportLimits {
     1. If |shapeA|[1] is not equal to |shapeB|[0], then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLGemmOptions/c}} [=map/exists=], then:
         1. If it is not [=unidirectionally broadcastable=] to the shape « |shapeA|[0], |shapeB|[1] », then [=exception/throw=] a {{TypeError}}.
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-gemm)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-gemm)), then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| be the result of [=creating an MLOperandDescriptor=] given |a|'s [=MLOperand/dataType=] and « |shapeA|[0], |shapeB|[1] ».
     1. *Make graph connections:*
         1. Let |output| be the result of [=creating an MLOperand=] given [=this=] and |desc|.
@@ -5413,8 +5413,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** [=sequence=]<{{MLOperand}}>. The first element is a 3-D tensor of shape *[numDirections, batchSize, hiddenSize]*, the cell output from the last time step of the network. Additionally, if {{MLGruOptions/returnSequence}} is set to true, the second element is the 4-D output tensor of shape *[steps, numDirections, batchSize, hiddenSize]* containing every cell outputs from each time step in the temporal sequence.
 </div>
 
-<table id=constraints-gru class='data' link-for="MLGraphBuilder/gru(input, weight, recurrentWeight, steps, hiddenSize, options)">
-  <caption>Constraints for {{MLGraphBuilder/gru()}}</caption>
+<table id=tensor-limits-gru class='data' link-for="MLGraphBuilder/gru(input, weight, recurrentWeight, steps, hiddenSize, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/gru()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -5496,7 +5496,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input|, |weight|, |recurrentWeight|, |options|.{{MLGruOptions/bias}} (if it [=map/exists=]), |options|.{{MLGruOptions/recurrentBias}} (if it [=map/exists=]), and |options|.{{MLGruOptions/initialHiddenState}} (if it [=map/exists=]) returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If the [=MLOperand/dataType=] of any of |input|, |weight| or |recurrentWeight| is not one of its [=/allowed data types=] (according to [this table](#constraints-gru)), then [=exception/throw=] a {{TypeError}}.
+    1. If the [=MLOperand/dataType=] of any of |input|, |weight| or |recurrentWeight| is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-gru)), then [=exception/throw=] a {{TypeError}}.
     1. If the [=MLOperand/rank=] of any of |input|, |weight| or |recurrentWeight| is not its [=/allowed rank=], then [=exception/throw=] a {{TypeError}}.
     1. If |input|'s [=MLOperand/shape=][0] is not equal to |steps|, then [=exception/throw=] a {{TypeError}}.
     1. Let |batchSize| be |input|'s [=MLOperand/shape=][1].
@@ -5510,13 +5510,13 @@ partial dictionary MLOpSupportLimits {
           Some underlying platforms operate on a single bias tensor which is a concatenation of {{MLGruOptions/bias}} and {{MLGruOptions/recurrentBias}}. Therefore, 3 * |hiddenSize| + 3 * |hiddenSize| also needs to be a [=valid dimension=].
         </details>
     1. If |options|.{{MLGruOptions/bias}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-gru)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-gru)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/shape=] is not [=list/equal=] to « |numDirections|, 3 * |hiddenSize| », then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLGruOptions/recurrentBias}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-gru)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-gru)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/shape=] is not [=list/equal=] to « |numDirections|, 3 * |hiddenSize| », then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLGruOptions/initialHiddenState}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-gru)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-gru)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/shape=] is not [=list/equal=] to « |numDirections|, |batchSize|, |hiddenSize| », then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLGruOptions/activations}} [=map/exists=], then:
         1. If its [=list/size=] is not 2, then [=exception/throw=] a {{TypeError}}.
@@ -5743,8 +5743,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The 2-D tensor of shape *[batchSize, hiddenSize]*, the cell output hidden state of a single time step of the recurrent network.
 </div>
 
-<table id=constraints-gruCell class='data' link-for="MLGraphBuilder/gruCell(input, weight, recurrentWeight, hiddenState, hiddenSize, options)">
-  <caption>Constraints for {{MLGraphBuilder/gruCell()}}</caption>
+<table id=tensor-limits-gruCell class='data' link-for="MLGraphBuilder/gruCell(input, weight, recurrentWeight, hiddenState, hiddenSize, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/gruCell()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -5814,8 +5814,8 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input|, |weight|, |recurrentWeight|, |hiddenState|, |options|.{{MLGruCellOptions/bias}} (if it [=map/exists=]), and |options|.{{MLGruCellOptions/recurrentBias}} (if it [=map/exists=]) returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If the [=MLOperand/dataType=] of any of |input|, |weight|, |recurrentWeight|, or |hiddenState| is not one of its [=/allowed data types=] (according to [this table](#constraints-gruCell)), then [=exception/throw=] a {{TypeError}}.
-    1. If the [=MLOperand/rank=] of any of |input|, |weight|, |recurrentWeight| or |hiddenState| is not its [=/allowed ranks=] (according to [this table](#constraints-gruCell)), then [=exception/throw=] a {{TypeError}}.
+    1. If the [=MLOperand/dataType=] of any of |input|, |weight|, |recurrentWeight|, or |hiddenState| is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-gruCell)), then [=exception/throw=] a {{TypeError}}.
+    1. If the [=MLOperand/rank=] of any of |input|, |weight|, |recurrentWeight| or |hiddenState| is not its [=/allowed ranks=] (according to [this table](#tensor-limits-gruCell)), then [=exception/throw=] a {{TypeError}}.
     1. Let |batchSize| be |input|'s [=MLOperand/shape=][0].
     1. Let |inputSize| be |input|'s [=MLOperand/shape=][1].
     1. If |weight|'s [=MLOperand/shape=] is not [=list/equal=] to « 3 * |hiddenSize|, |inputSize| », then [=exception/throw=] a {{TypeError}}.
@@ -5827,10 +5827,10 @@ partial dictionary MLOpSupportLimits {
           Some underlying platforms operate on a single bias tensor which is a concatenation of {{MLGruCellOptions/bias}} and {{MLGruCellOptions/recurrentBias}}. Therefore, 3 * |hiddenSize| + 3 * |hiddenSize| also needs to be a [=valid dimension=].
         </details>
     1. If |options|.{{MLGruCellOptions/bias}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-gruCell)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-gruCell)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/shape=] is not [=list/equal=] to « 3 * |hiddenSize| », then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLGruCellOptions/recurrentBias}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-gruCell)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-gruCell)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/shape=] is not [=list/equal=] to « 3 * |hiddenSize| », then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLGruCellOptions/activations}} [=map/exists=], then:
         1. If its [=list/size=] is not 2, then [=exception/throw=] a {{TypeError}}.
@@ -5990,8 +5990,8 @@ partial dictionary MLOpSupportLimits {
         - an {{MLOperand}}. The output tensor of the same shape as {{MLGraphBuilder/hardSigmoid(input, options)/input}}.
 </div>
 
-<table id=constraints-hardSigmoid class='data' link-for="MLGraphBuilder/hardSigmoid(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/hardSigmoid()}}</caption>
+<table id=tensor-limits-hardSigmoid class='data' link-for="MLGraphBuilder/hardSigmoid(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/hardSigmoid()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -6023,7 +6023,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-hardSigmoid)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-hardSigmoid)), then [=exception/throw=] a {{TypeError}}.
     1. Set |options|.{{MLHardSigmoidOptions/alpha}} to the result of [=casting=] |options|.{{MLHardSigmoidOptions/alpha}} to |input|'s [=MLOperand/dataType=].
     1. Set |options|.{{MLHardSigmoidOptions/beta}} to the result of [=casting=] |options|.{{MLHardSigmoidOptions/beta}} to |input|'s [=MLOperand/dataType=].
     1. *Make graph connections:*
@@ -6075,8 +6075,8 @@ partial dictionary MLOpSupportLimits {
         - an {{MLOperand}}. The output tensor of the same shape as {{MLGraphBuilder/hardSwish(input, options)/input}}.
 </div>
 
-<table id=constraints-hardSwish class='data' link-for="MLGraphBuilder/hardSwish(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/hardSwish()}}</caption>
+<table id=tensor-limits-hardSwish class='data' link-for="MLGraphBuilder/hardSwish(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/hardSwish()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -6108,7 +6108,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-hardSwish)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-hardSwish)), then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Let |operator| be an [=operator=] for the "hardSwish" operation, given |options|.
@@ -6195,8 +6195,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The instance-normalized 4-D tensor of the same shape as {{MLGraphBuilder/instanceNormalization(input, options)/input}}.
 </div>
 
-<table id=constraints-instanceNormalization class='data' link-for="MLGraphBuilder/instanceNormalization(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/instanceNormalization()}}</caption>
+<table id=tensor-limits-instanceNormalization class='data' link-for="MLGraphBuilder/instanceNormalization(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/instanceNormalization()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -6250,15 +6250,15 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input|, |options|.{{MLInstanceNormalizationOptions/scale}} (if it [=map/exists=]), and |options|.{{MLInstanceNormalizationOptions/bias}} (if it [=map/exists=]) returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-instanceNormalization)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-instanceNormalization)), then [=exception/throw=] a {{TypeError}}.
     1. If |input|'s [=MLOperand/rank=] is not its [=/allowed rank=], then [=exception/throw=] a {{TypeError}}.
     1. Set |options|.{{MLInstanceNormalizationOptions/epsilon}} to the result of [=casting=] |options|.{{MLInstanceNormalizationOptions/epsilon}} to |input|'s [=MLOperand/dataType=].
     1. Let |axis| be 1 if |options|.{{MLInstanceNormalizationOptions/layout}} is {{MLInputOperandLayout/"nchw"}}, and 3 otherwise.
     1. If |options|.{{MLInstanceNormalizationOptions/scale}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-instanceNormalization)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-instanceNormalization)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/shape=] is not [=list/equal=] to « |input|'s [=MLOperand/shape=][|axis|] », then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLInstanceNormalizationOptions/bias}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-instanceNormalization)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-instanceNormalization)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/shape=] is not [=list/equal=] to « |input|'s [=MLOperand/shape=][|axis|] », then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
@@ -6348,8 +6348,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The layer-normalized N-D tensor of the same shape as {{MLGraphBuilder/layerNormalization(input, options)/input}}.
 </div>
 
-<table id=constraints-layerNormalization class='data' link-for="MLGraphBuilder/layerNormalization(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/layerNormalization()}}</caption>
+<table id=tensor-limits-layerNormalization class='data' link-for="MLGraphBuilder/layerNormalization(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/layerNormalization()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -6391,15 +6391,15 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input|, |options|.{{MLLayerNormalizationOptions/scale}} (if it [=map/exists=]), and |options|.{{MLLayerNormalizationOptions/bias}} (if it [=map/exists=]) returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-layerNormalization)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-layerNormalization)), then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLLayerNormalizationOptions/axes}} does not [=map/exist=], then set |options|.{{MLLayerNormalizationOptions/axes}} to a new [=/list=], either [=the range=] from 1 to |input|'s [=MLOperand/rank=], exclusive, if |input|'s [=MLOperand/rank=] is greater than 1, or an empty [=/list=] otherwise.
     1. Otherwise, if |options|.{{MLLayerNormalizationOptions/axes}} contains duplicate values, or if any of its [=list/items=] is not in [=the range=] 0 to |input|'s [=MLOperand/rank=], exclusive, then [=exception/throw=] a {{TypeError}}.
     1. Set |options|.{{MLLayerNormalizationOptions/epsilon}} to the result of [=casting=] |options|.{{MLLayerNormalizationOptions/epsilon}} to |input|'s [=MLOperand/dataType=].
     1. If |options|.{{MLLayerNormalizationOptions/scale}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-layerNormalization)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-layerNormalization)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/rank=] is not equal to |options|.{{MLLayerNormalizationOptions/axes}}'s [=list/size=], then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLLayerNormalizationOptions/bias}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-layerNormalization)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-layerNormalization)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/rank=] is not equal to |options|.{{MLLayerNormalizationOptions/axes}}'s [=list/size=], then [=exception/throw=] a {{TypeError}}.
     1. [=list/For each=] |index| in [=the range=] 0 to |options|.{{MLLayerNormalizationOptions/axes}}'s [=list/size=], exclusive:
         1. Let |axis| be |options|.{{MLLayerNormalizationOptions/axes}}[|index|].
@@ -6483,8 +6483,8 @@ partial dictionary MLOpSupportLimits {
         - an {{MLOperand}}. The output tensor of the same shape as {{MLGraphBuilder/leakyRelu(input, options)/input}}.
 </div>
 
-<table id=constraints-leakyRelu class='data' link-for="MLGraphBuilder/leakyRelu(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/leakyRelu()}}</caption>
+<table id=tensor-limits-leakyRelu class='data' link-for="MLGraphBuilder/leakyRelu(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/leakyRelu()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -6516,7 +6516,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-leakyRelu)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-leakyRelu)), then [=exception/throw=] a {{TypeError}}.
     1. Set |options|.{{MLLeakyReluOptions/alpha}} to the result of [=casting=] |options|.{{MLLeakyReluOptions/alpha}} to |input|'s [=MLOperand/dataType=].
     1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
@@ -6581,8 +6581,8 @@ partial dictionary MLOpSupportLimits {
         - an {{MLOperand}}. The output tensor of the same shape as {{MLGraphBuilder/linear(input, options)/input}}.
 </div>
 
-<table id=constraints-linear class='data' link-for="MLGraphBuilder/linear(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/linear()}}</caption>
+<table id=tensor-limits-linear class='data' link-for="MLGraphBuilder/linear(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/linear()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -6614,7 +6614,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-linear)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-linear)), then [=exception/throw=] a {{TypeError}}.
     1. Set |options|.{{MLLinearOptions/alpha}} to the result of [=casting=] |options|.{{MLLinearOptions/alpha}} to |input|'s [=MLOperand/dataType=].
     1. Set |options|.{{MLLinearOptions/beta}} to the result of [=casting=] |options|.{{MLLinearOptions/beta}} to |input|'s [=MLOperand/dataType=].
     1. *Make graph connections:*
@@ -6742,8 +6742,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** [=sequence=]<{{MLOperand}}>. The first element is a 3-D tensor of shape *[numDirections, batchSize, hiddenSize]*, the output hidden state from the last time step of the network. The second element is a 3-D tensor of shape *[numDirections, batchSize, hiddenSize]*, the output cell state from the last time step of the network. Additionally, if {{MLLstmOptions/returnSequence}} is set to true, the third element is the 4-D output tensor of shape *[steps, numDirections, batchSize, hiddenSize]* containing every output from each time step in the temporal sequence.
 </div>
 
-<table id=constraints-lstm class='data' link-for="MLGraphBuilder/lstm(input, weight, recurrentWeight, steps, hiddenSize, options)">
-  <caption>Constraints for {{MLGraphBuilder/lstm()}}</caption>
+<table id=tensor-limits-lstm class='data' link-for="MLGraphBuilder/lstm(input, weight, recurrentWeight, steps, hiddenSize, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/lstm()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -6847,7 +6847,7 @@ partial dictionary MLOpSupportLimits {
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input|, |weight|, |recurrentWeight|, |options|.{{MLLstmOptions/bias}} (if it [=map/exists=]), |options|.{{MLLstmOptions/recurrentBias}} (if it [=map/exists=]), |options|.{{MLLstmOptions/peepholeWeight}} (if it [=map/exists=]), |options|.{{MLLstmOptions/initialHiddenState}} (if it [=map/exists=]), and |options|.{{MLLstmOptions/initialCellState}} (if it [=map/exists=]) returns false, then [=exception/throw=] a {{TypeError}}.
     1. Let |numDirections| be 2 if |options|.{{MLLstmOptions/direction}} is {{MLRecurrentNetworkDirection/"both"}}, or 1 otherwise.
-    1. If the [=MLOperand/dataType=] of any of |input|, |weight| or |recurrentWeight| is not one of its [=/allowed data types=] (according to [this table](#constraints-lstm)), then [=exception/throw=] a {{TypeError}}.
+    1. If the [=MLOperand/dataType=] of any of |input|, |weight| or |recurrentWeight| is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-lstm)), then [=exception/throw=] a {{TypeError}}.
     1. If the [=MLOperand/rank=] of any of |input|, |weight| or |recurrentWeight| is not its [=/allowed rank=], then [=exception/throw=] a {{TypeError}}.
     1. If |steps| is 0, then [=exception/throw=] a {{TypeError}}.
     1. If |input|'s [=MLOperand/shape=][0] is not equal to |steps|, then [=exception/throw=] a {{TypeError}}.
@@ -6861,19 +6861,19 @@ partial dictionary MLOpSupportLimits {
           Some underlying platforms operate on a single bias tensor which is a concatenation of {{MLLstmOptions/bias}} and {{MLLstmOptions/recurrentBias}}. Therefore, 4 * |hiddenSize| + 4 * |hiddenSize| also needs to be a [=valid dimension=].
         </details>
     1. If |options|.{{MLLstmOptions/bias}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-lstm)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-lstm)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/shape=] is not [=list/equal=] to « |numDirections|, 4 * |hiddenSize| », then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLLstmOptions/recurrentBias}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-lstm)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-lstm)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/shape=] is not [=list/equal=] to « |numDirections|, 4 * |hiddenSize| », then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLLstmOptions/peepholeWeight}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-lstm)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-lstm)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/shape=] is not [=list/equal=] to « |numDirections|, 3 * |hiddenSize| », then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLLstmOptions/initialHiddenState}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-lstm)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-lstm)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/shape=] is not [=list/equal=] to « |numDirections|, |batchSize|, |hiddenSize| », then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLLstmOptions/initialCellState}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-lstm)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-lstm)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/shape=] is not [=list/equal=] to « |numDirections|, |batchSize|, |hiddenSize| », then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLLstmOptions/activations}} [=map/exists=], then:
         1. If its [=list/size=] is not 3, then [=exception/throw=] a {{TypeError}}.
@@ -7140,8 +7140,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** [=sequence=]<{{MLOperand}}>. The first element is the output hidden state of the current time step of the recurrent network. The following element is the output cell state. Both elements are 2-D tensors of shape *[batchSize, hiddenSize]*.
 </div>
 
-<table id=constraints-lstmCell class='data' link-for="MLGraphBuilder/lstmCell(input, weight, recurrentWeight, hiddenState, cellState, hiddenSize, options)">
-  <caption>Constraints for {{MLGraphBuilder/lstmCell()}}</caption>
+<table id=tensor-limits-lstmCell class='data' link-for="MLGraphBuilder/lstmCell(input, weight, recurrentWeight, hiddenState, cellState, hiddenSize, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/lstmCell()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -7237,7 +7237,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input|, |weight|, |recurrentWeight|, |hiddenState|, |cellState|, |options|.{{MLLstmCellOptions/bias}} (if it [=map/exists=]), |options|.{{MLLstmCellOptions/recurrentBias}} (if it [=map/exists=]), and |options|.{{MLLstmCellOptions/peepholeWeight}} (if it [=map/exists=]) returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If the [=MLOperand/dataType=] of any of |input|, |weight|, |recurrentWeight|, |hiddenState| or |cellState| is not one of its [=/allowed data types=] (according to [this table](#constraints-lstmCell)), then [=exception/throw=] a {{TypeError}}.
+    1. If the [=MLOperand/dataType=] of any of |input|, |weight|, |recurrentWeight|, |hiddenState| or |cellState| is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-lstmCell)), then [=exception/throw=] a {{TypeError}}.
     1. If the [=MLOperand/rank=] of any of |input|, |weight|, |recurrentWeight|, |hiddenState| or |cellState| is not its [=/allowed rank=], then [=exception/throw=] a {{TypeError}}.
     1. Let |batchSize| be |input|'s [=MLOperand/shape=][0].
     1. Let |inputSize| be |input|'s [=MLOperand/shape=][1].
@@ -7251,13 +7251,13 @@ partial dictionary MLOpSupportLimits {
           Some underlying platforms operate on a single bias tensor which is a concatenation of {{MLLstmCellOptions/bias}} and {{MLLstmCellOptions/recurrentBias}}. Therefore, 4 * |hiddenSize| + 4 * |hiddenSize| also needs to be a [=valid dimension=].
         </details>
     1. If |options|.{{MLLstmCellOptions/bias}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-lstmCell)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-lstmCell)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/shape=] is not [=list/equal=] to « 4 * |hiddenSize| », then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLLstmCellOptions/recurrentBias}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-lstmCell)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-lstmCell)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/shape=] is not [=list/equal=] to « 4 * |hiddenSize| », then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLLstmCellOptions/peepholeWeight}} [=map/exists=], then:
-        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-lstmCell)), then [=exception/throw=] a {{TypeError}}.
+        1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-lstmCell)), then [=exception/throw=] a {{TypeError}}.
         1. If its [=MLOperand/shape=] is not [=list/equal=] to « 3 * |hiddenSize| », then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLLstmCellOptions/activations}} [=map/exists=], then:
         1. If its [=list/size=] is not 3, then [=exception/throw=] a {{TypeError}}.
@@ -7436,8 +7436,8 @@ partial dictionary MLOpSupportLimits {
         - If either {{MLGraphBuilder/matmul(a, b, options)/a}} or {{MLGraphBuilder/matmul(a, b, options)/b}} is `N`-dimensional where `N > 2`, it is treated as a stack of matrices with dimensions corresponding to the last two indices. The matrix multiplication will be [=broadcast=] according to [[!numpy-broadcasting-rule]]. The shapes of {{MLGraphBuilder/matmul(a, b, options)/a}} and {{MLGraphBuilder/matmul(a, b, options)/b}}, except the last two dimensions, must be [=bidirectionally broadcastable=]. The output is a `N`-dimensional tensor whose rank is the maximum [=MLOperand/rank=] of the input tensors. For each dimension, except the last two, of the output tensor, its size is the maximum size along that dimension of the input tensors.
 </div>
 
-<table id=constraints-matmul class='data' link-for="MLGraphBuilder/matmul(a, b, options)">
-  <caption>Constraints for {{MLGraphBuilder/matmul()}}</caption>
+<table id=tensor-limits-matmul class='data' link-for="MLGraphBuilder/matmul(a, b, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/matmul()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -7474,7 +7474,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |a| and |b| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If the [=MLOperand/dataType=] of any of |a| or |b| is not one of its [=/allowed data types=] (according to [this table](#constraints-matmul)), then [=exception/throw=] a {{TypeError}}.
+    1. If the [=MLOperand/dataType=] of any of |a| or |b| is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-matmul)), then [=exception/throw=] a {{TypeError}}.
     1. *Calculate the output shape:*
         1. Let |shapeA| be a [=list/clone=] of |a|'s [=MLOperand/shape=].
         1. Let |rankA| be |a|'s [=MLOperand/rank=].
@@ -7549,8 +7549,8 @@ partial dictionary MLOpSupportLimits {
     `output size = beginning padding + input size + ending padding`
 </div>
 
-<table id=constraints-pad class='data' link-for="MLGraphBuilder/pad(input, beginningPadding, endingPadding, options)">
-  <caption>Constraints for {{MLGraphBuilder/pad()}}</caption>
+<table id=tensor-limits-pad class='data' link-for="MLGraphBuilder/pad(input, beginningPadding, endingPadding, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/pad()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -7746,8 +7746,8 @@ partial dictionary MLOpSupportLimits {
     `output size = ceil(1 + (input size - filter size + beginning padding + ending padding) / stride)`
 </div>
 
-<table id=constraints-pooling class='data' link-for="MLGraphBuilder/averagePool2d(input, options), MLGraphBuilder/l2Pool2d(input, options), MLGraphBuilder/maxPool2d(input, options)">
-  <caption>Constraints for pooling operations</caption>
+<table id=tensor-limits-pooling class='data' link-for="MLGraphBuilder/averagePool2d(input, options), MLGraphBuilder/l2Pool2d(input, options), MLGraphBuilder/maxPool2d(input, options)">
+  <caption>Tensor limits for pooling operations</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -7921,8 +7921,8 @@ partial dictionary MLOpSupportLimits {
         - an {{MLOperand}}. The output N-D tensor of [=MLOperand/rank=] equal to the maximum of {{MLGraphBuilder/prelu(input, slope, options)/input}}'s [=MLOperand/rank=] and {{MLGraphBuilder/prelu(input, slope, options)/slope}}'s [=MLOperand/rank=].
 </div>
 
-<table id=constraints-prelu class='data' link-for="MLGraphBuilder/prelu(input, slope, options)">
-  <caption>Constraints for {{MLGraphBuilder/prelu()}}</caption>
+<table id=tensor-limits-prelu class='data' link-for="MLGraphBuilder/prelu(input, slope, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/prelu()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -7968,7 +7968,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input| and |slope| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If the [=MLOperand/dataType=] of any of |input| or |slope| is not one of its [=/allowed data types=] (according to [this table](#constraints-prelu)), then [=exception/throw=] a {{TypeError}}.
+    1. If the [=MLOperand/dataType=] of any of |input| or |slope| is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-prelu)), then [=exception/throw=] a {{TypeError}}.
     1. Let |outputShape| be the result of [=bidirectionally broadcasting=] |slope|'s [=MLOperand/shape=] and |input|'s [=MLOperand/shape=].
         1. If that returns failure, then [=exception/throw=] a {{TypeError}}.
     1. Let |descriptor| be the result of [=creating an MLOperandDescriptor=] given |input|'s [=MLOperand/dataType=] and |outputShape|.
@@ -8058,8 +8058,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The output N-D tensor of [=MLOperand/rank=] in the range 0 to {{MLGraphBuilder/reduceL1(input, options)/input}}'s [=MLOperand/rank=], inclusive, depending on {{MLReduceOptions/axes}} and {{MLReduceOptions/keepDimensions}}. If the input operand is a scalar, the reduction function is applied to the scalar value, and the output is also a scalar.
 </div>
 
-<table id=constraints-reduction class='data' link-for="MLGraphBuilder/reduceL1(input, options), MLGraphBuilder/reduceL2(input, options), MLGraphBuilder/reduceLogSum(input, options), MLGraphBuilder/reduceLogSumExp(input, options), MLGraphBuilder/reduceMax(input, options), MLGraphBuilder/reduceMean(input, options), MLGraphBuilder/reduceMin(input, options), MLGraphBuilder/reduceProduct(input, options), MLGraphBuilder/reduceSum(input, options), MLGraphBuilder/reduceSumSquare(input, options)">
-  <caption>Constraints for reduction-operations</caption>
+<table id=tensor-limits-reduction class='data' link-for="MLGraphBuilder/reduceL1(input, options), MLGraphBuilder/reduceL2(input, options), MLGraphBuilder/reduceLogSum(input, options), MLGraphBuilder/reduceLogSumExp(input, options), MLGraphBuilder/reduceMax(input, options), MLGraphBuilder/reduceMean(input, options), MLGraphBuilder/reduceMin(input, options), MLGraphBuilder/reduceProduct(input, options), MLGraphBuilder/reduceSum(input, options), MLGraphBuilder/reduceSumSquare(input, options)">
+  <caption>Tensor limits for reduction-operations</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -8276,8 +8276,8 @@ partial dictionary MLOpSupportLimits {
         - an {{MLOperand}}. The output tensor of the same shape as {{MLGraphBuilder/relu(input, options)/input}}.
 </div>
 
-<table id=constraints-relu class='data' link-for="MLGraphBuilder/relu(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/relu()}}</caption>
+<table id=tensor-limits-relu class='data' link-for="MLGraphBuilder/relu(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/relu()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -8309,7 +8309,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-relu)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-relu)), then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Let |operator| be an [=operator=] for the "relu" operation, given |options|.
@@ -8426,8 +8426,8 @@ partial dictionary MLOpSupportLimits {
         The default value is [2, 3].
 </dl>
 
-<table id=constraints-resample2d class='data' link-for="MLGraphBuilder/resample2d(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/resample2d()}}</caption>
+<table id=tensor-limits-resample2d class='data' link-for="MLGraphBuilder/resample2d(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/resample2d()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -8459,7 +8459,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-resample2d)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-resample2d)), then [=exception/throw=] a {{TypeError}}.
     1. If |input|'s [=MLOperand/rank=] is not its [=/allowed rank=], then [=exception/throw=] a {{TypeError}}.
     1. If |options|.{{MLResample2dOptions/scales}} does not [=map/exist=], then set it to the [=/list=] « 1.0, 1.0 ».
     1. Otherwise, if any of its [=list/items=] is less than or equal to 0, or if its [=list/size=] is not 2, then [=exception/throw=] a {{TypeError}}.
@@ -8537,8 +8537,8 @@ partial dictionary MLOpSupportLimits {
     tensor is specified by {{MLGraphBuilder/reshape(input, newShape, options)/newShape}}.
 </div>
 
-<table id=constraints-reshape class='data' link-for="MLGraphBuilder/reshape(input, newShape, options)">
-  <caption>Constraints for {{MLGraphBuilder/reshape()}}</caption>
+<table id=tensor-limits-reshape class='data' link-for="MLGraphBuilder/reshape(input, newShape, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/reshape()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -8570,7 +8570,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |newShape|'s [=list/size=] is not output tensor's [=/allowed ranks=] (according to [this table](#constraints-reshape)), then [=exception/throw=] a {{TypeError}}.
+    1. If |newShape|'s [=list/size=] is not output tensor's [=/allowed ranks=] (according to [this table](#tensor-limits-reshape)), then [=exception/throw=] a {{TypeError}}.
     1. Let |outputShape| be an empty array of {{unsigned long}}.
     1. If |newShape|'s [=list/size=] is 0, then set |outputShape| to an empty [=/list=] for a scalar.
     1. If any [=list/item=] in |newShape| is not a [=valid dimension=], then [=exception/throw=] a {{TypeError}}.
@@ -8620,8 +8620,8 @@ partial dictionary MLOpSupportLimits {
         - an {{MLOperand}}. The output tensor of the same shape as {{MLGraphBuilder/reverse(input, options)/input}}.
 </div>
 
-<table id=constraints-reverse class='data' link-for="MLGraphBuilder/reverse(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/reverse()}}</caption>
+<table id=tensor-limits-reverse class='data' link-for="MLGraphBuilder/reverse(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/reverse()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -8653,7 +8653,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-reverse)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-reverse)), then [=exception/throw=] a {{TypeError}}.
     1. Let |inputRank| be |input|'s [=MLOperand/rank=].
     1. If |axes| is not given, then let |axes| be [=the range=] 0 to |inputRank|, exclusive.
     1. Otherwise, if |axes| contains duplicate values, or if any of its elements is not in [=the range=] 0 to |inputRank|, exclusive, then return failure.
@@ -8710,8 +8710,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The output N-D tensor of [=MLOperand/rank=] equal to {{MLGraphBuilder/scatterElements(input, indices, updates, options)/input}}'s [=MLOperand/rank=].
 </div>
 
-<table id=constraints-scatterelements class='data' link-for="MLGraphBuilder/scatterElements(input, indices, updates, options)">
-  <caption>Constraints for {{MLGraphBuilder/scatterElements()}}</caption>
+<table id=tensor-limits-scatterelements class='data' link-for="MLGraphBuilder/scatterElements(input, indices, updates, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/scatterElements()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -8769,7 +8769,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input| and |indices| and |updates| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |indices|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-scatterelements)), then [=exception/throw=] a {{TypeError}}.
+    1. If |indices|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-scatterelements)), then [=exception/throw=] a {{TypeError}}.
     1. If |updates|'s [=MLOperand/dataType=] is not equal to |input|'s [=MLOperand/dataType=], then [=exception/throw=] a {{TypeError}}.
     1. If the [=MLOperand/rank=] of any of |input|, |indices|, or |updates| is not its [=/allowed rank=], then [=exception/throw=] a {{TypeError}}.
     1. Let |axis| be |options|.{{MLScatterOptions/axis}}.
@@ -8923,8 +8923,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The output N-D tensor of [=MLOperand/rank=] equal to {{MLGraphBuilder/scatterND(input, indices, updates, options)/input}}'s [=MLOperand/rank=] + {{MLGraphBuilder/scatterND(input, indices, updates, options)/indices}}'s [=MLOperand/rank=] - {{MLGraphBuilder/scatterND(input, indices, updates, options)/indices}}'s [=MLOperand/shape=][-1] - 1.
 </div>
 
-<table id=constraints-scatternd class='data' link-for="MLGraphBuilder/scatterND(input, indices, updates, options)">
-  <caption>Constraints for {{MLGraphBuilder/scatterND()}}</caption>
+<table id=tensor-limits-scatternd class='data' link-for="MLGraphBuilder/scatterND(input, indices, updates, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/scatterND()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -8970,7 +8970,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input|, |indices|, and |updates| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |indices|'s [=MLOperand/dataType=]'s is not one of the [=/allowed data types=] (according to [this table](#constraints-scatternd)), then [=exception/throw=] a {{TypeError}}.
+    1. If |indices|'s [=MLOperand/dataType=]'s is not one of the [=/allowed data types=] (according to [this table](#tensor-limits-scatternd)), then [=exception/throw=] a {{TypeError}}.
     1. If |updates|'s [=MLOperand/dataType=] is not equal to |input|'s [=MLOperand/dataType=], then [=exception/throw=] a {{TypeError}}.
     1. If the [=MLOperand/rank=] of any of |input|, |indices|, or |updates| is not its [=/allowed rank=], then [=exception/throw=] a {{TypeError}}.
     1. Let |inputShape| be |input|'s [=MLOperand/shape=] and |inputRank| be |input|'s [=MLOperand/rank=].
@@ -9128,8 +9128,8 @@ partial dictionary MLOpSupportLimits {
         - an {{MLOperand}}. The output tensor of the same shape as {{MLGraphBuilder/sigmoid(input, options)/input}}.
 </div>
 
-<table id=constraints-sigmoid class='data' link-for="MLGraphBuilder/sigmoid(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/sigmoid()}}</caption>
+<table id=tensor-limits-sigmoid class='data' link-for="MLGraphBuilder/sigmoid(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/sigmoid()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -9161,7 +9161,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-sigmoid)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-sigmoid)), then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Let |operator| be an [=operator=] for the "sigmoid" operation, given |options|.
@@ -9227,8 +9227,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The output tensor of the same rank as the input tensor with tensor values stripped to the specified starting and ending indices in each dimension.
 </div>
 
-<table id=constraints-slice class='data' link-for="MLGraphBuilder/slice(input, starts, sizes, options)">
-  <caption>Constraints for {{MLGraphBuilder/slice()}}</caption>
+<table id=tensor-limits-slice class='data' link-for="MLGraphBuilder/slice(input, starts, sizes, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/slice()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -9317,8 +9317,8 @@ partial dictionary MLOpSupportLimits {
         - an {{MLOperand}}. The output N-D tensor that contains the softmax results, of the same shape as {{MLGraphBuilder/softmax(input, axis, options)/input}}.
 </div>
 
-<table id=constraints-softmax class='data' link-for="MLGraphBuilder/softmax(input, axis, options)">
-  <caption>Constraints for {{MLGraphBuilder/softmax()}}</caption>
+<table id=tensor-limits-softmax class='data' link-for="MLGraphBuilder/softmax(input, axis, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/softmax()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -9350,7 +9350,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-softmax)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-softmax)), then [=exception/throw=] a {{TypeError}}.
     1. If |axis| is greater than or equal to |input|'s [=MLOperand/rank=], then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
@@ -9405,8 +9405,8 @@ partial dictionary MLOpSupportLimits {
         - an {{MLOperand}}. The output tensor of the same shape as {{MLGraphBuilder/softplus(input, options)/input}}.
 </div>
 
-<table id=constraints-softplus class='data' link-for="MLGraphBuilder/softplus(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/softplus()}}</caption>
+<table id=tensor-limits-softplus class='data' link-for="MLGraphBuilder/softplus(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/softplus()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -9438,7 +9438,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-softplus)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-softplus)), then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Let |operator| be an [=operator=] for the "softplus" operation and |options|.
@@ -9498,8 +9498,8 @@ partial dictionary MLOpSupportLimits {
         - an {{MLOperand}}. The output tensor of the same shape as {{MLGraphBuilder/softsign(input, options)/input}}.
 </div>
 
-<table id=constraints-softsign class='data' link-for="MLGraphBuilder/softsign(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/softsign()}}</caption>
+<table id=tensor-limits-softsign class='data' link-for="MLGraphBuilder/softsign(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/softsign()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -9531,7 +9531,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-softsign)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-softsign)), then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Let |operator| be an [=operator=] for the "softsign" operation and |options|.
@@ -9581,8 +9581,8 @@ partial dictionary MLOpSupportLimits {
         The dimension along which to split. Its value must be in the range [0, N-1] where N is the [=MLOperand/rank=] of the input tensor.
 </dl>
 
-<table id=constraints-split class='data' link-for="MLGraphBuilder/split(input, splits, options)">
-  <caption>Constraints for {{MLGraphBuilder/split()}}</caption>
+<table id=tensor-limits-split class='data' link-for="MLGraphBuilder/split(input, splits, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/split()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -9697,8 +9697,8 @@ partial dictionary MLOpSupportLimits {
         - an {{MLOperand}}. The output tensor of the same shape as {{MLGraphBuilder/tanh(input, options)/input}}.
 </div>
 
-<table id=constraints-tanh class='data' link-for="MLGraphBuilder/tanh(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/tanh()}}</caption>
+<table id=tensor-limits-tanh class='data' link-for="MLGraphBuilder/tanh(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/tanh()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -9730,7 +9730,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#constraints-tanh)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-tanh)), then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Let |operator| be an [=operator=] for the "tanh" operation, given |options|.
@@ -9783,8 +9783,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The reversed N-D tensor.
 </div>
 
-<table id=constraints-tile class='data' link-for="MLGraphBuilder/tile(input, repetitions, options)">
-  <caption>Constraints for {{MLGraphBuilder/tile()}}</caption>
+<table id=tensor-limits-tile class='data' link-for="MLGraphBuilder/tile(input, repetitions, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/tile()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -9868,8 +9868,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The permuted or transposed N-D tensor.
 </div>
 
-<table id=constraints-transpose class='data' link-for="MLGraphBuilder/transpose(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/transpose()}}</caption>
+<table id=tensor-limits-transpose class='data' link-for="MLGraphBuilder/transpose(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/transpose()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -9951,8 +9951,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The output tensor representing a triangular matrix, or batch of matrices which is the same shape as the input.
 </div>
 
-<table id=constraints-triangular class='data' link-for="MLGraphBuilder/triangular(input, options)">
-  <caption>Constraints for {{MLGraphBuilder/triangular()}}</caption>
+<table id=tensor-limits-triangular class='data' link-for="MLGraphBuilder/triangular(input, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/triangular()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -9984,7 +9984,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/rank=] is not one of its [=/allowed ranks=] (according to [this table](#constraints-triangular)), then [=exception/throw=] a {{TypeError}}.
+    1. If |input|'s [=MLOperand/rank=] is not one of its [=/allowed ranks=] (according to [this table](#tensor-limits-triangular)), then [=exception/throw=] a {{TypeError}}.
     1. *Make graph connections:*
         1. Let |output| be the result of [=copying an MLOperand=] given |input|.
         1. Let |operator| be an [=operator=] for the "triangular" operation, given |options|.
@@ -10091,8 +10091,8 @@ partial dictionary MLOpSupportLimits {
     **Returns:** an {{MLOperand}}. The output tensor that contains the values selected element-wise from either the {{MLGraphBuilder/where(condition, trueValue, falseValue, options)/trueValue}} or the {{MLGraphBuilder/where(condition, trueValue, falseValue, options)/falseValue}} tensor.
 </div>
 
-<table id=constraints-where class='data' link-for="MLGraphBuilder/where(condition, trueValue, falseValue, options)">
-  <caption>Constraints for {{MLGraphBuilder/where()}}</caption>
+<table id=tensor-limits-where class='data' link-for="MLGraphBuilder/where(condition, trueValue, falseValue, options)">
+  <caption>Tensor limits for {{MLGraphBuilder/where()}}</caption>
   <thead>
     <tr>
       <th>operand</th>
@@ -10147,7 +10147,7 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |condition|, |trueValue|, and |falseValue| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If the [=MLOperand/dataType=] of any of |condition|, |trueValue|, or |falseValue| is not one of its [=/allowed data types=] (according to [this table](#constraints-where)), then [=exception/throw=] a {{TypeError}}.
+    1. If the [=MLOperand/dataType=] of any of |condition|, |trueValue|, or |falseValue| is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-where)), then [=exception/throw=] a {{TypeError}}.
     1. Let |outputShape| be the result of [=bidirectionally broadcasting=] |trueValue|'s [=MLOperand/shape=] and |falseValue|'s [=MLOperand/shape=].
         1. If that returns failure, then [=exception/throw=] a {{TypeError}}.
     1. Set |outputShape| to the result of [=bidirectionally broadcasting=] |condition|'s [=MLOperand/shape=] and |outputShape|.


### PR DESCRIPTION
This PR also supports rankRange for graph input, constant and output in opSupportLimits.

Fix #835


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/857.html" title="Last updated on Sep 16, 2025, 12:32 PM UTC (ad2f04b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/857/d23b701...huningxin:ad2f04b.html" title="Last updated on Sep 16, 2025, 12:32 PM UTC (ad2f04b)">Diff</a>