### PR TITLE
Bugfix: Add missing data type validations for QDQ ops

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4181,6 +4181,7 @@ partial dictionary MLOpSupportLimits {
     1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-dequantizelinear)), then [=exception/throw=] a {{TypeError}}.
     1. If |scale|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-dequantizelinear)), then [=exception/throw=] a {{TypeError}}.
     1. If |zeroPoint|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-dequantizelinear)), then [=exception/throw=] a {{TypeError}}.
+    1. If |zeroPoint|'s [=MLOperand/dataType=] is not equal to |input|'s [=MLOperand/dataType=], then [=exception/throw=] a {{TypeError}}.
     1. If |scale|'s [=MLOperand/rank=] or |zeroPoint|'s [=MLOperand/rank=] is not equal to |input|'s [=MLOperand/rank=], then [=exception/throw=] a {{TypeError}}.
     1. If |scale|'s [=MLOperand/shape=] is not [=list/equal=] to |zeroPoint|'s [=MLOperand/shape=], then [=exception/throw=] a {{TypeError}}.
     1. If [=blockwise broadcasting=] |scale|'s [=MLOperand/shape=] and |input|'s [=MLOperand/shape=] returns false, then [=exception/throw=] a {{TypeError}}.
@@ -4343,6 +4344,7 @@ partial dictionary MLOpSupportLimits {
     1. If [=MLGraphBuilder/validating operand=] with [=this=] and any of |input|, |scale|, and |zeroPoint| returns false, then [=exception/throw=] a {{TypeError}}.
     1. If |input|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-quantizelinear)), then [=exception/throw=] a {{TypeError}}.
     1. If |scale|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-quantizelinear)), then [=exception/throw=] a {{TypeError}}.
+    1. If |scale|'s [=MLOperand/dataType=] is not equal to |input|'s [=MLOperand/dataType=], then [=exception/throw=] a {{TypeError}}.
     1. If |zeroPoint|'s [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-quantizelinear)), then [=exception/throw=] a {{TypeError}}.
     1. If |scale|'s [=MLOperand/rank=] or |zeroPoint|'s [=MLOperand/rank=] is not equal to |input|'s [=MLOperand/rank=], then [=exception/throw=] a {{TypeError}}.
     1. If |scale|'s [=MLOperand/shape=] is not [=list/equal=] to |zeroPoint|'s [=MLOperand/shape=], then [=exception/throw=] a {{TypeError}}.


### PR DESCRIPTION
Validate zeroPoint's data type is the same as input's for dequantizeLinear. 
Validate scale's data type is the same as input's for quantizeLinear.

Fix: #921


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/huningxin/webnn/pull/922.html" title="Last updated on Mar 2, 2026, 2:32 AM UTC (33c62f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/922/0bf77c7...huningxin:33c62f3.html" title="Last updated on Mar 2, 2026, 2:32 AM UTC (33c62f3)">Diff</a>