### PR TITLE
Add roundEven(), isNaN(), isInfinite() to Operators

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -845,6 +845,7 @@ Note: Some operators belong to multiple categories. For example, {{MLGraphBuilde
       {{MLGraphBuilder/log()}},
       {{MLGraphBuilder/neg()}},
       {{MLGraphBuilder/reciprocal()}},
+      {{MLGraphBuilder/roundEven()}},
       {{MLGraphBuilder/sin()}},
       {{MLGraphBuilder/sqrt()}},
       {{MLGraphBuilder/tan()}},
@@ -865,7 +866,9 @@ Note: Some operators belong to multiple categories. For example, {{MLGraphBuilde
       {{MLGraphBuilder/logicalNot()}},
       {{MLGraphBuilder/logicalAnd()}},
       {{MLGraphBuilder/logicalOr()}},
-      {{MLGraphBuilder/logicalXor()}}
+      {{MLGraphBuilder/logicalXor()}},
+      {{MLGraphBuilder/isNaN()}},
+      {{MLGraphBuilder/isInfinite()}}
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Addition of some operators to List.

Reference: #859

_Non-Substantive as no new implementations_


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shubhamg13/webnn/pull/936.html" title="Last updated on Aug 12, 2026, 6:57 AM UTC (fa18b8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/936/07d09bb...shubhamg13:fa18b8b.html" title="Last updated on Aug 12, 2026, 6:57 AM UTC (fa18b8b)">Diff</a>