### PR TITLE
Restrict scale's values of dequantizeLinear and quantizeLinear to be positive and nonzero

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4106,7 +4106,7 @@ partial dictionary MLOpSupportLimits {
 <div dfn-for="MLGraphBuilder/dequantizeLinear(input, scale, zeroPoint, options)" dfn-type=argument>
     **Arguments:**
         - <dfn>input</dfn>: an {{MLOperand}}. The input tensor.
-        - <dfn>scale</dfn>: an {{MLOperand}}. The scale tensor to multiply each input value by after adjusting by the zero point. It must be [=blockwise broadcastable=] with the input. Values must be positive and nonzero, or else the behavior is [=implementation-defined=] (e.g. correct results, incorrect results or compilation failure).
+        - <dfn>scale</dfn>: an {{MLOperand}}. The scale tensor to multiply each input value by after adjusting by the zero point. It must be [=blockwise broadcastable=] with the input. Values must be positive and nonzero, or else the behavior is [=implementation-defined=] (e.g. correct results, incorrect results, or compilation failure).
         - <dfn>zeroPoint</dfn>: an {{MLOperand}}. The zero point tensor to subtract from each input value. It has the same [=MLOperand/shape=] as the scale.
         - <dfn>options</dfn>: an {{MLOperatorOptions}}. Specifies the optional parameters of the operation.
 
@@ -4280,7 +4280,7 @@ partial dictionary MLOpSupportLimits {
 <div dfn-for="MLGraphBuilder/quantizeLinear(input, scale, zeroPoint, options)" dfn-type=argument>
     **Arguments:**
         - <dfn>input</dfn>: an {{MLOperand}}. The input tensor.
-        - <dfn>scale</dfn>: an {{MLOperand}}. The scale tensor to divide each input value by before adjusting by the zero point. It must be [=blockwise broadcastable=] with the input. Values must be positive and nonzero, or else behaviors are implementation dependent (e.g. correct results, incorrect results, compilation failure).
+        - <dfn>scale</dfn>: an {{MLOperand}}. The scale tensor to divide each input value by before adjusting by the zero point. It must be [=blockwise broadcastable=] with the input. Values must be positive and nonzero, or else behaviors are implementation dependent (e.g. correct results, incorrect results, or compilation failure).
         - <dfn>zeroPoint</dfn>: an {{MLOperand}}. The zero point tensor to add to each rescaled input value. It has the same [=MLOperand/shape=] as the scale.
         - <dfn>options</dfn>: an {{MLOperatorOptions}}. Specifies the optional parameters of the operation.
 


### PR DESCRIPTION
This is a Spec change PR for #879 where we're discussing about the lack of widespread support for the current negative scale of `dequantizeLinear` and `quantizeLinear` across all backend.

@fdwr @reillyeon @huningxin PTAL, thanks!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/BruceDai/webnn/pull/906.html" title="Last updated on Jan 16, 2026, 8:38 AM UTC (eab6604)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/906/be76e5d...BruceDai:eab6604.html" title="Last updated on Jan 16, 2026, 8:38 AM UTC (eab6604)">Diff</a>