### PR TITLE
Bugfix: modify output's allowed data type as "uint8" for element-wise logical operations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3413,7 +3413,7 @@ partial dictionary MLOpSupportLimits {
   </tr>
   <tr>
     <td>*output*</td>
-    <td>[=/same type as|same as=] {{a}}</td>
+    <td>{{MLOperandDataType/"uint8"}}</td>
     <td>maximum of {{a}}'s [=MLOperand/rank=] and {{b}}'s [=MLOperand/rank=]</td>
   </tr>
 </table>


### PR DESCRIPTION
This pr is to fix #865.
@fdwr @huningxin PTAL, thanks!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/BruceDai/webnn/pull/866.html" title="Last updated on Jun 9, 2025, 9:41 AM UTC (33821f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/866/61d4d5a...BruceDai:33821f8.html" title="Last updated on Jun 9, 2025, 9:41 AM UTC (33821f8)">Diff</a>