### PR TITLE
Bugfix: Only allow 1 to N rank input for operators that take 1 axis

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2243,7 +2243,7 @@ partial dictionary MLOpSupportLimits {
   <tr>
     <td>{{input}}</td>
     <td>[=/any data type|any=]</td>
-    <td>[=/any rank|N=]</td>
+    <td>1 to [=/any rank|N=]</td>
   </tr>
   <tr>
     <td>*output*</td>
@@ -2267,6 +2267,7 @@ partial dictionary MLOpSupportLimits {
     1. [=Assert=]: |op| is one of "argMin", "argMax".
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
+    1. If |axis| is greater than or equal to |input|'s [=MLOperand/rank=], then [=exception/throw=] a {{TypeError}}.
     1. If |input|'s [=MLOperand/shape=][|axis|] is greater than |options|.{{MLArgMinMaxOptions/outputDataType}}'s maximum value, then [=exception/throw=] a {{TypeError}}.
     1. Let |outputShape| be the result of [=MLGraphBuilder/calculating reduction output sizes=] given |input|'s [=MLOperand/shape=], « |axis| », and |options|.{{MLArgMinMaxOptions/keepDimensions}}. If that returns failure, then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| be the result of [=creating an MLOperandDescriptor=] given |options|.{{MLArgMinMaxOptions/outputDataType}} and |outputShape|.
@@ -2369,7 +2370,7 @@ partial dictionary MLOpSupportLimits {
   <tr>
     <td>{{input}}</td>
     <td>{{MLOperandDataType/"float32"}}, {{MLOperandDataType/"float16"}}</td>
-    <td>[=/any rank|N=]</td>
+    <td>1 to [=/any rank|N=]</td>
   </tr>
   <tr>
     <td>{{mean}}</td>
@@ -2753,7 +2754,7 @@ partial dictionary MLOpSupportLimits {
   <tr>
     <td>{{inputs}}'s [=list/items=]</td>
     <td>[=/any data type|any=]</td>
-    <td>[=/any rank|N=]</td>
+    <td>1 to [=/any rank|N=]</td>
   </tr>
   <tr>
     <td>*output*</td>
@@ -3307,7 +3308,7 @@ partial dictionary MLOpSupportLimits {
   <tr>
     <td>{{input}}</td>
     <td>[=/any data type|any=]</td>
-    <td>[=/any rank|N=]</td>
+    <td>1 to [=/any rank|N=]</td>
   </tr>
   <tr>
     <td>*output*</td>
@@ -4579,7 +4580,7 @@ partial dictionary MLOpSupportLimits {
   <tr>
     <td>{{input}}</td>
     <td>[=/any data type|any=]</td>
-    <td>[=/any rank|N=]</td>
+    <td>1 to [=/any rank|N=]</td>
   </tr>
   <tr>
     <td>{{indices}}</td>
@@ -9318,7 +9319,7 @@ partial dictionary MLOpSupportLimits {
   <tr>
     <td>{{input}}</td>
     <td>{{MLOperandDataType/"float32"}}, {{MLOperandDataType/"float16"}}</td>
-    <td>[=/any rank|N=]</td>
+    <td>1 to [=/any rank|N=]</td>
   </tr>
   <tr>
     <td>*output*</td>
@@ -9582,7 +9583,7 @@ partial dictionary MLOpSupportLimits {
   <tr>
     <td>{{input}}</td>
     <td>[=/any data type|any=]</td>
-    <td>[=/any rank|N=]</td>
+    <td>1 to [=/any rank|N=]</td>
   </tr>
   <tr>
     <td>*outputs*</td>


### PR DESCRIPTION
Only allow 1 to N rank input operand for `argMin`, `argMax`, `batchNormalization`, `concat`, `cumulativeSum`, `gather`, `softmax` and `split` operators that take 1 axis.

@fdwr and @reillyeon  , PTAL. 

/cc @miaobin

Fix #873


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/882.html" title="Last updated on Aug 27, 2025, 3:05 AM UTC (a4e0745)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/882/2c0f3a0...huningxin:a4e0745.html" title="Last updated on Aug 27, 2025, 3:05 AM UTC (a4e0745)">Diff</a>