### PR TITLE
Add explicit start and end dates for the changelog

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -23,7 +23,7 @@ Deadline: 2026-03-22
 Assume Explicit For: yes
 Complain About: accidental-2119 yes
 Status Text: <p>
-  Since <a href="https://www.w3.org/TR/2024/CR-webnn-20240411/">Candidate Recommendation Snapshot, 11 April 2024</a>, the WebNN specification has undergone substantial evolution with over 100 significant changes. The most notable additions include a third wave of operators for enhanced transformers support, the MLTensor API for buffer sharing, and a new abstract device selection mechanism. The API surface has been modernized and interoperability improvements have been made informed by wider implementation experience and developer feedback. This specification version strengthens security and privacy considerations including fingerprinting mitigations, and adds new accessibility considerations. These changes reflect the specification's maturation toward product readiness with improved developer ergonomics, wider backend compatibility, and standards compliance. For more details, see [[#changes]].
+  Between Candidate Recommendation Snapshot <a href="https://www.w3.org/TR/2024/CR-webnn-20240411/">11 April 2024</a> and <a href="https://www.w3.org/TR/2026/CR-webnn-20260122/">22 January 2026</a>, the WebNN specification has undergone substantial evolution with over 100 significant changes. The most notable additions include a third wave of operators for enhanced transformers support, the MLTensor API for buffer sharing, and a new abstract device selection mechanism. The API surface has been modernized and interoperability improvements have been made informed by wider implementation experience and developer feedback. This specification version strengthens security and privacy considerations including fingerprinting mitigations, and adds new accessibility considerations. These changes reflect the specification's maturation toward product readiness with improved developer ergonomics, wider backend compatibility, and standards compliance. For more details, see [[#changes]].
   </p>
   <p>This document is maintained and updated at any time. Some parts of this document are work in progress and further improvements are expected to be reflected in revised Candidate Recommendation Drafts and Snapshots.</p>
   <p>Before requesting transition to <a href="https://www.w3.org/standards/types#PR">Proposed Recommendation</a>, the Working Group will seek to demonstrate that:</p>
@@ -10587,7 +10587,7 @@ Thanks to Fuqiao Xue and the W3C Internationalization Activity for reviews and s
 This section documents changes made to this specification since its previous major publication in terms of <a href="https://www.w3.org/policies/process/#correction-classes">Classes of Changes</a>.
 
     <details>
-    <summary>Detailed changes since <a href="https://www.w3.org/TR/2024/CR-webnn-20240411/">Candidate Recommendation Snapshot, 11 April 2024</a></summary>
+    <summary>Detailed changes between Candidate Recommendation Snapshot <a href="https://www.w3.org/TR/2024/CR-webnn-20240411/">11 April 2024</a> and <a href="https://www.w3.org/TR/2026/CR-webnn-20260122/">22 January 2026</a></summary>
 
     <p>New features (<a href="https://www.w3.org/policies/process/#class-4">class 4</a>)</p>
     <ul>


### PR DESCRIPTION
We are expected to provide a changelog at CRS publication time. Between CRS publications, we will rely on git commit logs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/pull/918.html" title="Last updated on Jan 23, 2026, 11:19 AM UTC (a99faf0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/918/50ec174...a99faf0.html" title="Last updated on Jan 23, 2026, 11:19 AM UTC (a99faf0)">Diff</a>