### PR TITLE
Add `roundEven` operator

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3583,6 +3583,7 @@ partial interface MLGraphBuilder {
   MLOperand log(MLOperand input, optional MLOperatorOptions options = {});
   MLOperand neg(MLOperand input, optional MLOperatorOptions options = {});
   MLOperand reciprocal(MLOperand input, optional MLOperatorOptions options = {});
+  MLOperand roundEven(MLOperand input, optional MLOperatorOptions options = {});
   MLOperand sin(MLOperand input, optional MLOperatorOptions options = {});
   MLOperand sign(MLOperand input, optional MLOperatorOptions options = {});
   MLOperand sqrt(MLOperand input, optional MLOperatorOptions options = {});
@@ -3600,6 +3601,7 @@ partial dictionary MLOpSupportLimits {
   MLSingleInputSupportLimits log;
   MLSingleInputSupportLimits neg;
   MLSingleInputSupportLimits reciprocal;
+  MLSingleInputSupportLimits roundEven;
   MLSingleInputSupportLimits sin;
   MLSingleInputSupportLimits sign;
   MLSingleInputSupportLimits sqrt;
@@ -3661,6 +3663,8 @@ partial dictionary MLOpSupportLimits {
     :: Support limits for operator {{MLGraphBuilder/neg()}}.
     : <dfn>reciprocal</dfn>
     :: Support limits for operator {{MLGraphBuilder/reciprocal()}}.
+    : <dfn>roundEven</dfn>
+    :: Support limits for operator {{MLGraphBuilder/roundEven()}}.
     : <dfn>sin</dfn>
     :: Support limits for operator {{MLGraphBuilder/sin()}}.
     : <dfn>sign</dfn>
@@ -3683,6 +3687,7 @@ partial dictionary MLOpSupportLimits {
         - *log*: Compute the natural logarithm of the input tensor, element-wise.
         - *neg*: Compute the numerical negative value of the input tensor, element-wise.
         - *reciprocal*: Compute the reciprocal of the input tensor, element-wise.
+        - *roundEven*: Round the input tensor with halves to the nearest even value, element-wise (e.g. [0.1, 0.9, 1.1, 1.9, -3.5, -2.5, -1.5, 1.5, 2.5, 3.5] yields [0.0, 1.0, 1.0, 2.0, -4.0, -2.0, -2.0, 2.0, 2.0, 4.0]).
         - *sin*: Compute the sine of the input tensor, element-wise.
         - *sign*: Compute the sign (-1, 0, 1) of the input tensor, element-wise, returning 1 if > 0, -1 if < 0, and 0 otherwise.
         - *sqrt*: Compute the square root of the input tensor, element-wise.
@@ -3693,7 +3698,7 @@ partial dictionary MLOpSupportLimits {
   <summary>
     To <dfn for="MLGraphBuilder" data-lt="element-wise-unary-op">create an element-wise unary operation</dfn> given [=string=] |op|, {{MLOperand}} |input|, optional [=/list=] |allowedDataTypes|, and |options|, run the following steps:
   </summary>
-    1. [=Assert=]: |op| is one of "abs", "ceil", "cos", "erf", "exp", "floor", "identity", "log", "neg", "reciprocal", "sin", "sign", "sqrt", "tan".
+    1. [=Assert=]: |op| is one of "abs", "ceil", "cos", "erf", "exp", "floor", "identity", "log", "neg", "reciprocal", "roundEven", "sin", "sign", "sqrt", "tan".
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
     1. If |allowedDataTypes| is given and it does not [=list/contain=] |input|'s [=MLOperand/dataType=], then [=exception/throw=] a {{TypeError}}.
@@ -3776,6 +3781,13 @@ partial dictionary MLOpSupportLimits {
     <div algorithm>
     The <dfn method for=MLGraphBuilder>reciprocal(|input|, |options|)</dfn> method steps are:
         1. Let |output| be the result of [=MLGraphBuilder/element-wise-unary-op|creating an element-wise unary operation=] given "reciprocal", |input|, « {{MLOperandDataType/"float32"}}, {{MLOperandDataType/"float16"}} », and |options|.
+            1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
+        1. Return |output|.
+    </div>
+
+    <div algorithm>
+    The <dfn method for=MLGraphBuilder>roundEven(|input|, |options|)</dfn> method steps are:
+        1. Let |output| be the result of [=MLGraphBuilder/element-wise-unary-op|creating an element-wise unary operation=] given "roundEven", |input|, « {{MLOperandDataType/"float32"}}, {{MLOperandDataType/"float16"}} », and |options|.
             1. If that [=exception/throws=] an error, then re-[=exception/throw=] the error.
         1. Return |output|.
     </div>
@@ -4103,7 +4115,6 @@ partial dictionary MLOpSupportLimits {
     <summary>
     The behavior of this operation can be [EMULATED]
     </summary>
-    This emulation relies on a pending `roundEven` operator in <#817>.
     <pre highlight="js">
     function quantizeLinear(builder, input, scale, zeroPoint, options) {
       // output = clamp(roundEven(input / scale) + zeroPoint, 0, 255)

--- a/index.bs
+++ b/index.bs
@@ -3609,7 +3609,7 @@ partial dictionary MLOpSupportLimits {
 };
 </script>
 
-<div dfn-for="MLGraphBuilder/abs(input, options), MLGraphBuilder/ceil(input, options), MLGraphBuilder/cos(input, options), MLGraphBuilder/erf(input, options), MLGraphBuilder/exp(input, options), MLGraphBuilder/floor(input, options), MLGraphBuilder/identity(input, options), MLGraphBuilder/log(input, options), MLGraphBuilder/neg(input, options), MLGraphBuilder/reciprocal(input, options), MLGraphBuilder/sin(input, options), MLGraphBuilder/sign(input, options), MLGraphBuilder/sqrt(input, options), MLGraphBuilder/tan(input, options)" dfn-type=argument>
+<div dfn-for="MLGraphBuilder/abs(input, options), MLGraphBuilder/ceil(input, options), MLGraphBuilder/cos(input, options), MLGraphBuilder/erf(input, options), MLGraphBuilder/exp(input, options), MLGraphBuilder/floor(input, options), MLGraphBuilder/identity(input, options), MLGraphBuilder/log(input, options), MLGraphBuilder/neg(input, options), MLGraphBuilder/reciprocal(input, options), MLGraphBuilder/roundEven(input, options), MLGraphBuilder/sin(input, options), MLGraphBuilder/sign(input, options), MLGraphBuilder/sqrt(input, options), MLGraphBuilder/tan(input, options)" dfn-type=argument>
     **Arguments:**
         - <dfn>input</dfn>: an {{MLOperand}}. The input tensor.
         - <dfn>options</dfn>: an {{MLOperatorOptions}}. Specifies the optional parameters of the operation.
@@ -3619,7 +3619,7 @@ partial dictionary MLOpSupportLimits {
     tensor is the same as the shape of input tensor.
 </div>
 
-<table id=constraints-elementwise-unary class='data' link-for="MLGraphBuilder/abs(input, options), MLGraphBuilder/ceil(input, options), MLGraphBuilder/cos(input, options), MLGraphBuilder/erf(input, options), MLGraphBuilder/exp(input, options), MLGraphBuilder/floor(input, options), MLGraphBuilder/identity(input, options), MLGraphBuilder/log(input, options), MLGraphBuilder/neg(input, options), MLGraphBuilder/reciprocal(input, options), MLGraphBuilder/sin(input, options), MLGraphBuilder/sign(input, options), MLGraphBuilder/sqrt(input, options), MLGraphBuilder/tan(input, options)">
+<table id=constraints-elementwise-unary class='data' link-for="MLGraphBuilder/abs(input, options), MLGraphBuilder/ceil(input, options), MLGraphBuilder/cos(input, options), MLGraphBuilder/erf(input, options), MLGraphBuilder/exp(input, options), MLGraphBuilder/floor(input, options), MLGraphBuilder/identity(input, options), MLGraphBuilder/log(input, options), MLGraphBuilder/neg(input, options), MLGraphBuilder/reciprocal(input, options), MLGraphBuilder/roundEven(input, options), MLGraphBuilder/sin(input, options), MLGraphBuilder/sign(input, options), MLGraphBuilder/sqrt(input, options), MLGraphBuilder/tan(input, options)">
   <caption>Constraints for element-wise unary options</caption>
   <thead>
     <tr>


### PR DESCRIPTION
- Fixes #817.
- Addresses incomplete `quantizeLinear` emulation step.

```diff
partial interface MLGraphBuilder
{
    ...
+   MLOperand roundEven(MLOperand input, optional MLOperatorOptions options = {});
    ...
};
```

## Mappings to backend functions:

`RHE` **r**ound **h**alves to nearest **e**ven:
- [DML ROUND](https://learn.microsoft.com/en-us/windows/win32/api/directml/ns-directml-dml_element_wise_round_operator_desc) with [DML_ROUNDING_MODE_HALVES_TO_NEAREST_EVEN](https://learn.microsoft.com/en-us/windows/win32/api/directml/ne-directml-dml_rounding_mode)
- [tfl.round (TFL::RoundOp)](https://www.tensorflow.org/mlir/tfl_ops#tflround_tflroundop) 🤔 \*It's not clearly documented for TFLite, but I'm presuming TFL follows TF in using RHE.
- [ONNX Round](https://onnx.ai/onnx/operators/onnx__Round.html)
- [PyTorch torch.round](https://pytorch.org/docs/stable/generated/torch.round.html)
- ❔[coremltools.converters.mil.mil.ops.defs.iOS15.elementwise_unary.round](https://apple.github.io/coremltools/source/coremltools.converters.mil.mil.ops.defs.html#coremltools.converters.mil.mil.ops.defs.iOS15.elementwise_unary.round) 🤔 \*From [Ningxin's investigation](https://github.com/webmachinelearning/webnn/issues/817#issuecomment-2833839764), CoreML's `round`ing mode behaves inconsistently depending on whether it goes through the NPU vs GPU, but it *should* be consistently emulatable via `elementwise_binary.sub(x, elementwise_binary.mod(x, 1.0f))`. 🤞


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fdwr/webnn/pull/859.html" title="Last updated on Jun 7, 2025, 2:35 AM UTC (697eaee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/859/61d4d5a...fdwr:697eaee.html" title="Last updated on Jun 7, 2025, 2:35 AM UTC (697eaee)">Diff</a>