### PR TITLE
fix reduceLogSumExp, softplus, and tanh decompositions to not overflow so easily

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9487,8 +9487,7 @@ partial dictionary MLOpSupportLimits {
     </summary>
     <pre highlight="js">
     function softplus(builder, input) {
-      return builder.log(
-        builder.add(builder.exp(input), builder.constant(input.dataType, 1)));
+      return builder.add(input, builder.log(builder.add(builder.constant(input.dataType, 1), builder.exp(builder.neg(input)))));
     }
     </pre>
   </details>

--- a/index.bs
+++ b/index.bs
@@ -9778,13 +9778,13 @@ partial dictionary MLOpSupportLimits {
     </summary>
     <pre highlight="js">
     function tanh(builder, input) {
-      return builder.div(
+      return builder.mul(builder.sign(input), builder.div(
         builder.sub(
           builder.constant(input.dataType, 1),
-          builder.exp(builder.mul(builder.constant(input.dataType, -2), input))),
+          builder.exp(builder.mul(builder.constant(input.dataType, -2), builder.abs(input)))),
         builder.add(
           builder.constant(input.dataType, 1),
-          builder.exp(builder.mul(builder.constant(input.dataType, -2), input))));
+          builder.exp(builder.mul(builder.constant(input.dataType, -2), builder.abs(input))))));
     }
     </pre>
   </details>

--- a/index.bs
+++ b/index.bs
@@ -9780,11 +9780,11 @@ partial dictionary MLOpSupportLimits {
     function tanh(builder, input) {
       return builder.div(
         builder.sub(
-          builder.exp(builder.mul(builder.constant(input.dataType, 2), input)),
-          builder.constant(input.dataType, 1)),
+          builder.constant(input.dataType, 1),
+          builder.exp(builder.mul(builder.constant(input.dataType, -2), input))),
         builder.add(
-          builder.exp(builder.mul(builder.constant(input.dataType, 2), input)),
-          builder.constant(input.dataType, 1)));
+          builder.constant(input.dataType, 1),
+          builder.exp(builder.mul(builder.constant(input.dataType, -2), input))));
     }
     </pre>
   </details>

--- a/index.bs
+++ b/index.bs
@@ -9487,7 +9487,7 @@ partial dictionary MLOpSupportLimits {
     </summary>
     <pre highlight="js">
     function softplus(builder, input) {
-      return builder.add(input, builder.log(builder.add(builder.constant(input.dataType, 1), builder.exp(builder.neg(input)))));
+      return builder.add(builder.max(input, builder.constant(input.dataType, 0)), builder.log(builder.add(builder.constant(input.dataType, 1), builder.exp(builder.neg(builder.abs(input))))));
     }
     </pre>
   </details>

--- a/index.bs
+++ b/index.bs
@@ -8270,7 +8270,8 @@ partial dictionary MLOpSupportLimits {
     }
 
     function reduceLogSumExp(builder, input, options) {
-      return builder.log(builder.reduceSum(builder.exp(input), options));
+      const maxX = builder.reduceMax(input, {axes: options.axes, keepDimensions: true});
+      return builder.add(maxX, builder.log(builder.reduceSum(builder.exp(builder.sub(input, maxX)), options)));
     }
 
     function reduceSumSquare(builder, input, options) {


### PR DESCRIPTION
test case:
reduceLogSumExp([89]) should give 89, not Infinity


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/vmukhachev/webnn/pull/916.html" title="Last updated on Jan 13, 2026, 9:46 PM UTC (5e297be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/916/91745cf...vmukhachev:5e297be.html" title="Last updated on Jan 13, 2026, 9:46 PM UTC (5e297be)">Diff</a>