### PR TITLE
Add a non-normative table of operators by category

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -736,6 +736,184 @@ Depending on the underlying platform, the user agent <span class=allow-2119>may<
 
 For a history and rationale of this design, please see the <a href="https://github.com/webmachinelearning/webnn/blob/master/device-selection-explainer.md">device selection explainer</a>.
 
+## Operators ## {#programming-model-operators}
+
+*This section is non-normative.*
+
+The WebNN API defines a set of operators required by well-known CNN and RNN, transformer and generative models that address key [[#usecases-application]]. The details of each operator are defined in the normative sections of this specification, in alphabetical order by the operator name. These operators are grouped into categories based on their functionality in the following non-normative table to give a functional overview of the API surface.
+
+<table id='operators' class='data'>
+  <caption>Operators by category</caption>
+  <thead>
+    <tr>
+      <th>Category</th>
+      <th>Operators​</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Tensor creation</td>
+      <td>
+      {{MLGraphBuilder/input()}},
+      {{MLGraphBuilder/constant(tensor)|constant()}}
+      </td>
+    </tr>
+    <tr>
+      <td>Tensor manipulation</td>
+      <td>
+      {{MLGraphBuilder/concat()}},
+      {{MLGraphBuilder/expand()}},
+      {{MLGraphBuilder/gather()}},
+      {{MLGraphBuilder/gatherElements()}},
+      {{MLGraphBuilder/scatterElements()}},
+      {{MLGraphBuilder/gatherND()}},
+      {{MLGraphBuilder/scatterND()}},
+      {{MLGraphBuilder/pad()}},
+      {{MLGraphBuilder/reshape()}},
+      {{MLGraphBuilder/slice()}},
+      {{MLGraphBuilder/split()}},
+      {{MLGraphBuilder/transpose()}},
+      {{MLGraphBuilder/resample2d()}},
+      {{MLGraphBuilder/reverse()}},
+      {{MLGraphBuilder/tile()}}
+      </td>
+    </tr>
+    <tr>
+      <td>Tensor quantization</td>
+      <td>
+      {{MLGraphBuilder/quantizeLinear()}},
+      {{MLGraphBuilder/dequantizeLinear()}}
+      </td>
+    </tr>
+    <tr>
+      <td>Tensor casting</td>
+      <td>
+      {{MLGraphBuilder/cast()}}
+      </td>
+    </tr>
+    <tr>
+      <td>Mathematics</td>
+      <td>
+      {{MLGraphBuilder/add()}},
+      {{MLGraphBuilder/sub()}},
+      {{MLGraphBuilder/mul()}},
+      {{MLGraphBuilder/div()}},
+      {{MLGraphBuilder/max()}},
+      {{MLGraphBuilder/min()}},
+      {{MLGraphBuilder/pow()}},
+      {{MLGraphBuilder/abs()}},
+      {{MLGraphBuilder/ceil()}},
+      {{MLGraphBuilder/cos()}},
+      {{MLGraphBuilder/erf()}},
+      {{MLGraphBuilder/exp()}},
+      {{MLGraphBuilder/floor()}},
+      {{MLGraphBuilder/identity()}},
+      {{MLGraphBuilder/log()}},
+      {{MLGraphBuilder/neg()}},
+      {{MLGraphBuilder/reciprocal()}},
+      {{MLGraphBuilder/sin()}},
+      {{MLGraphBuilder/sqrt()}},
+      {{MLGraphBuilder/tan()}},
+      {{MLGraphBuilder/sign()}},
+      {{MLGraphBuilder/roundEven()}}
+      </td>
+    </tr>
+    <tr>
+      <td>Logical</td>
+      <td>
+      {{MLGraphBuilder/equal()}},
+      {{MLGraphBuilder/notEqual()}},
+      {{MLGraphBuilder/greater()}},
+      {{MLGraphBuilder/greaterOrEqual()}},
+      {{MLGraphBuilder/lesser()}},
+      {{MLGraphBuilder/lesserOrEqual()}},
+      {{MLGraphBuilder/logicalNot()}},
+      {{MLGraphBuilder/where()}},
+      {{MLGraphBuilder/logicalAnd()}},
+      {{MLGraphBuilder/logicalOr()}},
+      {{MLGraphBuilder/logicalXor()}}
+      </td>
+    </tr>
+    <tr>
+      <td>Convolution</td>
+      <td>
+      {{MLGraphBuilder/conv2d()}},
+      {{MLGraphBuilder/convTranspose2d()}}
+      </td>
+    </tr>
+    <tr>
+      <td>Matrix multiplication</td>
+      <td>
+      {{MLGraphBuilder/matmul()}},
+      {{MLGraphBuilder/gemm()}}
+      </td>
+    </tr>
+    <tr>
+      <td>Pooling</td>
+      <td>
+      {{MLGraphBuilder/averagePool2d()}},
+      {{MLGraphBuilder/l2Pool2d()}},
+      {{MLGraphBuilder/maxPool2d()}}
+      </td>
+    </tr>
+    <tr>
+      <td>Activation</td>
+      <td>
+      {{MLGraphBuilder/clamp()}},
+      {{MLGraphBuilder/elu()}},
+      {{MLGraphBuilder/gelu()}},
+      {{MLGraphBuilder/hardSigmoid()}},
+      {{MLGraphBuilder/hardSwish()}},
+      {{MLGraphBuilder/leakyRelu()}},
+      {{MLGraphBuilder/linear()}},
+      {{MLGraphBuilder/prelu()}},
+      {{MLGraphBuilder/relu()}},
+      {{MLGraphBuilder/sigmoid()}},
+      {{MLGraphBuilder/softmax()}},
+      {{MLGraphBuilder/softplus()}},
+      {{MLGraphBuilder/softsign()}},
+      {{MLGraphBuilder/tanh()}},
+      {{MLGraphBuilder/triangular()}}
+      </td>
+    </tr>
+    <tr>
+      <td>Normalization</td>
+      <td>
+      {{MLGraphBuilder/batchNormalization()}},
+      {{MLGraphBuilder/instanceNormalization()}},
+      {{MLGraphBuilder/layerNormalization()}}
+      </td>
+    </tr>
+    <tr>
+      <td>Reduction</td>
+      <td>
+      {{MLGraphBuilder/argMin()}},
+      {{MLGraphBuilder/argMax()}},
+      {{MLGraphBuilder/reduceL1()}},
+      {{MLGraphBuilder/reduceL2()}},
+      {{MLGraphBuilder/reduceLogSum()}},
+      {{MLGraphBuilder/reduceLogSumExp()}},
+      {{MLGraphBuilder/reduceMax()}},
+      {{MLGraphBuilder/reduceMean()}},
+      {{MLGraphBuilder/reduceMin()}},
+      {{MLGraphBuilder/reduceProduct()}},
+      {{MLGraphBuilder/reduceSum()}},
+      {{MLGraphBuilder/reduceSumSquare()}},
+      {{MLGraphBuilder/cumulativeSum()}}
+      </td>
+    </tr>
+    <tr>
+      <td>Recurrent Neural Networks</td>
+      <td>
+      {{MLGraphBuilder/gruCell()}},
+      {{MLGraphBuilder/gru()}},
+      {{MLGraphBuilder/lstmCell()}},
+      {{MLGraphBuilder/lstm()}}
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 ## Task Source ## {#programming-model-task-source}
 
 The <dfn>ML task source</dfn> is a [=task source=] to be used for all [=tasks=] related to asynchronous compilation and execution of {{MLGraph}}s and creation of {{MLContext}}s.


### PR DESCRIPTION
This non-normative table with functional grouping of operators complements the normative definition of operators that are currently in alphabetical order.

I tried to check we're covering all the operators, but it is very likely I may have missed some. I proactively added `roundEven` #859. Feedback welcome whether this makes sense and what would make for a good categorization.

The caveat is this table needs to be manually maintained alongside the normative definition, but that'd be just one extra line.