### PR TITLE
Bugfix: Fix typos in dequantizeLinear's decomposition code

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3999,9 +3999,9 @@ partial dictionary MLOpSupportLimits {
     // - inputShape = [2,3,4,5,6] with axis = 2 yields shape [6,4,30].
     // - inputShape = [4] with axis = 0 yields shape [1,4,1].
     function getFlattenedShapeAroundAxis(inputShape, axis) {
-      axis = Math.max(Math.min(axis, input.shape.length - 1), 0);
+      axis = Math.max(Math.min(axis, inputShape.length - 1), 0);
       const shapeBefore = inputShape.slice(0, axis);
-      const shapeAfter = inputShape.slice(axis + 1, input.shape.length);
+      const shapeAfter = inputShape.slice(axis + 1, inputShape.length);
       const countBefore = shapeBefore.reduce((a, b) => a * b, 1);
       const countAfter = shapeAfter.reduce((a, b) => a * b, 1);
       return [countBefore, inputShape[axis], countAfter];


### PR DESCRIPTION
This PR is to fix #863.
@fdwr  @huningxin PTAL, thanks!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/BruceDai/webnn/pull/864.html" title="Last updated on Jun 9, 2025, 9:21 AM UTC (958095d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/864/61d4d5a...BruceDai:958095d.html" title="Last updated on Jun 9, 2025, 9:21 AM UTC (958095d)">Diff</a>