### PR TITLE
Correct pad scalar rank inconsistency

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7580,7 +7580,6 @@ partial dictionary MLOpSupportLimits {
   </summary>
     1. If [=this=] [=MLGraphBuilder/can not build=], then [=exception/throw=] an "{{InvalidStateError}}" {{DOMException}}.
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and |input| returns false, then [=exception/throw=] a {{TypeError}}.
-    1. If |input|'s [=MLOperand/rank=] is 0, then [=exception/throw=] a {{TypeError}}.
     1. If |beginningPadding|'s [=list/size=] and |endingPadding|'s [=list/size=] are not both equal to |input|'s [=MLOperand/rank=], then [=exception/throw=] a {{TypeError}}.
     1. Let |desc| be a copy of |input|.{{MLOperand/[[descriptor]]}}.
     1. Let |outputShape| be a copy of |input|'s [=MLOperand/shape=].


### PR DESCRIPTION
Fixes #893. The spec says pad's `opSupportLimits` support input ranks from 0 to N, and the Chromium implementation [see PR](https://chromium-review.googlesource.com/c/chromium/src/+/6972256/9/services/webnn/ort/context_impl_ort.cc#224) supports scalar `pad` (acts as nop, like an empty `transpose` or `tile` would), but this one algorithm step says it doesn't. So, resolve the inconsistency by deleting that line.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fdwr/webnn/pull/894.html" title="Last updated on Sep 30, 2025, 6:02 AM UTC (43fe777)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/894/a3e8163...fdwr:43fe777.html" title="Last updated on Sep 30, 2025, 6:02 AM UTC (43fe777)">Diff</a>