### PR TITLE
Enforce validation when creating an MLOperandDescriptor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1686,6 +1686,7 @@ An {{MLOperandDescriptor}} |A| is <dfn for=MLOperandDescriptor>equal</dfn> to an
     1. Let |descriptor| be a new {{MLOperandDescriptor}}.
     1. Set |descriptor|.{{MLOperandDescriptor/dataType}} to |dataType|.
     1. Set |descriptor|.{{MLOperandDescriptor/shape}} to a [=list/clone=] of |shape|.
+    1. If [=MLOperandDescriptor/checking dimensions=] given |descriptor| returns false, then [=exception/throw=] a {{TypeError}}.
     1. Return |descriptor|.
 </details>
 
@@ -5917,8 +5918,11 @@ partial dictionary MLOpSupportLimits {
         1. Let |activations| be « {{MLRecurrentNetworkActivation/"sigmoid"}}, {{MLRecurrentNetworkActivation/"tanh"}} ».
     1. *Calculate the output shape:*
         1. Let |desc0| be the result of [=creating an MLOperandDescriptor=] given |input|'s [=MLOperand/dataType=] and « |numDirections|, |batchSize|, |hiddenSize| ».
-        1. If |options|.{{MLGruOptions/returnSequence}} is true, then:
-            1. Let |desc1| be the result of [=creating an MLOperandDescriptor=] given |input|'s [=MLOperand/dataType=] and « |steps|, |numDirections|, |batchSize|, |hiddenSize| ».
+        1. Let |desc1| be the result of [=creating an MLOperandDescriptor=] given |input|'s [=MLOperand/dataType=] and « |steps|, |numDirections|, |batchSize|, |hiddenSize| ».
+            <details class=note>
+              <summary>Why build |desc1| unconditionally?</summary>
+              Some underlying platforms produce the full-sequence output tensor regardless of {{MLGruOptions/returnSequence}}. Therefore, |desc1| also needs to be valid.
+            </details>
     1. *Make graph connections:*
         1. Let |operator| be an [=operator=] for the "gru" operation, given |weight|, |recurrentWeight|, |steps|, |hiddenSize| and |options|.
         1. Let |output0| be the result of [=creating an MLOperand=] given [=this=] and |desc0|.
@@ -7364,8 +7368,11 @@ partial dictionary MLOpSupportLimits {
         1. Let |activations| be « {{MLRecurrentNetworkActivation/"sigmoid"}}, {{MLRecurrentNetworkActivation/"tanh"}}, {{MLRecurrentNetworkActivation/"tanh"}} ».
     1. *Calculate the output shape:*
         1. Let |desc| be the result of [=creating an MLOperandDescriptor=] given |input|'s [=MLOperand/dataType=] and « |numDirections|, |batchSize|, |hiddenSize| ».
-        1. If |options|.{{MLLstmOptions/returnSequence}} is true, then:
-            1. Let |desc2| be the result of [=creating an MLOperandDescriptor=] given |input|'s [=MLOperand/dataType=] and « |steps|, |numDirections|, |batchSize|, |hiddenSize| ».
+        1. Let |desc2| be the result of [=creating an MLOperandDescriptor=] given |input|'s [=MLOperand/dataType=] and « |steps|, |numDirections|, |batchSize|, |hiddenSize| ».
+            <details class=note>
+              <summary>Why build |desc2| unconditionally?</summary>
+              Some underlying platforms produce the full-sequence output tensor regardless of {{MLLstmOptions/returnSequence}}. Therefore, |desc2| also needs to be valid.
+            </details>
     1. *Make graph connections:*
         1. Let |operator| be an [=operator=] for the "lstm" operation, given |weight|, |recurrentWeight|, |steps|, |hiddenSize| and |options|.
         1. Let |output0| be the result of [=creating an MLOperand=] given [=this=] and |desc|.


### PR DESCRIPTION
Fix https://github.com/webmachinelearning/webnn/issues/949

This PR makes `create an MLOperandDescriptor` validate the resulting shape via checking dimensions, so oversized outputs are rejected during graph building. `concat()`, `pad()`, and the pooling ops are restructured to construct their descriptor from the final computed shape instead of mutating one created earlier.

This PR also adds unconditional validation for the full-sequence output of `gru()`/`lstm()`, which some platforms produce regardless of the `returnSequence` flag.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shiyi9801/webnn/pull/955.html" title="Last updated on Sep 14, 2026, 8:47 AM UTC (816b267)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/webmachinelearning/webnn/955/36224cf...shiyi9801:816b267.html" title="Last updated on Sep 14, 2026, 8:47 AM UTC (816b267)">Diff</a>