### PR TITLE
Bugfix: Allow 0-D output for gather()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4928,8 +4928,8 @@ partial dictionary MLOpSupportLimits {
     <td>*output*</td>
     <td>[=/same type as|same as=] {{input}}</td>
     <td>{{MLOperandDataType/"float32"}}, {{MLOperandDataType/"float16"}}, {{MLOperandDataType/"int32"}}, {{MLOperandDataType/"int8"}}, {{MLOperandDataType/"uint8"}}</td>
-    <td>1 to [=/any rank|N=]</td>
-    <td>1 to 5</td>
+    <td>[=/any rank|N=]</td>
+    <td>0 to 5</td>
   </tr>
 </table>
 


### PR DESCRIPTION
The indices operand already allows rank 0, and the output rank is rank(input) + rank(indices) - 1. So a rank-1 input gathered with scalar indices produces a rank-0 output.

The algorithm steps needed no change; they already produce an empty output shape for this case.

Fixes #946