### PR TITLE
Clarify division operator rounding

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8436,6 +8436,7 @@ partial dictionary MLOpSupportLimits {
             vy1 = vx0y1 * (1 - tx) + vx1y1 * tx
             output tensor value = vy0 * (1 - ty) + vy1 * ty
             ```
+
         </dl>
 
     : <dfn>scales</dfn>


### PR DESCRIPTION
Minor clarification that `div` expects to round toward zero (truncation), rather than say being floored to [negative zero like Numpy's floor_divide](https://numpy.org/doc/stable/reference/generated/numpy.floor_divide.html).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fdwr/webnn/pull/909.html" title="Last updated on Dec 9, 2025, 4:55 PM UTC (15b10be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/909/7952cc2...fdwr:15b10be.html" title="Last updated on Dec 9, 2025, 4:55 PM UTC (15b10be)">Diff</a>