### PR TITLE
Validate output channels are a multiple of groups in conv2d

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3054,6 +3054,7 @@ partial dictionary MLOpSupportLimits {
             </dl>
         1. If |inputChannels| % |options|.{{MLConv2dOptions/groups}} is not 0, then [=exception/throw=] a {{TypeError}}.
         1. Otherwise, if |inputChannels| / |options|.{{MLConv2dOptions/groups}} is not equal to |filterInputChannels|, then [=exception/throw=] a {{TypeError}}.
+        1. If |outputChannels| % |options|.{{MLConv2dOptions/groups}} is not 0, then [=exception/throw=] a {{TypeError}}.
         1. If |options|.{{MLConv2dOptions/bias}} [=map/exists=], then:
             1. If its [=MLOperand/shape=] is not [=list/equal=] to « |outputChannels| », then [=exception/throw=] a {{TypeError}}.
             1. If its [=MLOperand/dataType=] is not one of its [=/allowed data types=] (according to [this table](#tensor-limits-conv2d)), then [=exception/throw=] a {{TypeError}}.


### PR DESCRIPTION
This PR addresses #925.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lynne0326/webnn/pull/932.html" title="Last updated on May 8, 2026, 12:27 AM UTC (da81815)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/932/db1e51c...lynne0326:da81815.html" title="Last updated on May 8, 2026, 12:27 AM UTC (da81815)">Diff</a>